### PR TITLE
Handle API change in scikit-learn 0.19 for tests

### DIFF
--- a/coremltools/_deps/__init__.py
+++ b/coremltools/_deps/__init__.py
@@ -19,6 +19,7 @@ def __get_version(version):
 
 # ---------------------------------------------------------------------------------------
 HAS_SKLEARN = True
+SKLEARN_VERSION = None
 SKLEARN_MIN_VERSION = '0.15'
 def __get_sklearn_version(version):
     # matching 0.15b, 0.16bf, etc
@@ -28,7 +29,8 @@ def __get_sklearn_version(version):
 
 try:
     import sklearn
-    if __get_sklearn_version(sklearn.__version__) < _StrictVersion(SKLEARN_MIN_VERSION):
+    SKLEARN_VERSION = __get_sklearn_version(sklearn.__version__)
+    if SKLEARN_VERSION < _StrictVersion(SKLEARN_MIN_VERSION):
         HAS_SKLEARN = False
         _logging.warn(('scikit-learn version %s is not supported. Minimum required version: %s. '
                       'Disabling scikit-learn conversion API.')

--- a/coremltools/test/test_random_forest_classifier_numeric.py
+++ b/coremltools/test/test_random_forest_classifier_numeric.py
@@ -8,8 +8,9 @@ import itertools
 import os
 import pandas as pd
 import numpy as np
-from coremltools._deps import HAS_SKLEARN
+from coremltools._deps import HAS_SKLEARN, SKLEARN_VERSION
 from coremltools.models.utils import evaluate_classifier
+from distutils.version import StrictVersion
 import pytest
 
 if HAS_SKLEARN:
@@ -69,8 +70,10 @@ class RandomForestBinaryClassifierBostonHousingScikitNumericTest(
             min_samples_leaf = [1, 5],
             min_weight_fraction_leaf = [0.0, 0.5],
             max_leaf_nodes = [None, 20],
-            min_impurity_decrease = [1e-07, 0.1],
         )
+
+        if SKLEARN_VERSION >= StrictVersion('0.19'):
+            options['min_impurity_decrease'] = [1e-07, 0.1]
 
         # Make a cartesian product of all options
         product = itertools.product(*options.values())
@@ -117,8 +120,10 @@ class RandomForestMultiClassClassificationBostonHousingScikitNumericTest(
                        min_samples_leaf = [1, 5],
                        min_weight_fraction_leaf = [0.0, 0.5],
                        max_leaf_nodes = [None, 20],
-                       min_impurity_decrease = [1e-07, 0.1],
         )
+
+        if SKLEARN_VERSION >= StrictVersion('0.19'):
+            options['min_impurity_decrease'] = [1e-07, 0.1]
 
         # Make a cartesian product of all options
         product = itertools.product(*options.values())


### PR DESCRIPTION
The option `min_impurity_decrease` was introduced in scikit-learn 0.19, so this checks if that setting is available. With this, the test passes with both pre and post that release.

A simpler solution is just take out `min_impurity_decrease` altogether as long as we support earlier versions than 0.19.