### PR TITLE
Fixed typo, updated broken link to main docs and added spec link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ convolutional and recurrent), tree ensembles with boosting, and generalized
 linear models. Models in this format can be directly integrated into apps
 through Xcode.
 
-coremltools in a python package for creating, examining, and testing models in
+:code:`coremltools` is a python package for creating, examining, and testing models in
 the .mlmodel format.  In particular, it can be used to:
 
 - Convert existing models to .mlmodel format from popular machine learning tools including Keras, Caffe, scikit-learn, libsvm, and XGBoost.
@@ -28,7 +28,7 @@ Once you have set up a python environment, run::
 
     pip install -U coremltools
 
-The package `documentation <https://apple.github.io/coremltools/docs/>`_ contains
+The package `documentation <https://apple.github.io/coremltools/>`_ contains
 more details on how to use coremltools.
 
 Dependencies
@@ -51,7 +51,7 @@ More Information
 ----------------
 
 - `Core ML framework documentation <http://developer.apple.com/documentation/coreml>`_
-- `Download Core ML model specification <https://docs-assets.developer.corp.apple.com/coreml/documentation/mlmodel_specification.zip>`_
+- `Core ML model specification <https://apple.github.io/coremltools/coremlspecification>`_
 - `Machine learning at Apple <https://developer.apple.com/machine-learning>`_
 
 License

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -175,6 +175,8 @@ At a high level, the protobuf specification consists of:
 - Model parameters: The set of parameters required to represent a specific instance of the model.
 - Metadata: Information about the origin, license, and author of the model.
 
+For more information, please take a look at the `Core ML model specification <https://apple.github.io/coremltools/coremlspecification>`_
+
 
 Contents
 ========


### PR DESCRIPTION
This commit includes the following:
- A fixed typo in the README.rst and style matching the package documentation
- An updated link to the main package documentation
- Updated link to the specification in the README
- Added link to the specification in the main package documentation 
