### PR TITLE
fix keras converter with shared layers.

### DIFF
--- a/coremltools/converters/keras/_topology2.py
+++ b/coremltools/converters/keras/_topology2.py
@@ -169,9 +169,8 @@ class NetGraph(object):
         self.output_layers = []
         if hasattr(self.model, 'output_layers'):
             # find corresponding output layers in CoreML model
-            # if layers are shared, merge them.
-            self.output_layers = [self.get_coreml_layers(kl)[0] for kl in
-                    list(set(self.model.output_layers))]
+            # if layers are shared, get from the second or more index..
+            self.output_layers = [self.get_coreml_layers(kl)[self.model.output_layers[:i].count(kl)] for kl in self.model.output_layers]
         elif len(self.model.outputs) > 0:
             for model_output in self.model.outputs:                
                 for l in self.layer_list:

--- a/coremltools/converters/keras/_topology2.py
+++ b/coremltools/converters/keras/_topology2.py
@@ -169,8 +169,8 @@ class NetGraph(object):
         self.output_layers = []
         if hasattr(self.model, 'output_layers'):
             # find corresponding output layers in CoreML model
-            # if layers are shared, get from the second or more index..
-            self.output_layers = [self.get_coreml_layers(kl)[self.model.output_layers[:i].count(kl)] for kl in self.model.output_layers]
+            # if layers are shared, get from the second or more index.
+            self.output_layers = [self.get_coreml_layers(kl)[self.model.output_layers[:i].count(kl)] for i,kl in enumerate(self.model.output_layers)]
         elif len(self.model.outputs) > 0:
             for model_output in self.model.outputs:                
                 for l in self.layer_list:

--- a/coremltools/converters/keras/_topology2.py
+++ b/coremltools/converters/keras/_topology2.py
@@ -169,9 +169,9 @@ class NetGraph(object):
         self.output_layers = []
         if hasattr(self.model, 'output_layers'):
             # find corresponding output layers in CoreML model
-            # assume output layers are not shared
-            self.output_layers = [self.get_coreml_layers(kl)[0] for kl in 
-                    self.model.output_layers]
+            # if layers are shared, merge them.
+            self.output_layers = [self.get_coreml_layers(kl)[0] for kl in
+                    list(set(self.model.output_layers))]
         elif len(self.model.outputs) > 0:
             for model_output in self.model.outputs:                
                 for l in self.layer_list:
@@ -633,7 +633,7 @@ class NetGraph(object):
             layer = self.layer_list[idx]
             keras_layer = self.keras_layer_map[layer]
             predecessors = self.reverse_edge_map[layer]
-            successors = self.edge_map[layer]
+            successors = self.edge_map.get(layer, [])
             new_layers = [layer+'_'+str(i) for i in range(len(predecessors))]
             self.layer_list[idx:idx+1] = new_layers
             for i, new_layer in enumerate(new_layers):


### PR DESCRIPTION
keras converter could not use shared layers as output. So I fixed convert error and merge shared outputs in one output to complete convert.

Before, when I convert the model like this,

```
inputs = []
for i in range(3):
    inputs.append(Input(shape=(3,)))
dense = Dense(5)
densed = [dense(_i) for _i in inputs]
model = Model(inputs=inputs, outputs=densed)
```

I got this error.

```
KeyError: u'dense_1'
```

because output layer is not included in `self.edge_map` at build in _topology2.py.

And after this fix, I cannot convert because of shared layers outputs.
So I merge shared layers into one output.

Therefore, above model has three outputs at keras but only one output at mlmodel.

Let me know if I misunderstand about layers.
I think this is related to https://github.com/apple/coremltools/issues/73 .