### PR TITLE
No more 1D convolution input length limit for Keras converter

### DIFF
--- a/coremltools/converters/keras/_keras2_converter.py
+++ b/coremltools/converters/keras/_keras2_converter.py
@@ -244,8 +244,6 @@ def _convert(model,
             is_seq = True
         output_dims[idx] =  _convert_to_coreml_shape(dim, is_seq)
 
-    # from nose.tools import set_trace
-    # set_trace()
     input_types = [datatypes.Array(*dim) for dim in input_dims]
     output_types = [datatypes.Array(*dim) for dim in output_dims]
 

--- a/coremltools/models/model.py
+++ b/coremltools/models/model.py
@@ -238,8 +238,7 @@ class MLModel(object):
         >>> predictions = model.predict(data)
         """
         if self.__proxy__:
-            # return self.__proxy__.predict(data,useCPUOnly)
-            return self.__proxy__.predict(data)
+            return self.__proxy__.predict(data,useCPUOnly)
         else:
             if _sys.platform != 'darwin' or float('.'.join(_platform.mac_ver()[0].split('.')[:2])) < 10.13:
                 raise Exception('Model prediction is only supported on macOS version 10.13.')

--- a/coremltools/test/test_keras2_numeric.py
+++ b/coremltools/test/test_keras2_numeric.py
@@ -136,8 +136,6 @@ class KerasNumericCorrectnessTest(unittest.TestCase):
         
         # Assuming coreml model output names are in the same order as Keras 
         # Output list, put predictions into a list, sorted by output name
-        # from nose.tools import set_trace
-        # set_trace()
         coreml_preds = coreml_model.predict(coreml_input)
         c_preds = [coreml_preds[name] for name in output_names]
 
@@ -149,9 +147,6 @@ class KerasNumericCorrectnessTest(unittest.TestCase):
         keras_preds = model.predict(input_data)
         k_preds = keras_preds if type(keras_preds) is list else [keras_preds]
         
-        
-        # from nose.tools import set_trace
-        # set_trace()
         # Compare each output blob
         for idx, k_pred in enumerate(k_preds):
             if transpose_keras_result:


### PR DESCRIPTION
This PR liberates the Keras converter's from being restricted to a maximum 1D convolution input length (400). This is done by improving the converter logic on deciding what a 3D tensor (Batch, Length, Channels) really means. It:
(1) Revised topological understanding in Keras converter so that it can distinguish between a (Batch, Sequence, Channels) tensor and a (Batch, 1DArrayLength,Channels) tensor. It does so by backtracking the input layer types.
(2) Because of (1), it allows 1D array input >> 400 to be handled. 1D convnets no longer needs permutation layers, so it becomes faster in runtime. And it does not involves trying from sequence length = 1, so compilation also becomes faster.
(3) Added and revised nose tests for long input 1D conv-nets, embedding-conv1d-recurrent architecture.
(4) Improves code quality. 

This PR helps the following bug fixes in the future:
(1) For some 1d conv-nets, an intermediate conv layer's output blob is needed as the model's output. With permute layers inserted, conv layer's output layout would not match the layout expected by the developer. This will cause confusion. 