### PR TITLE
Fixed-length sequence for embedding-flatten model in Keras

### DIFF
--- a/coremltools/converters/keras/_topology2.py
+++ b/coremltools/converters/keras/_topology2.py
@@ -606,6 +606,19 @@ class NetGraph(object):
                     keras_permute = _keras.layers.Permute(dims=dims)
                     self._insert_layer_between(sbn, succ, permute_layer, keras_permute)
     
+    def insert_permute_for_embed_flatten(self):
+        for layer in self.layer_list:
+            keras_layer = self.keras_layer_map[layer]
+            succs = self.get_successors(layer)
+            if len(succs) > 0: 
+                succ = succs[0]
+            keras_succ = self.keras_layer_map[succ]
+            if isinstance(keras_layer, _keras.layers.Embedding) and isinstance(keras_succ, _keras.layers.Flatten):
+                dims = (2,3,0,1)
+                permute_layer = layer + '_permute_'
+                keras_permute = _keras.layers.Permute(dims=dims)
+                self._insert_layer_between(layer, succ, permute_layer, keras_permute)
+    
     def build(self, is_top_level = True):
         # sanity check. 
         model = self.model
@@ -703,6 +716,7 @@ class NetGraph(object):
             self.remove_skip_layers(_KERAS_SKIP_LAYERS) # done 1 pass
             self.insert_1d_permute_layers()
             self.insert_permute_for_spatial_bn()
+            self.insert_permute_for_embed_flatten()
             self.defuse_activation()
             self.remove_internal_input_layers()
 

--- a/coremltools/test/test_keras2_numeric.py
+++ b/coremltools/test/test_keras2_numeric.py
@@ -1612,6 +1612,22 @@ class KerasBasicNumericCorrectnessTest(KerasNumericCorrectnessTest):
 
         self._test_keras_model(model, input_blob = 'data', output_blob = 'output', delta=1e-2)
     
+    def test_embedding_fixed_length(self):
+        sequence_length = 5
+        vocab_size = 10
+        embed_channels = 4
+        
+        dense_units = sequence_length * embed_channels
+        model = Sequential()
+        model.add(Embedding(vocab_size, embed_channels, input_length=sequence_length))
+        model.add(Flatten())
+        model.add(Dense(dense_units))
+        model.add(Dense(20))
+        
+        print 'Test: model.input_shape = ', model.input_shape
+        model.set_weights([np.random.rand(*w.shape) for w in model.get_weights()])
+        self._test_keras_model(model, one_dim_seq_flags=[True])
+    
     def test_dense_fused_act_in_td(self):
         np.random.seed(1988)
         x_in = Input(shape=(10,2))


### PR DESCRIPTION
This PR adds a workaround for Keras models with fixed length sequence that decides parameter sizes in later layers, as reported in:
https://forums.developer.apple.com/message/238051#238051