### PR TITLE
fix bug add_elementwise with mode multiply

### DIFF
--- a/coremltools/models/neural_network.py
+++ b/coremltools/models/neural_network.py
@@ -704,7 +704,7 @@ class NeuralNetworkBuilder(object):
         elif mode == 'MULTIPLY':
             spec_layer.multiply.MergeFromString('')
             if alpha:
-                spec_layer.add.alpha = alpha
+                spec_layer.multiply.alpha = alpha
         elif mode == 'COS':
             spec_layer.dot.cosineSimilarity = True
         elif mode == 'DOT':


### PR DESCRIPTION
The wrong field in the mlmodel protobuf is updated with add_elementwise is called with mode "multiply".
The current implementation updates the field "add" when the correct field should be "mulitply".
This commit fixes this.