### PR TITLE
Force channel_last keras image data format

### DIFF
--- a/coremltools/converters/keras/_keras2_converter.py
+++ b/coremltools/converters/keras/_keras2_converter.py
@@ -147,6 +147,13 @@ def _convert(model,
             predicted_feature_name = None,
             predicted_probabilities_output = ''):
 
+    # Check Keras format
+    if _keras.backend.image_data_format() == 'channels_first':
+        print("Keras image data format 'channels_first' detected. Currently only 'channels_last' is supported. "
+            "Changing to 'channels_last', but your model may not be converted "
+            "converted properly.")
+        _keras.backend.set_image_data_format('channels_last')
+    
     if isinstance(model, _string_types):
         model = _keras.models.load_model(model)
     elif isinstance(model, tuple):

--- a/coremltools/converters/keras/_layers2.py
+++ b/coremltools/converters/keras/_layers2.py
@@ -115,6 +115,12 @@ def _same_elements_per_channel(x):
             return False
     return True
 
+def _check_data_format(keras_layer):
+    if hasattr(keras_layer,('data_format')):
+        if keras_layer.data_format != 'channels_last':
+            raise ValueError("Converter currently supports data_format = "
+                "'channels_last' only.")        
+
 def convert_dense(builder, layer, input_names, output_names, keras_layer):
     """
     Convert a dense layer from keras to coreml.
@@ -231,6 +237,9 @@ def convert_convolution(builder, layer, input_names, output_names, keras_layer):
     builder: NeuralNetworkBuilder
         A neural network builder object.
     """
+    
+    _check_data_format(keras_layer)
+    
     # Get input and output names
     input_name, output_name = (input_names[0], output_names[0])
 
@@ -370,6 +379,8 @@ def convert_separable_convolution(builder, layer, input_names, output_names, ker
     builder: NeuralNetworkBuilder
         A neural network builder object.
     """
+    _check_data_format(keras_layer)
+    
     # Get input and output names
     input_name, output_name = (input_names[0], output_names[0])
 
@@ -538,6 +549,7 @@ def convert_pooling(builder, layer, input_names, output_names, keras_layer):
     builder: NeuralNetworkBuilder
         A neural network builder object.
     """
+    _check_data_format(keras_layer)
     # Get input and output names
     input_name, output_name = (input_names[0], output_names[0])
 
@@ -628,6 +640,7 @@ def convert_padding(builder, layer, input_names, output_names, keras_layer):
     builder: NeuralNetworkBuilder
         A neural network builder object.
     """
+    _check_data_format(keras_layer)
     # Get input and output names
     input_name, output_name = (input_names[0], output_names[0])
     
@@ -678,6 +691,8 @@ def convert_cropping(builder, layer, input_names, output_names, keras_layer):
     builder: NeuralNetworkBuilder
         A neural network builder object.
     """
+    
+    _check_data_format(keras_layer)
     # Get input and output names
     input_name, output_name = (input_names[0], output_names[0])
     is_1d = isinstance(keras_layer, _keras.layers.Cropping1D)
@@ -727,6 +742,7 @@ def convert_upsample(builder, layer, input_names, output_names, keras_layer):
     builder: NeuralNetworkBuilder
         A neural network builder object.
     """
+    _check_data_format(keras_layer)
     # Get input and output names
     input_name, output_name = (input_names[0], output_names[0])
 


### PR DESCRIPTION
Keras convolutional layers have a “format” parameter that allows user to specify either “channel_first” or “channel_last”. Keras converter only supports “channel_last”. We should error out gracefully.
This PR adds check on "channels_last" and errors out if not set. 
