### PR TITLE
Bump dependency on scikit-learn and xgboost (based on extensive testing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ In addition, it has the following soft dependencies that are only needed when
 you are converting models of these formats:
 
 - Keras (1.2.2, 2.0.4+) with Tensorflow (1.0.x, 1.1.x)
-- Xgboost (0.6+)
-- scikit-learn (0.15+)
+- Xgboost (0.7+)
+- scikit-learn (0.17+)
 - libSVM
 
 


### PR DESCRIPTION
I'm proposing bumping some versions of dependencies in the README, for the following reasons:

XGBoost v0.6 can't export to JSON, which the converter depends on.
Coremltools previously depended on an unreleased v0.6+ version, but
now that v0.7 is released, let's bump this.

Scikit-learn: Many tests (22+) are broken on 0.15 and 0.16, so
this bump is simply a reflection of reality.