### PR TITLE
removed mouseout from node so node params stay persistent

### DIFF
--- a/coremltools/graph_visualization/app.js
+++ b/coremltools/graph_visualization/app.js
@@ -441,11 +441,6 @@ document.addEventListener('DOMContentLoaded', function() {
             div.innerHTML = content;
 		});
 
-		cy.$('node').on('mouseout', function(e){
-			var div = document.getElementById('node-info');
-			div.innerHTML = '';
-		});
-
 		cy.on('tap', 'edge', function (evt) {
            var edge = evt.target;
            var edgeLabel = edge.data().source;


### PR DESCRIPTION
Removed mouse out event, this makes the node parameters persist even when the mouse is not on the node and changes to the new node in the event of a new mouseover.