### PR TITLE
Python 3 Changes

### DIFF
--- a/coremltools/models/_graph_visualization.py
+++ b/coremltools/models/_graph_visualization.py
@@ -11,7 +11,7 @@ import ast as _ast
 import json as _json
 import os as _os
 import numpy as _np
-from _infer_shapes_nn_mlmodel import infer_shapes as _infer_shapes
+from ._infer_shapes_nn_mlmodel import infer_shapes as _infer_shapes
 
 
 def _calculate_edges(cy_nodes, cy_edges, shape_dict=None):

--- a/coremltools/models/model.py
+++ b/coremltools/models/model.py
@@ -242,5 +242,7 @@ class MLModel(object):
         else:
             if _sys.platform != 'darwin' or float('.'.join(_platform.mac_ver()[0].split('.')[:2])) < 10.13:
                 raise Exception('Model prediction is only supported on macOS version 10.13.')
+            if _sys.version_info.major >= 3:
+                raise Exception('Model prediction is currently only supported in Python 2.7')
             else:
                 raise Exception('Unable to load CoreML.framework. Cannot make predictions.')

--- a/coremltools/models/neural_network.py
+++ b/coremltools/models/neural_network.py
@@ -1033,13 +1033,13 @@ class NeuralNetworkBuilder(object):
             Wt = Wt.flatten()
         else:
             Wt = W.transpose((2,3,0,1)).flatten()
-        for idx in xrange(Wt.size):
+        for idx in range(Wt.size):
             weights.floatValue.append(float(Wt[idx]))
 
         # Assign biases
         if has_bias:
             bias = spec_layer_params.bias
-            for f in xrange(output_channels):
+            for f in range(output_channels):
                 bias.floatValue.append(float(b[f]))
         
         # add dilation factors

--- a/coremltools/models/utils.py
+++ b/coremltools/models/utils.py
@@ -13,7 +13,7 @@ import os as _os
 import six as _six
 
 from .._deps import HAS_SKLEARN as _HAS_SKLEARN
-from _graph_visualization import \
+from ._graph_visualization import \
     _neural_network_nodes_and_edges, \
     _pipeline_nodes_and_edges, _start_server
 

--- a/coremltools/test/test_io_types.py
+++ b/coremltools/test/test_io_types.py
@@ -125,7 +125,7 @@ class TestIODataTypes(unittest.TestCase):
                                  )
                                  )
             except RuntimeError:
-                print "{} not supported. ".format(dtype)
+                print("{} not supported. ".format(dtype))
 
     def test_random_forest_regressor(self):
         for dtype in self.number_data_type.keys():
@@ -148,7 +148,7 @@ class TestIODataTypes(unittest.TestCase):
                                        )
                                        )
             except RuntimeError:
-                print "{} not supported. ".format(dtype)
+                print("{} not supported. ".format(dtype))
 
     def test_support_vector_classifier(self):
         for dtype in self.number_data_type.keys():
@@ -189,7 +189,7 @@ class TestIODataTypes(unittest.TestCase):
                                  )
                                  )
             except RuntimeError:
-                print "{} not supported. ".format(dtype)
+                print("{} not supported. ".format(dtype))
 
     def test_linear_regressor(self):
         for dtype in self.number_data_type.keys():
@@ -211,7 +211,7 @@ class TestIODataTypes(unittest.TestCase):
                                        )
                                        )
             except RuntimeError:
-                print "{} not supported. ".format(dtype)
+                print("{} not supported. ".format(dtype))
 
     @attr('keras2')
     def test_keras_dense_model(self):

--- a/coremltools/test/test_io_types.py
+++ b/coremltools/test/test_io_types.py
@@ -218,7 +218,7 @@ class TestIODataTypes(unittest.TestCase):
         model = keras.models.Sequential()
         model.add(keras.layers.Dense(3, activation='sigmoid', kernel_initializer='random_uniform',
                                      bias_initializer='random_uniform', input_dim=3))
-        for key, dtype in self.number_data_type.iteritems():
+        for key, dtype in self.number_data_type.items():
             try:
                 input_data = np.random.rand(1, 3).astype(key)
                 keras_out = model.predict(input_data)
@@ -247,7 +247,7 @@ class TestIODataTypes(unittest.TestCase):
 
         model = keras.models.Sequential()
         model.add(keras.layers.Embedding(100, 3, input_length=5, input_dtype='float32'))
-        for key, dtype in self.number_data_type.iteritems():
+        for key, dtype in self.number_data_type.items():
             try:
                 input_data = np.random.randint(0, 100, size=(1, 5)).astype(key)
                 keras_out = np.squeeze(model.predict(input_data)).flatten()

--- a/coremltools/test/test_keras2_numeric.py
+++ b/coremltools/test/test_keras2_numeric.py
@@ -126,7 +126,7 @@ class KerasNumericCorrectnessTest(unittest.TestCase):
                         one_dim_seq_flags[0]).astype('f').copy()}
 
         # Compile the model
-        output_names = ['output'+str(i) for i in xrange(len(model.outputs))]
+        output_names = ['output'+str(i) for i in range(len(model.outputs))]
         coreml_model = _get_coreml_model(model, model_path, input_names, 
                 output_names)
         
@@ -152,7 +152,7 @@ class KerasNumericCorrectnessTest(unittest.TestCase):
             cp = c_preds[idx].flatten()
             # Compare predictions
             self.assertEquals(len(kp), len(cp))
-            for i in xrange(len(kp)):
+            for i in range(len(kp)):
                 max_den = max(1.0, kp[i], cp[i])
                 self.assertAlmostEquals(kp[i]/max_den, 
                                         cp[i]/max_den, 

--- a/coremltools/test/test_multiple_images_preprocessing.py
+++ b/coremltools/test/test_multiple_images_preprocessing.py
@@ -55,9 +55,9 @@ def compare_models(caffe_preds, coreml_preds):
         if relative_error > max_relative_error:
             max_relative_error = relative_error
 
-    print 'maximum relative error: ', max_relative_error
-    #print 'caffe preds : ', caffe_preds
-    #print 'coreml preds: ', coreml_preds      
+    print('maximum relative error: ', max_relative_error)
+    #print('caffe preds : ', caffe_preds)
+    #print('coreml preds: ', coreml_preds)
     return max_relative_error 
     
 class ManyImages(unittest.TestCase):

--- a/coremltools/test/test_multiple_images_preprocessing.py
+++ b/coremltools/test/test_multiple_images_preprocessing.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import unittest
 import tarfile
 import shutil

--- a/coremltools/test/test_neural_networks.py
+++ b/coremltools/test/test_neural_networks.py
@@ -30,7 +30,7 @@ class BasicNumericCorrectnessTest(unittest.TestCase):
     def test_classifier(self):
         np.random.seed(1988)
         
-        print 'running test classifier'
+        print('running test classifier')
         
         input_dim = 5
         num_hidden = 12

--- a/coremltools/test/test_numpy_nn_layers.py
+++ b/coremltools/test/test_numpy_nn_layers.py
@@ -883,15 +883,15 @@ class StressTest(CorrectnessTest):
                          start = [0,1,2,5],
                          end = [5,100,56,-1,-2,-4],
                          stride = [1,2,3]
-                         )              
-        params = [x for x in apply(itertools.product, params_dict.values())] 
+                         )
+        params = list(itertools.product(*params_dict.values()))
         all_candidates = [dict(zip(params_dict.keys(), x)) for x in params]     
         valid_params = []               
         for pr in all_candidates:
             X = np.random.rand(*pr["input_shape"])
             if get_size_after_stride(X, pr):
                 valid_params.append(pr)        
-        print "Total params to be tested: ", len(valid_params), "out of canditates: ", len(all_candidates)
+        print("Total params to be tested: ", len(valid_params), "out of canditates: ", len(all_candidates))
         '''
         Test
         '''
@@ -900,8 +900,8 @@ class StressTest(CorrectnessTest):
         failed_tests_numerical = []
         for i in range(len(valid_params)):
             params = valid_params[i]
-            #print "=========: ", params
-            #if i % 10 == 0: print "======== Testing {}/{}".format(str(i), str(len(valid_params)))
+            #print("=========: ", params)
+            #if i % 10 == 0: print("======== Testing {}/{}".format(str(i), str(len(valid_params))))
             X = np.random.rand(*params["input_shape"])
             np_preds = get_numpy_predictions_slice(X, params)
             coreml_preds, eval = get_coreml_predictions_slice(X, params)
@@ -933,7 +933,7 @@ class StressTest(CorrectnessTest):
                        mode = ['logsum'],
                        axis = ['HW'],
                        )                             
-        params = [x for x in apply(itertools.product, params_dict.values())] 
+        params = list(itertools.product(*params_dict.values()))
         all_candidates = [dict(zip(params_dict.keys(), x)) for x in params]     
         valid_params = []               
         for pr in all_candidates:
@@ -941,7 +941,7 @@ class StressTest(CorrectnessTest):
                 if pr["axis"] == 'CHW' or pr["axis"] == 'HW':
                     continue            
             valid_params.append(pr)        
-        print "Total params to be tested: ", len(valid_params), "out of canditates: ", len(all_candidates)
+        print("Total params to be tested: ", len(valid_params), "out of canditates: ", len(all_candidates))
         '''
         Test
         '''
@@ -950,8 +950,8 @@ class StressTest(CorrectnessTest):
         failed_tests_numerical = []
         for i in range(len(valid_params)):
             params = valid_params[i]
-            #print "=========: ", params
-            #if i % 10 == 0: print "======== Testing {}/{}".format(str(i), str(len(valid_params)))
+            #print("=========: ", params)
+            #if i % 10 == 0: print("======== Testing {}/{}".format(str(i), str(len(valid_params))))
             X = np.random.rand(*params["input_shape"])
             np_preds = get_numpy_predictions_reduce(X, params)
             coreml_preds, eval = get_coreml_predictions_reduce(X, params)

--- a/coremltools/test/test_numpy_nn_layers.py
+++ b/coremltools/test/test_numpy_nn_layers.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import unittest
 import numpy as np
 import os, shutil

--- a/coremltools/test/test_recurrent_stress_tests.py
+++ b/coremltools/test/test_recurrent_stress_tests.py
@@ -504,7 +504,7 @@ class RNNLayer(RecurrentLayerTest):
     def setUp(self):
         super(RNNLayer, self).setUp()
         self.simple_rnn_params_dict = dict()
-        self.rnn_layer_params = [x for x in apply(itertools.product, self.simple_rnn_params_dict.values())]
+        self.rnn_layer_params = list(itertools.product(self.simple_rnn_params_dict.values()))
 
     def test_rnn_layer(self):
         i = 0

--- a/coremltools/test/test_tf_numeric.py
+++ b/coremltools/test/test_tf_numeric.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import unittest
 import numpy as np
 import os, shutil

--- a/coremltools/test/test_tf_numeric.py
+++ b/coremltools/test/test_tf_numeric.py
@@ -155,7 +155,7 @@ class StressTest(CorrectnessTest):
                             block_size = [2,3,4,5],
                             mode = ['SPACE_TO_DEPTH','DEPTH_TO_SPACE']
                             )
-        params = [x for x in apply(itertools.product, params_dict.values())] 
+        params = [x for x in list(itertools.product(*params_dict.values()))]
         all_candidates = [dict(zip(params_dict.keys(), x)) for x in params]     
         valid_params = []               
         for pr in all_candidates:
@@ -165,7 +165,7 @@ class StressTest(CorrectnessTest):
             else:
                 if pr["C"] % (pr["block_size"] ** 2) == 0:
                     valid_params.append(pr)        
-        print "Total params to be tested: ", len(valid_params), "out of canditates: ", len(all_candidates)
+        print("Total params to be tested: ", len(valid_params), "out of canditates: ", len(all_candidates))
         '''
         Test
         '''
@@ -174,8 +174,8 @@ class StressTest(CorrectnessTest):
         failed_tests_numerical = []
         for i in range(len(valid_params)):
             params = valid_params[i]
-            #print "=========: ", params
-            #if i % 10 == 0: print "======== Testing {}/{}".format(str(i), str(len(valid_params)))
+            #print("=========: ", params)
+            #if i % 10 == 0: print("======== Testing {}/{}".format(str(i), str(len(valid_params))))
             X = np.random.rand(1,params["C"],params["H"],params["W"])
             tf_preds = get_tf_predictions_reorganize(np.transpose(X,[0,2,3,1]), params)
             tf_preds = np.transpose(tf_preds, [0,3,1,2])
@@ -205,7 +205,7 @@ class StressTest(CorrectnessTest):
                            multiplier = [1,2,3,4],
                            padding = ['SAME', 'VALID']
                            )
-        params = [x for x in apply(itertools.product, params_dict.values())] 
+        params = [x for x in list(itertools.product(*params_dict.values()))]
         all_candidates = [dict(zip(params_dict.keys(), x)) for x in params]     
         valid_params = []               
         for pr in all_candidates:
@@ -213,7 +213,7 @@ class StressTest(CorrectnessTest):
                 if np.floor((pr["H"]-pr["kernel_size"])/pr["stride"]) + 1 <= 0:
                     continue
             valid_params.append(pr)       
-        print "Total params to be tested: ", len(valid_params), "out of canditates: ", len(all_candidates)
+        print("Total params to be tested: ", len(valid_params), "out of canditates: ", len(all_candidates))
         '''
         Test
         '''


### PR DESCRIPTION
This change allows partial Python 3 support. From Python 3, you should be able to do everything except evaluate models or convert Caffe models. From Python 2, nothing should change.