### PR TITLE
Skip Keras 2 only test if user has Keras 1

### DIFF
--- a/coremltools/test/test_io_types.py
+++ b/coremltools/test/test_io_types.py
@@ -4,6 +4,7 @@
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
 import coremltools
+from coremltools._deps import HAS_KERAS2_TF
 import keras
 import sklearn
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
@@ -214,6 +215,7 @@ class TestIODataTypes(unittest.TestCase):
             except RuntimeError:
                 print("{} not supported. ".format(dtype))
 
+    @unittest.skipIf(not HAS_KERAS2_TF, 'Missing keras 2. Skipping test.')
     @pytest.mark.keras2
     def test_keras_dense_model(self):
         model = keras.models.Sequential()


### PR DESCRIPTION
This test is marked as Keras 2 only but still runs (and fails) under Keras 1. This introduces a skipIf to avoid this.