### PR TITLE
Fix LoadConstantLayer fp16 data size calculation

### DIFF
--- a/mlmodel/src/NeuralNetworkValidator.cpp
+++ b/mlmodel/src/NeuralNetworkValidator.cpp
@@ -748,7 +748,7 @@ namespace CoreML {
         if (paramType == FLOAT32) {
             data_size = static_cast<uint64_t>(params.data().floatvalue_size());
         } else {
-            data_size = static_cast<uint64_t>(params.data().float16value().size());
+            data_size = static_cast<uint64_t>(params.data().float16value().size() / 2);
         }
 
         if (params.shape_size() != 3) {


### PR DESCRIPTION
LoadConstantLayer's data size calculation in float16 has been forgotted to divided by 2.