### PR TITLE
Add missing spaces to error message

### DIFF
--- a/coremltools/converters/keras/_keras2_converter.py
+++ b/coremltools/converters/keras/_keras2_converter.py
@@ -232,7 +232,7 @@ def _convert(model,
             else: # keras provided fixed batch and sequence length, so the input was (batch, sequence, channel)
                 input_dims[idx] = (dim[2],)
         else:
-            raise ValueError('Input' + input_names[idx] + 'has input shape of length' + str(len(dim)))
+            raise ValueError("Input '%s' has input shape of length %d" % (input_names[idx], len(dim)))
 
     # Retrieve output shapes from model
     if type(model.output_shape) is list:


### PR DESCRIPTION
Example of the error message right now:
```
ValueError: Inputimagehas input shape of length4
```
This fixes the spacing and adds quotes around the name to make it more clear:
```
ValueError: Input 'image' has input shape of length 4
```