### PR TITLE
Index range bug in keras converter function "make_output_layers()"

### DIFF
--- a/coremltools/converters/keras/_topology2.py
+++ b/coremltools/converters/keras/_topology2.py
@@ -165,21 +165,24 @@ class NetGraph(object):
         """
         Extract the ordering of output layers. 
         """
-        # TODO - finish this
         self.output_layers = []
         if hasattr(self.model, 'output_layers'):
             # find corresponding output layers in CoreML model
             # assume output layers are not shared
-            self.output_layers = [self.get_coreml_layers(kl)[0] for kl in 
-                    self.model.output_layers]
+            for kl in self.model.output_layers:
+                coreml_layers = self.get_coreml_layers(kl)
+                if len(coreml_layers) > 0:
+                    for cl in coreml_layers:
+                        self.output_layers.append(cl)
         elif len(self.model.outputs) > 0:
-            for model_output in self.model.outputs:                
+            for model_output in self.model.outputs:
                 for l in self.layer_list:
                     out_tensor = self.keras_layer_map[l].output
                     if out_tensor == model_output:
                         self.output_layers.append(l)
-        else:
-            raise ValueError("Output values cannot be identified.")
+
+        if len(self.output_layers) == 0:
+            raise ValueError("No outputs can be identified")
     
     def get_input_layers(self):
         return self.input_layers


### PR DESCRIPTION
This PR adds code to handle list "index out of range" exception when calling `make_output_layers()`. 
The bug is reported in Issue #90, where in `make_output_layers()` there's a call directly to `get_coreml_layers()[0]`  while `get_coreml_layers()` can return an empty list. 

This PR does not, however, identify the cause of `get_coreml_layers()` returning an empty list, which should not be the case for any Keras layer in `model.output_layers`. 