### PR TITLE
XGBoost 0.7 name change fix

### DIFF
--- a/coremltools/converters/xgboost/_tree_ensemble.py
+++ b/coremltools/converters/xgboost/_tree_ensemble.py
@@ -118,7 +118,11 @@ def convert_tree_ensemble(model, feature_names, target, force_32bit_float):
 
         # Now use the booster API.
         if isinstance(model, _xgboost.XGBRegressor):
-            model = model.booster()
+            # Name change in 0.7
+            if hasattr(model, 'get_booster'):
+                model = model.get_booster()
+            else:
+                model = model.booster()
 
         # Xgboost sometimes has feature names in there. Sometimes does not.
         if (feature_names is None) and (model.feature_names is None):


### PR DESCRIPTION
This fixes the following broken test cases under xgboost 0.7 (while still preserving compatibility with older versions):
```
test_boosted_trees_regression_numeric.py::XGboostRegressorBostonHousingNumericTest::test_boston_housing_float_double_corner_case
test_boosted_trees_regression_numeric.py::XGboostRegressorBostonHousingNumericTest::test_boston_housing_parameter_stress_test
test_boosted_trees_regression_numeric.py::XGboostRegressorBostonHousingNumericTest::test_boston_housing_simple_boosted_tree_regression
test_boosted_trees_regression_numeric.py::XGboostRegressorBostonHousingNumericTest::test_boston_housing_simple_decision_tree_regression
test_boosted_trees_regression_numeric.py::XGboostRegressorBostonHousingNumericTest::test_boston_housing_simple_random_forest_regression
```
There are other broken xgboost test cases, so this does not give full 0.7 compliance.

Name change introduced here: https://github.com/dmlc/xgboost/commit/29289d23020305bef5533c7231a5b2942931466f