### PR TITLE
Fixing 1D convolution --> flatten layer bug

### DIFF
--- a/coremltools/converters/keras/_layers2.py
+++ b/coremltools/converters/keras/_layers2.py
@@ -536,14 +536,12 @@ def convert_flatten(builder, layer, input_names, output_names, keras_layer):
     in_shape = keras_layer.input_shape
     if len(in_shape) == 4:
         blob_order = 1
-    if len(in_shape) == 3 and in_shape[0] == None:
+    if len(in_shape) == 3 and in_shape[0] is None:
         # handling Keras rank-3 tensor (Batch, Sequence, Channels)
-        dim = (2,1,0,3)
-        blob_order = 1
         permute_output_name = output_name + '__permute__'
-        builder.add_permute(name=layer+'__permute__', dim=dim,
+        builder.add_permute(name=layer+'__permute__', dim=(2,1,0,3),
             input_name=input_name, output_name=permute_output_name)
-        builder.add_flatten(name=layer, mode=blob_order,
+        builder.add_flatten(name=layer, mode=1,
             input_name=permute_output_name, output_name=output_name)
     else:
         builder.add_flatten(name=layer, mode=blob_order, input_name=input_name,

--- a/coremltools/converters/keras/_topology2.py
+++ b/coremltools/converters/keras/_topology2.py
@@ -608,19 +608,6 @@ class NetGraph(object):
                     keras_permute = _keras.layers.Permute(dims=dims)
                     self._insert_layer_between(sbn, succ, permute_layer, keras_permute)
     
-    def insert_permute_for_embed_flatten(self):
-        for layer in self.layer_list:
-            keras_layer = self.keras_layer_map[layer]
-            succs = self.get_successors(layer)
-            if len(succs) > 0: 
-                succ = succs[0]
-            keras_succ = self.keras_layer_map[succ]
-            if isinstance(keras_layer, _keras.layers.Embedding) and isinstance(keras_succ, _keras.layers.Flatten):
-                dims = (2,3,0,1)
-                permute_layer = layer + '_permute_'
-                keras_permute = _keras.layers.Permute(dims=dims)
-                self._insert_layer_between(layer, succ, permute_layer, keras_permute)
-    
     def build(self, is_top_level = True):
         # sanity check. 
         model = self.model
@@ -718,7 +705,6 @@ class NetGraph(object):
             self.remove_skip_layers(_KERAS_SKIP_LAYERS) # done 1 pass
             self.insert_1d_permute_layers()
             self.insert_permute_for_spatial_bn()
-            self.insert_permute_for_embed_flatten()
             self.defuse_activation()
             self.remove_internal_input_layers()
 

--- a/coremltools/test/test_keras2_numeric.py
+++ b/coremltools/test/test_keras2_numeric.py
@@ -1052,7 +1052,7 @@ class KerasBasicNumericCorrectnessTest(KerasNumericCorrectnessTest):
 
         model = Sequential()
         model.add(LSTM(num_channels, input_shape = (input_length, input_dim),
-            implementation = 0, recurrent_activation = 'sigmoid'))
+            implementation = 1, recurrent_activation = 'sigmoid'))
 
         model.set_weights([np.random.rand(*w.shape)*0.2-0.1 for w in model.get_weights()])
         self._test_keras_model(model, mode = 'zeros', input_blob = 'data', output_blob = 'output')
@@ -1065,7 +1065,7 @@ class KerasBasicNumericCorrectnessTest(KerasNumericCorrectnessTest):
 
         model = Sequential()
         model.add(LSTM(num_channels, input_shape = (input_length, input_dim),
-            implementation = 0, recurrent_activation = 'sigmoid'))
+            implementation = 1, recurrent_activation = 'sigmoid'))
 
         model.set_weights([np.random.rand(*w.shape)*0.2-0.1 for w in model.get_weights()])
         self._test_keras_model(model, mode = 'ones', input_blob = 'data', output_blob = 'output')
@@ -1279,7 +1279,7 @@ class KerasBasicNumericCorrectnessTest(KerasNumericCorrectnessTest):
         # Define a model
         model = Sequential()
         model.add(Bidirectional(LSTM(num_channels, 
-            implementation = 0, recurrent_activation = 'sigmoid'),
+            implementation = 1, recurrent_activation = 'sigmoid'),
             input_shape=(input_length, input_dim)))
 
         # Set some random weights
@@ -1720,7 +1720,7 @@ class KerasBasicNumericCorrectnessTest(KerasNumericCorrectnessTest):
         # Define a model
         model = Sequential()
         model.add(LSTM(num_channels, input_shape = (input_length, input_dim), 
-            implementation = 0, recurrent_activation = 'sigmoid'))
+            implementation = 1, recurrent_activation = 'sigmoid'))
 
         # Set some random weights
         model.set_weights([(np.random.rand(*w.shape)-0.5)*0.2 for w in model.get_weights()])
@@ -1753,10 +1753,20 @@ class KerasBasicNumericCorrectnessTest(KerasNumericCorrectnessTest):
         model.add(Dense(dense_units))
         model.add(Dense(20))
         
-        print 'Test: model.input_shape = ', model.input_shape
         model.set_weights([np.random.rand(*w.shape) for w in model.get_weights()])
         self._test_keras_model(model, one_dim_seq_flags=[True])
     
+    def test_conv1d_flatten(self):
+        model = Sequential()
+        model.add(AveragePooling1D(2,input_shape=(64,9)))
+        model.add(Conv1D(16, 1, padding='same', activation='relu', use_bias=False))
+        model.add(MaxPooling1D(2))
+        model.add(Flatten())
+        model.add(Dense(units=7, activation='softmax', use_bias=False))
+
+        model.set_weights([np.random.rand(*w.shape) for w in model.get_weights()])
+        self._test_keras_model(model)
+
     def test_dense_fused_act_in_td(self):
         np.random.seed(1988)
         x_in = Input(shape=(10,2))


### PR DESCRIPTION
When 1D convolution output is directly fed by flatten layer, Keras converter gives a wrong output shape. 
For example: 
```
input_layer = keras.layers.InputLayer(input_shape=(WINDOW_SIZE, NUM_INPUT_FEATURES), name='input')
encoder_layers = [
    keras.layers.AveragePooling1D(2),
    Conv1D(16, 1, padding='same', activation='relu', use_bias=False),
    keras.layers.MaxPooling1D(2),
    Conv1D(16, 1, padding='same', activation='linear', use_bias=False),
    keras.layers.MaxPooling1D(pool_size=2)]
classif_layers = [
    keras.layers.Flatten(),
    # Dropout(0.5),
    Dense(units=7, activation='softmax', use_bias=False)
]
model = keras.models.Sequential([input_layer] + encoder_layers + classif_layers)

import coremltools
coreml_model = coremltools.converters.keras.convert('model.h5')
coreml_model.save('tennis_model.mlmodel')

data = np.ones([WINDOW_SIZE,1,NUM_INPUT_FEATURES]) * 1.0
output_dict = coreml_model.predict({'input1': data})
```
The above code generates an output of shape `(8,7)`, which ignores the flattening operation on the sequence axis. 

This PR:
(1) fix the aforementioned bug
(2) add a corresponding test case
(3) update reccurent layers implementation from 0(deprecated in Keras) to 1