### PR TITLE
Fix simpleRNN's removed attribute 'implementation'

### DIFF
--- a/coremltools/converters/keras/_layers2.py
+++ b/coremltools/converters/keras/_layers2.py
@@ -880,8 +880,8 @@ def convert_simple_rnn(builder, layer, input_names, output_names, keras_layer):
     W_x = _np.zeros((hidden_size, input_size))
     b = None
 
-    implementation = 0 if not hasattr(keras_layer, 'implementation') else \
-            keras_layer.implementation
+    implementation = keras_layer.implementation if hasattr(keras_layer,
+            'implementation') else 0
     if implementation == 0:
         W_h = keras_layer.get_weights()[1].T
         W_x = keras_layer.get_weights()[0].T

--- a/coremltools/converters/keras/_layers2.py
+++ b/coremltools/converters/keras/_layers2.py
@@ -880,7 +880,9 @@ def convert_simple_rnn(builder, layer, input_names, output_names, keras_layer):
     W_x = _np.zeros((hidden_size, input_size))
     b = None
 
-    if keras_layer.implementation == 0:
+    implementation = 0 if not hasattr(keras_layer, 'implementation') else \
+            keras_layer.implementation
+    if implementation == 0:
         W_h = keras_layer.get_weights()[1].T
         W_x = keras_layer.get_weights()[0].T
         if keras_layer.use_bias:

--- a/coremltools/test/test_keras2_numeric.py
+++ b/coremltools/test/test_keras2_numeric.py
@@ -1793,7 +1793,7 @@ class KerasTopologyCorrectnessTest(KerasNumericCorrectnessTest):
         model = Model(inputs=[x], outputs=[z])
 
         model.set_weights([np.random.rand(*w.shape) for w in model.get_weights()])
-        self._test_keras_model(model, mode = 'random', delta=1e-3)
+        self._test_keras_model(model, mode = 'random', delta=1e-2)
     
     def test_tiny_multiple_outputs(self):
         x = Input(shape=(3,))


### PR DESCRIPTION
This PR:
(1) Fix simpleRNN's removed attribute 'implementation' in most recent Keras version
(2) Fix the delta value for a test running on GPU
