### PR TITLE
Protobuf (on Linux) requires bytes objects

### DIFF
--- a/coremltools/converters/libsvm/_libsvm_converter.py
+++ b/coremltools/converters/libsvm/_libsvm_converter.py
@@ -93,7 +93,7 @@ def convert(libsvm_model, feature_names, target, input_length, probability):
         for cur_input_name in feature_names:
             input = export_spec.description.input.add()
             input.name = cur_input_name
-            input.type.doubleType.MergeFromString('')
+            input.type.doubleType.MergeFromString(b'')
 
     # Set target
     output = export_spec.description.output.add()
@@ -102,12 +102,12 @@ def convert(libsvm_model, feature_names, target, input_length, probability):
     # Set the interface types
     if(svm_type_enum == libsvm.EPSILON_SVR or svm_type_enum == libsvm.NU_SVR):
         export_spec.description.predictedFeatureName = target
-        output.type.doubleType.MergeFromString('')
+        output.type.doubleType.MergeFromString(b'')
         nr_class = 2
 
     elif(svm_type_enum == libsvm.C_SVC or svm_type_enum == libsvm.NU_SVC):
         export_spec.description.predictedFeatureName = target
-        output.type.int64Type.MergeFromString('')
+        output.type.int64Type.MergeFromString(b'')
 
         nr_class = len(libsvm_model.get_labels())
 
@@ -118,15 +118,15 @@ def convert(libsvm_model, feature_names, target, input_length, probability):
         if probability and bool(libsvm_model.probA):
             output = export_spec.description.output.add()
             output.name = probability
-            output.type.dictionaryType.MergeFromString('')
-            output.type.dictionaryType.int64KeyType.MergeFromString('')
+            output.type.dictionaryType.MergeFromString(b'')
+            output.type.dictionaryType.int64KeyType.MergeFromString(b'')
             export_spec.description.predictedProbabilitiesName = probability
 
     else:
         raise ValueError('Only the following SVM types are supported: C_SVC, NU_SVC, EPSILON_SVR, NU_SVR')
 
     if(libsvm_model.param.kernel_type == libsvm.LINEAR):
-        svm.kernel.linearKernel.MergeFromString('')  # Hack to set kernel to an empty type
+        svm.kernel.linearKernel.MergeFromString(b'')  # Hack to set kernel to an empty type
     elif(libsvm_model.param.kernel_type == libsvm.RBF):
         svm.kernel.rbfKernel.gamma = libsvm_model.param.gamma
     elif(libsvm_model.param.kernel_type == libsvm.POLY):

--- a/coremltools/converters/sklearn/_svm_common.py
+++ b/coremltools/converters/sklearn/_svm_common.py
@@ -22,7 +22,7 @@ def _set_kernel(model, spec):
 
     result = None
     if(model.kernel == 'linear'):
-        spec.kernel.linearKernel.MergeFromString('')  # hack to set kernel to an empty type
+        spec.kernel.linearKernel.MergeFromString(b'')  # hack to set kernel to an empty type
     elif(model.kernel == 'rbf'):
             spec.kernel.rbfKernel.gamma = gamma_value(model)
     elif(model.kernel == 'poly'):

--- a/coremltools/models/datatypes.py
+++ b/coremltools/models/datatypes.py
@@ -189,30 +189,30 @@ def _set_datatype(proto_type_obj, datatype_instance):
 
     # Now set the protobuf from this interface.
     if isinstance(datatype_instance, Int64):
-        proto_type_obj.int64Type.MergeFromString('')
+        proto_type_obj.int64Type.MergeFromString(b'')
 
     elif isinstance(datatype_instance, Double):
-        proto_type_obj.doubleType.MergeFromString('')
+        proto_type_obj.doubleType.MergeFromString(b'')
 
     elif isinstance(datatype_instance, String):
-        proto_type_obj.stringType.MergeFromString('')
+        proto_type_obj.stringType.MergeFromString(b'')
 
     elif isinstance(datatype_instance, Array):
-        proto_type_obj.multiArrayType.MergeFromString('')
+        proto_type_obj.multiArrayType.MergeFromString(b'')
         proto_type_obj.multiArrayType.dataType = Model_pb2.ArrayFeatureType.DOUBLE
 
         for n in datatype_instance.dimensions:
             proto_type_obj.multiArrayType.shape.append(n)
 
     elif isinstance(datatype_instance, Dictionary):
-        proto_type_obj.dictionaryType.MergeFromString('')
+        proto_type_obj.dictionaryType.MergeFromString(b'')
 
         kt = datatype_instance.key_type
         
         if isinstance(kt, Int64):
-            proto_type_obj.dictionaryType.int64KeyType.MergeFromString('')
+            proto_type_obj.dictionaryType.int64KeyType.MergeFromString(b'')
         elif isinstance(kt, String):
-            proto_type_obj.dictionaryType.stringKeyType.MergeFromString('')
+            proto_type_obj.dictionaryType.stringKeyType.MergeFromString(b'')
         else:
             raise ValueError("Dictionary key type must be either string or int.")
 

--- a/coremltools/models/neural_network.py
+++ b/coremltools/models/neural_network.py
@@ -17,17 +17,17 @@ import numpy as np
 
 def _set_recurrent_activation(param, activation):
     if activation == 'SIGMOID':
-        param.sigmoid.MergeFromString('')
+        param.sigmoid.MergeFromString(b'')
     elif activation == 'TANH':
-        param.tanh.MergeFromString('')
+        param.tanh.MergeFromString(b'')
     elif activation == 'LINEAR':
-        param.linear.MergeFromString('')
+        param.linear.MergeFromString(b'')
     elif activation == 'SIGMOID_HARD':
-        param.sigmoidHard.MergeFromString('')
+        param.sigmoidHard.MergeFromString(b'')
     elif activation == 'SCALED_TANH':
-        param.scaledTanh.MergeFromString('')
+        param.scaledTanh.MergeFromString(b'')
     elif activation == 'RELU':
-        param.ReLU.MergeFromString('')
+        param.ReLU.MergeFromString(b'')
     else:
         raise TypeError("Unsupported activation type with Recurrrent layer: %s." % activation)
 
@@ -263,7 +263,7 @@ class NeuralNetworkBuilder(object):
             raise ValueError(
                 "Model should have atleast one output (the probabilities) to automatically make it a classifier.")
         probOutput = spec.description.output[0]
-        probOutput.type.dictionaryType.MergeFromString('')
+        probOutput.type.dictionaryType.MergeFromString(b'')
         if len(class_labels) == 0:
             return
         class_type = type(class_labels[0])
@@ -277,14 +277,14 @@ class NeuralNetworkBuilder(object):
         classLabel.name = predicted_feature_name
         if class_type == int:
             nn_spec.ClearField('int64ClassLabels')
-            probOutput.type.dictionaryType.int64KeyType.MergeFromString('')
-            classLabel.type.int64Type.MergeFromString('')
+            probOutput.type.dictionaryType.int64KeyType.MergeFromString(b'')
+            classLabel.type.int64Type.MergeFromString(b'')
             for c in class_labels:
                 nn_spec.int64ClassLabels.vector.append(c)
         else:
             nn_spec.ClearField('stringClassLabels')
-            probOutput.type.dictionaryType.stringKeyType.MergeFromString('')
-            classLabel.type.stringType.MergeFromString('')
+            probOutput.type.dictionaryType.stringKeyType.MergeFromString(b'')
+            classLabel.type.stringType.MergeFromString(b'')
             for c in class_labels:
                 nn_spec.stringClassLabels.vector.append(c)
 
@@ -477,7 +477,7 @@ class NeuralNetworkBuilder(object):
         spec_layer.name = name
         spec_layer.input.append(input_name)
         spec_layer.output.append(output_name)
-        spec_layer_params = spec_layer.softmax.MergeFromString('')
+        spec_layer_params = spec_layer.softmax.MergeFromString(b'')
 
     def add_activation(self, name, non_linearity, input_name, output_name,
         params=None):
@@ -575,16 +575,16 @@ class NeuralNetworkBuilder(object):
 
         # Fill in the parameters
         if non_linearity == 'RELU':
-            spec_layer_params.ReLU.MergeFromString('')
+            spec_layer_params.ReLU.MergeFromString(b'')
   
         elif non_linearity == 'SIGMOID':
-            spec_layer_params.sigmoid.MergeFromString('')
+            spec_layer_params.sigmoid.MergeFromString(b'')
 
         elif non_linearity == 'TANH':
-            spec_layer_params.tanh.MergeFromString('')
+            spec_layer_params.tanh.MergeFromString(b'')
 
         elif non_linearity == 'SCALED_TANH':
-            spec_layer_params.scaledTanh.MergeFromString('')
+            spec_layer_params.scaledTanh.MergeFromString(b'')
             if params is None:
                 alpha, beta = (0.0, 0.0)
             else:
@@ -593,10 +593,10 @@ class NeuralNetworkBuilder(object):
             spec_layer_params.scaledTanh.beta = beta
 
         elif non_linearity == 'SOFTPLUS':
-            spec_layer_params.softplus.MergeFromString('')
+            spec_layer_params.softplus.MergeFromString(b'')
 
         elif non_linearity == 'SOFTSIGN':
-            spec_layer_params.softsign.MergeFromString('')
+            spec_layer_params.softsign.MergeFromString(b'')
 
         elif non_linearity == 'SIGMOID_HARD':
             if params is None:
@@ -698,11 +698,11 @@ class NeuralNetworkBuilder(object):
         elif mode == 'SEQUENCE_CONCAT':
             spec_layer.concat.sequenceConcat = True
         elif mode == 'ADD':
-            spec_layer.add.MergeFromString('')
+            spec_layer.add.MergeFromString(b'')
             if alpha:
                 spec_layer.add.alpha = alpha
         elif mode == 'MULTIPLY':
-            spec_layer.multiply.MergeFromString('')
+            spec_layer.multiply.MergeFromString(b'')
             if alpha:
                 spec_layer.multiply.alpha = alpha
         elif mode == 'COS':
@@ -710,11 +710,11 @@ class NeuralNetworkBuilder(object):
         elif mode == 'DOT':
             spec_layer.dot.cosineSimilarity = False
         elif mode == 'MAX':
-            spec_layer.max.MergeFromString('')
+            spec_layer.max.MergeFromString(b'')
         elif mode == 'MIN':
-            spec_layer.min.MergeFromString('')    
+            spec_layer.min.MergeFromString(b'')    
         elif mode == 'AVE':
-            spec_layer.average.MergeFromString('')
+            spec_layer.average.MergeFromString(b'')
         else:
             raise ValueError("Unspported elementwise mode %s" % mode)
 
@@ -987,7 +987,7 @@ class NeuralNetworkBuilder(object):
         spec_layer.name = name
         spec_layer.input.append(input_name)
         spec_layer.output.append(output_name)
-        spec_layer.convolution.MergeFromString('') # hack to set empty message
+        spec_layer.convolution.MergeFromString(b'') # hack to set empty message
 
         # Set the layer params
         spec_layer_params = spec_layer.convolution
@@ -1191,9 +1191,9 @@ class NeuralNetworkBuilder(object):
         if padding_type == 'constant':
             spec_layer_params.constant.value = value
         elif padding_type == 'reflection':
-            spec_layer_params.reflection.MergeFromString('')
+            spec_layer_params.reflection.MergeFromString(b'')
         elif padding_type == 'replication':
-            spec_layer_params.replication.MergeFromString('')
+            spec_layer_params.replication.MergeFromString(b'')
         else:
             raise ValueError("Unknown padding_type %s" %(padding_type))              
         
@@ -2484,7 +2484,7 @@ class NeuralNetworkBuilder(object):
             spec_layer.output.append(outname)
 
         # Have to do it this way since I can't just assign custom in a layer
-        spec_layer.custom.MergeFromString("")
+        spec_layer.custom.MergeFromString(b'')
         if custom_proto_spec:
             spec_layer.custom.CopyFrom(custom_proto_spec)
 

--- a/coremltools/test/test_model.py
+++ b/coremltools/test/test_model.py
@@ -24,11 +24,11 @@ class MLModelTest(unittest.TestCase):
         for f in features:
             input_ = spec.description.input.add()
             input_.name = f
-            input_.type.doubleType.MergeFromString('')
+            input_.type.doubleType.MergeFromString(b'')
 
         output_ = spec.description.output.add()
         output_.name = output
-        output_.type.doubleType.MergeFromString('')
+        output_.type.doubleType.MergeFromString(b'')
 
         lr = spec.glmRegressor
         lr.offset.append(0.1)

--- a/coremltools/test/test_neural_networks.py
+++ b/coremltools/test/test_neural_networks.py
@@ -141,11 +141,11 @@ class CustomLayerUtilsTest(unittest.TestCase):
         for f in features:
             input_ = spec.description.input.add()
             input_.name = f
-            input_.type.doubleType.MergeFromString('')
+            input_.type.doubleType.MergeFromString(b'')
 
         output_ = spec.description.output.add()
         output_.name = output
-        output_.type.doubleType.MergeFromString('')
+        output_.type.doubleType.MergeFromString(b'')
 
         layer = spec.neuralNetwork.layers.add()
         layer.name = 'custom1'


### PR DESCRIPTION
This is a fix for Python 3, while on Python 2 the `b` prefix is a no-op.
Protobuf on macOS never had this issue, so this is a fix for Linux.