### PR TITLE
Fix _KERAS_MERGE_LAYERS is undefined name

### DIFF
--- a/coremltools/converters/keras/_keras2_converter.py
+++ b/coremltools/converters/keras/_keras2_converter.py
@@ -73,9 +73,10 @@ if _HAS_KERAS2_TF:
     
 
 def _is_merge_layer(layer):
-    for lt in _KERAS_MERGE_LAYERS:
-        if isinstance(layer, lt):
-            return True
+    if _HAS_KERAS2_TF:
+        for lt in _topology2._KERAS_MERGE_LAYERS:
+            if isinstance(layer, lt):
+                return True
     return False
 
 def _check_unsupported_layers(model):


### PR DESCRIPTION
_KERAS_MERGE_LAYERS is defined in _topology2 which is a conditional import based on _HAS_KERAS2_TF.  Without this change, an NameError might be raised at runtime.