### PR TITLE
Mark slow tests as such

### DIFF
--- a/coremltools/test/test_caffe_stress_tests.py
+++ b/coremltools/test/test_caffe_stress_tests.py
@@ -252,6 +252,7 @@ class CaffeLayers(unittest.TestCase):
                 
         return relative_error, failed_tests
 
+    @pytest.mark.slow
     def test_caffe_inner_product_layer(self):
         self.run_case(
             layer_type='inner_product',
@@ -259,6 +260,7 @@ class CaffeLayers(unittest.TestCase):
             output_layer='LayerInnerProduct'
         )
 
+    @pytest.mark.slow
     def test_caffe_inner_product_activation_layer(self):
         self.run_case(
             layer_type='inner_product_activation',
@@ -312,6 +314,7 @@ class CaffeLayers(unittest.TestCase):
             output_layer='LayerBias'
         )
 
+    @pytest.mark.slow
     def test_crop_layer(self):
         self.run_case(
             layer_type='crop',
@@ -335,6 +338,7 @@ class CaffeLayers(unittest.TestCase):
             output_layer='LayerPooling'
         )
 
+    @pytest.mark.slow
     def test_lrn(self):
         self.run_case(
             layer_type='lrn',


### PR DESCRIPTION
These tests all take a while and thus marked as slow. All are at least >3min, but several ran for much longer (1+ hour).

The longest ones now are `test_batchnorm` and `test_embed` which both take about 2.5 minutes. I did not mark those as slow.

It looks like a lot of these test many different seeds, so a better solution would be to have a fast version that runs a few seeds and a slow version that runs many more.