### PR TITLE
Add spatial dropout to skip list and test

### DIFF
--- a/coremltools/converters/keras/_keras2_converter.py
+++ b/coremltools/converters/keras/_keras2_converter.py
@@ -63,6 +63,8 @@ if _HAS_KERAS2_TF:
 
         _keras.engine.topology.InputLayer:_layers2.default_skip,
         _keras.layers.core.Dropout:_layers2.default_skip,
+        _keras.layers.core.SpatialDropout2D:_layers2.default_skip,
+        _keras.layers.core.SpatialDropout1D:_layers2.default_skip,
         _keras.layers.wrappers.TimeDistributed:_layers2.default_skip,
         
         _keras.applications.mobilenet.DepthwiseConv2D:_layers2.convert_convolution,

--- a/coremltools/converters/keras/_topology2.py
+++ b/coremltools/converters/keras/_topology2.py
@@ -43,6 +43,8 @@ _KERAS_MERGE_LAYERS = [
 
 _KERAS_SKIP_LAYERS = [
     _keras.layers.core.Dropout,
+    _keras.layers.core.SpatialDropout1D,
+    _keras.layers.core.SpatialDropout2D,
 ]
 
 def _to_list(x):

--- a/coremltools/test/test_keras2_numeric.py
+++ b/coremltools/test/test_keras2_numeric.py
@@ -21,6 +21,7 @@ if HAS_KERAS2_TF:
     from keras.layers import ZeroPadding2D, UpSampling2D, Cropping2D
     from keras.layers import ZeroPadding1D, UpSampling1D, Cropping1D
     from keras.layers import SimpleRNN, LSTM, GRU
+    from keras.layers.core import SpatialDropout1D, SpatialDropout2D
     from keras.layers.wrappers import Bidirectional, TimeDistributed
     from keras.applications.mobilenet import DepthwiseConv2D
     from coremltools.converters import keras as kerasConverter
@@ -1528,6 +1529,31 @@ class KerasBasicNumericCorrectnessTest(KerasNumericCorrectnessTest):
         model = Sequential()
         model.add(Conv2D(input_shape = input_shape,
             filters = num_kernels, kernel_size=(kernel_height, kernel_width)))
+        model.add(Dropout(0.5))
+        model.add(Flatten())
+        model.add(Dense(hidden_dim))
+
+        # Set some random weights
+        model.set_weights([np.random.rand(*w.shape) for w in model.get_weights()])
+
+        # Get the coreml model
+        self._test_keras_model(model)
+        
+    def test_tiny_conv_dropout_random(self):
+        np.random.seed(1988)
+        num_samples = 1
+        input_dim = 8
+        input_shape = (input_dim, input_dim, 3)
+        num_kernels = 2
+        kernel_height = 5
+        kernel_width = 5
+        hidden_dim = 4
+
+        # Define a model
+        model = Sequential()
+        model.add(Conv2D(input_shape = input_shape,
+            filters = num_kernels, kernel_size=(kernel_height, kernel_width)))
+        model.add(SpatialDropout2D(0.5))
         model.add(Flatten())
         model.add(Dense(hidden_dim))
 


### PR DESCRIPTION
This PR adds the two missing Keras layers, SpatialDropout2D and SpatialDropout1D into the skip list such that it doesn't throw an error. 
