### PR TITLE
Avoid Core ML prediction tests on unsupported platforms

### DIFF
--- a/coremltools/models/model.py
+++ b/coremltools/models/model.py
@@ -11,6 +11,7 @@ import tempfile as _tempfile
 from .utils import save_spec as _save_spec
 from .utils import load_spec as _load_spec
 from .utils import has_custom_layer as _has_custom_layer
+from .utils import macos_version as _macos_version
 from ..proto import Model_pb2 as _Model_pb2
 
 
@@ -262,7 +263,7 @@ class MLModel(object):
         if self.__proxy__:
             return self.__proxy__.predict(data,useCPUOnly)
         else:
-            if _sys.platform != 'darwin' or float('.'.join(_platform.mac_ver()[0].split('.')[:2])) < 10.13:
+            if _macos_version() < (10, 13):
                 raise Exception('Model prediction is only supported on macOS version 10.13 or later.')
 
             try:

--- a/coremltools/models/utils.py
+++ b/coremltools/models/utils.py
@@ -1001,3 +1001,15 @@ def replace_custom_layer_name(spec, oldname, newname):
             layer.custom.className = newname
 
 
+def macos_version():
+    """
+    Returns macOS version as a tuple of integers, making it easy to do proper
+    version comparisons. On non-Macs, it returns an empty tuple.
+    """
+    import sys
+    if sys.platform == 'darwin':
+        import platform
+        ver_str = platform.mac_ver()[0]
+        return tuple([int(v) for v in ver_str.split('.')])
+    else:
+        return ()

--- a/coremltools/test/test_NuSVR.py
+++ b/coremltools/test/test_NuSVR.py
@@ -11,7 +11,7 @@ import pytest
 
 from coremltools._deps import HAS_LIBSVM
 from coremltools._deps import HAS_SKLEARN
-from coremltools.models.utils import evaluate_regressor
+from coremltools.models.utils import evaluate_regressor, macos_version
 
 if HAS_LIBSVM:
     import svmutil
@@ -97,8 +97,9 @@ class NuSVRScikitTest(unittest.TestCase):
 
                 spec = scikit_converter.convert(cur_model, input_names, 'target')
 
-                metrics = evaluate_regressor(spec, df)
-                self.assertAlmostEquals(metrics['max_error'], 0)
+                if macos_version() >= (10, 13):
+                    metrics = evaluate_regressor(spec, df)
+                    self.assertAlmostEquals(metrics['max_error'], 0)
 
                 if not allow_slow:
                     break
@@ -191,8 +192,9 @@ class NuSVRLibSVMTest(unittest.TestCase):
 
                 spec = libsvm.convert(model, input_names, 'target')
 
-                metrics = evaluate_regressor(spec, df)
-                self.assertAlmostEquals(metrics['max_error'], 0)
+                if macos_version() >= (10, 13):
+                    metrics = evaluate_regressor(spec, df)
+                    self.assertAlmostEquals(metrics['max_error'], 0)
 
                 if not allow_slow:
                     break

--- a/coremltools/test/test_SVR.py
+++ b/coremltools/test/test_SVR.py
@@ -12,7 +12,7 @@ import pytest
 from coremltools._deps import HAS_LIBSVM
 from coremltools._deps import HAS_SKLEARN
 
-from coremltools.models.utils import evaluate_regressor
+from coremltools.models.utils import evaluate_regressor, macos_version
 
 if HAS_LIBSVM:
     import svmutil
@@ -104,8 +104,9 @@ class SvrScikitTest(unittest.TestCase):
 
                 spec = sklearn_converter.convert(cur_model, input_names, 'target')
 
-                metrics = evaluate_regressor(spec, df)
-                self.assertAlmostEquals(metrics['max_error'], 0)
+                if macos_version() >= (10, 13):
+                    metrics = evaluate_regressor(spec, df)
+                    self.assertAlmostEquals(metrics['max_error'], 0)
 
                 if not allow_slow:
                     break
@@ -144,9 +145,10 @@ class EpsilonSVRLibSVMTest(unittest.TestCase):
 
         # Default values
         spec = libsvm.convert(self.libsvm_model)
-        (df['prediction'], _, _) = svmutil.svm_predict(data['target'], data['data'].tolist(), self.libsvm_model)
-        metrics = evaluate_regressor(spec, df)
-        self.assertAlmostEquals(metrics['max_error'], 0)
+        if macos_version() >= (10, 13):
+            (df['prediction'], _, _) = svmutil.svm_predict(data['target'], data['data'].tolist(), self.libsvm_model)
+            metrics = evaluate_regressor(spec, df)
+            self.assertAlmostEquals(metrics['max_error'], 0)
 
         # One extra parameters. This is legal/possible.
         num_inputs = len(data['data'][0])
@@ -217,8 +219,9 @@ class EpsilonSVRLibSVMTest(unittest.TestCase):
 
                 spec = libsvm.convert(model, input_names=input_names, target_name='target')
 
-                metrics = evaluate_regressor(spec, df)
-                self.assertAlmostEquals(metrics['max_error'], 0)
+                if macos_version() >= (10, 13):
+                    metrics = evaluate_regressor(spec, df)
+                    self.assertAlmostEquals(metrics['max_error'], 0)
 
                 if not allow_slow:
                     break

--- a/coremltools/test/test_caffe_stress_tests.py
+++ b/coremltools/test/test_caffe_stress_tests.py
@@ -8,6 +8,7 @@ import json
 import numpy as np
 import math
 from coremltools.converters import caffe as caffe_converter
+from coremltools.models.utils import macos_version
 nets_path = os.getenv('CAFFE_MODELS_PATH', '')
 nets_path = nets_path + '/' if nets_path else ''
 import coremltools
@@ -151,23 +152,24 @@ class CaffeLayers(unittest.TestCase):
                 layer_type,
                 input_layer
             )
-            if conversion_result is False:
-                failed_tests_conversion.append(net_name)
-                continue
-            load_result = load_mlmodel(net_name, layer_type)
-            if load_result is False:
-                failed_tests_load.append(net_name)
-            if 'input' in net_name:
-                evaluation_result, failed_tests_evaluation = \
-                    self.evaluate_model(
-                        net_name,
-                        layer_type,
-                        input_layer,
-                        output_layer,
-                        net_data_files,
-                        failed_tests_evaluation,
-                        counter,
-                        delta)
+            if macos_version() >= (10, 13):
+                if conversion_result is False:
+                    failed_tests_conversion.append(net_name)
+                    continue
+                load_result = load_mlmodel(net_name, layer_type)
+                if load_result is False:
+                    failed_tests_load.append(net_name)
+                if 'input' in net_name:
+                    evaluation_result, failed_tests_evaluation = \
+                        self.evaluate_model(
+                            net_name,
+                            layer_type,
+                            input_layer,
+                            output_layer,
+                            net_data_files,
+                            failed_tests_evaluation,
+                            counter,
+                            delta)
         with open('./failed_tests_{}.json'.format(layer_type), mode='w') \
                 as file:
             json.dump({'conversion': failed_tests_conversion,

--- a/coremltools/test/test_composite_pipelines.py
+++ b/coremltools/test/test_composite_pipelines.py
@@ -13,6 +13,7 @@ import numpy as np
 from coremltools._deps import HAS_SKLEARN
 from coremltools.models.utils import evaluate_transformer
 from coremltools.models.utils import evaluate_regressor
+from coremltools.models.utils import macos_version
 from coremltools.converters.sklearn import convert
 
 if HAS_SKLEARN:
@@ -39,12 +40,12 @@ class GradientBoostingRegressorBostonHousingScikitNumericTest(unittest.TestCase)
         # Convert the model
         spec = convert(pl, data.feature_names, 'out')
 
-        input_data = [dict(zip(data.feature_names, row)) for row in data.data]
-        output_data = [{"out" : row} for row in pl.transform(data.data)]
+        if macos_version() >= (10, 13):
+            input_data = [dict(zip(data.feature_names, row)) for row in data.data]
+            output_data = [{"out" : row} for row in pl.transform(data.data)]
 
-        result = evaluate_transformer(spec, input_data, output_data)
-
-        assert result["num_errors"] == 0
+            result = evaluate_transformer(spec, input_data, output_data)
+            assert result["num_errors"] == 0
     
     def test_boston_OHE_plus_trees(self): 
 
@@ -59,13 +60,14 @@ class GradientBoostingRegressorBostonHousingScikitNumericTest(unittest.TestCase)
         # Convert the model
         spec = convert(pl, data.feature_names, 'target')
 
-        # Get predictions
-        df = pd.DataFrame(data.data, columns=data.feature_names)
-        df['prediction'] = pl.predict(data.data)
+        if macos_version() >= (10, 13):
+            # Get predictions
+            df = pd.DataFrame(data.data, columns=data.feature_names)
+            df['prediction'] = pl.predict(data.data)
 
-        # Evaluate it
-        result = evaluate_regressor(spec, df, 'target', verbose = False)
+            # Evaluate it
+            result = evaluate_regressor(spec, df, 'target', verbose = False)
 
-        assert result["max_error"] < 0.0001
+            assert result["max_error"] < 0.0001
 
     

--- a/coremltools/test/test_custom_neural_nets.py
+++ b/coremltools/test/test_custom_neural_nets.py
@@ -5,6 +5,7 @@ import shutil
 import tempfile
 import coremltools.models.datatypes as datatypes
 from coremltools.models import neural_network as neural_network
+from coremltools.models.utils import macos_version
 import coremltools
 
 
@@ -23,43 +24,38 @@ class SimpleTest(unittest.TestCase):
         '''
         
         coreml_preds = []
-        eval = True
-        try:
-            input_dim = (1,1,1)
-            output_dim = (1, 1, 1) #some random dimensions here: we are going to remove this information later
-            input_features = [('data', datatypes.Array(*input_dim))]
-            output_features = [('output', datatypes.Array(*output_dim))]
-            builder = neural_network.NeuralNetworkBuilder(input_features, output_features)
-            
-            #ADD Layers
-            builder.add_embedding('embed', W = np.random.rand(10, 32), b = None , input_dim = 10, output_channels = 32, has_bias = 0,
-                                  input_name = 'data', output_name = 'embed')
-            builder.add_permute('permute', dim = [3,1,2,0], input_name  = 'embed', output_name = 'permute')
-            builder.add_flatten('flatten', mode = 0, input_name  = 'permute', output_name = 'flatten')                                     
-            builder.add_inner_product('dense', W = np.random.rand(480,2), b = None, input_channels = 480, output_channels = 2, has_bias = 0,
-                                      input_name = 'flatten', output_name = 'output')
-            
-            #Remove output shape by deleting and adding an output
-            del builder.spec.description.output[-1]                            
-            output = builder.spec.description.output.add()
-            output.name = 'output' 
-            output.type.multiArrayType.dataType = coremltools.proto.FeatureTypes_pb2.ArrayFeatureType.ArrayDataType.Value('DOUBLE')
-            
-            #save the model                        
-            model_dir = tempfile.mkdtemp()
-            model_path = os.path.join(model_dir, 'test_layer.mlmodel')                        
-            coremltools.utils.save_spec(builder.spec, model_path)
-            #preprare input and get predictions
-            coreml_model = coremltools.models.MLModel(model_path)
-            X = np.random.randint(low=0,high=10,size=15)
-            X = np.reshape(X, (15,1,1,1,1)).astype(np.float32)
-            coreml_input = {'data': X}
+        input_dim = (1,1,1)
+        output_dim = (1, 1, 1) #some random dimensions here: we are going to remove this information later
+        input_features = [('data', datatypes.Array(*input_dim))]
+        output_features = [('output', datatypes.Array(*output_dim))]
+        builder = neural_network.NeuralNetworkBuilder(input_features, output_features)
+        
+        #ADD Layers
+        builder.add_embedding('embed', W = np.random.rand(10, 32), b = None , input_dim = 10, output_channels = 32, has_bias = 0,
+                              input_name = 'data', output_name = 'embed')
+        builder.add_permute('permute', dim = [3,1,2,0], input_name  = 'embed', output_name = 'permute')
+        builder.add_flatten('flatten', mode = 0, input_name  = 'permute', output_name = 'flatten')                                     
+        builder.add_inner_product('dense', W = np.random.rand(480,2), b = None, input_channels = 480, output_channels = 2, has_bias = 0,
+                                  input_name = 'flatten', output_name = 'output')
+        
+        #Remove output shape by deleting and adding an output
+        del builder.spec.description.output[-1]                            
+        output = builder.spec.description.output.add()
+        output.name = 'output' 
+        output.type.multiArrayType.dataType = coremltools.proto.FeatureTypes_pb2.ArrayFeatureType.ArrayDataType.Value('DOUBLE')
+        
+        #save the model                        
+        model_dir = tempfile.mkdtemp()
+        model_path = os.path.join(model_dir, 'test_layer.mlmodel')                        
+        coremltools.utils.save_spec(builder.spec, model_path)
+        #preprare input and get predictions
+        coreml_model = coremltools.models.MLModel(model_path)
+        X = np.random.randint(low=0,high=10,size=15)
+        X = np.reshape(X, (15,1,1,1,1)).astype(np.float32)
+        coreml_input = {'data': X}
+        if macos_version() >= (10, 13):
             coreml_preds = coreml_model.predict(coreml_input)['output']
-            if os.path.exists(model_dir):
-                shutil.rmtree(model_dir)
-        except RuntimeError as e:
-            print(e)
-            eval = False
-                
-        self.assertTrue(eval)
-        self.assertEquals(len(coreml_preds.flatten()), 2)
+            self.assertEquals(len(coreml_preds.flatten()), 2)
+
+        if os.path.exists(model_dir):
+            shutil.rmtree(model_dir)

--- a/coremltools/test/test_decision_tree_classifier_numeric.py
+++ b/coremltools/test/test_decision_tree_classifier_numeric.py
@@ -8,7 +8,7 @@ import itertools
 import pandas as pd
 import unittest
 from coremltools._deps import HAS_SKLEARN
-from coremltools.models.utils import evaluate_classifier
+from coremltools.models.utils import evaluate_classifier, macos_version
 import pytest
 
 if HAS_SKLEARN:
@@ -20,20 +20,21 @@ class DecisionTreeClassificationBostonHousingScikitNumericTest(unittest.TestCase
     def _check_metrics(self, metrics, params = {}):
         self.assertEquals(metrics['num_errors'], 0, msg = 'Failed case %s. Results %s' % (params, metrics))
 
-    def _train_convert_evaluate(self, **scikit_params):
+    def _train_convert_evaluate_assert(self, **scikit_params):
         scikit_model = DecisionTreeClassifier(random_state = 1, **scikit_params)
         scikit_model.fit(self.X, self.target)
 
         # Convert the model
         spec = skl_converter.convert(scikit_model, self.feature_names, self.output_name)
         
-        # Get predictions
-        df = pd.DataFrame(self.X, columns=self.feature_names)
-        df['prediction'] = scikit_model.predict(self.X)
-        
-        # Evaluate it
-        metrics = evaluate_classifier(spec, df)
-        return metrics
+        if macos_version() >= (10, 13):
+            # Get predictions
+            df = pd.DataFrame(self.X, columns=self.feature_names)
+            df['prediction'] = scikit_model.predict(self.X)
+            
+            # Evaluate it
+            metrics = evaluate_classifier(spec, df)
+            self._check_metrics(metrics, scikit_params)
 
 @unittest.skipIf(not HAS_SKLEARN, 'Missing sklearn. Skipping tests.')
 class DecisionTreeBinaryClassificationBostonHousingScikitNumericTest(
@@ -53,8 +54,7 @@ class DecisionTreeBinaryClassificationBostonHousingScikitNumericTest(
         self.output_name = 'target'
 
     def test_simple_binary_classifier(self):
-        metrics = self._train_convert_evaluate()
-        self._check_metrics(metrics)
+        self._train_convert_evaluate_assert()
     
     @pytest.mark.slow
     def test_binary_classifier_stress_test(self):
@@ -76,8 +76,7 @@ class DecisionTreeBinaryClassificationBostonHousingScikitNumericTest(
 
         print("Testing a total of %s cases. This could take a while" % len(args))
         for it, arg in enumerate(args):
-            metrics = self._train_convert_evaluate(**arg)
-            self._check_metrics(metrics, arg)
+            self._train_convert_evaluate_assert(**arg)
 
 @unittest.skipIf(not HAS_SKLEARN, 'Missing sklearn. Skipping tests.')
 class DecisionTreeMultiClassClassificationBostonHousingScikitNumericTest(
@@ -102,8 +101,7 @@ class DecisionTreeMultiClassClassificationBostonHousingScikitNumericTest(
         self.output_name = 'target'
 
     def test_simple_multiclass(self):
-        metrics = self._train_convert_evaluate()
-        self._check_metrics(metrics)
+        self._train_convert_evaluate_assert()
 
     @pytest.mark.slow
     def test_multiclass_stress_test(self):
@@ -124,5 +122,4 @@ class DecisionTreeMultiClassClassificationBostonHousingScikitNumericTest(
 
         print("Testing a total of %s cases. This could take a while" % len(args))
         for it, arg in enumerate(args):
-            metrics = self._train_convert_evaluate(**arg)
-            self._check_metrics(metrics, arg)
+            self._train_convert_evaluate_assert(**arg)

--- a/coremltools/test/test_dict_vectorizer.py
+++ b/coremltools/test/test_dict_vectorizer.py
@@ -9,6 +9,7 @@ from copy import copy
 import numpy as np
 from coremltools.models.utils import evaluate_transformer
 from coremltools.models.utils import evaluate_classifier
+from coremltools.models.utils import macos_version
 
 if HAS_SKLEARN:
     from coremltools.converters import sklearn
@@ -29,15 +30,13 @@ class DictVectorizerScikitTest(unittest.TestCase):
         m = sklearn.convert(trained_dict_vectorizer, 
                 input_features = "features", 
                 output_feature_names = "output")
-        
-        ret = evaluate_transformer(
-                m, [{"features" : row} for row in data], 
-                [{"output" : x_r} for x_r in X], True)
 
-        assert ret["num_errors"] == 0
+        if macos_version() >= (10, 13):
+            ret = evaluate_transformer(
+                    m, [{"features" : row} for row in data], 
+                    [{"output" : x_r} for x_r in X], True)
+            assert ret["num_errors"] == 0
 
-
-       
     def test_dictvectorizer(self):
 
         D = [{"foo": 1, "bar": 3},
@@ -85,9 +84,9 @@ class DictVectorizerScikitTest(unittest.TestCase):
 
         model = coremltools.converters.sklearn.convert(pl, input_features = "features", output_feature_names = "target")
 
-        x = pd.DataFrame( {"features" : x_train_dict, 
-                           "prediction" : pl.predict(x_train_dict)})
-        
-        cur_eval_metics = evaluate_classifier(model, x)
-        self.assertEquals(cur_eval_metics['num_errors'], 0)
-   
+        if macos_version() >= (10, 13):
+            x = pd.DataFrame( {"features" : x_train_dict, 
+                               "prediction" : pl.predict(x_train_dict)})
+
+            cur_eval_metics = evaluate_classifier(model, x)
+            self.assertEquals(cur_eval_metics['num_errors'], 0)

--- a/coremltools/test/test_glm_classifier.py
+++ b/coremltools/test/test_glm_classifier.py
@@ -10,7 +10,7 @@ import unittest
 
 from coremltools._deps import HAS_SKLEARN
 from coremltools.converters.sklearn import convert
-from coremltools.models.utils import evaluate_classifier, evaluate_classifier_with_probabilities
+from coremltools.models.utils import evaluate_classifier, evaluate_classifier_with_probabilities, macos_version
 
 if HAS_SKLEARN:
     from sklearn.linear_model import LogisticRegression
@@ -63,13 +63,13 @@ class GlmCassifierTest(unittest.TestCase):
             spec = convert(cur_model, input_features=column_names,
                            output_feature_names='target')
 
-            probability_lists = cur_model.predict_proba(x)
-            df['classProbability'] = [dict(zip(cur_model.classes_, cur_vals)) for cur_vals in probability_lists]
+            if macos_version() >= (10, 13):
+                probability_lists = cur_model.predict_proba(x)
+                df['classProbability'] = [dict(zip(cur_model.classes_, cur_vals)) for cur_vals in probability_lists]
 
-            metrics = evaluate_classifier_with_probabilities(spec, df, probabilities='classProbability', verbose=False)
-            self.assertEquals(metrics['num_key_mismatch'], 0)
-            self.assertLess(metrics['max_probability_error'],  0.00001)
-
+                metrics = evaluate_classifier_with_probabilities(spec, df, probabilities='classProbability', verbose=False)
+                self.assertEquals(metrics['num_key_mismatch'], 0)
+                self.assertLess(metrics['max_probability_error'],  0.00001)
 
     def test_linear_svc_binary_classification_with_string_labels(self):
         self._conversion_and_evaluation_helper_for_linear_svc(['Foo', 'Bar'])
@@ -96,9 +96,9 @@ class GlmCassifierTest(unittest.TestCase):
 
             spec = convert(cur_model, input_features=column_names,
                            output_feature_names='target')
-            
-            df['prediction'] = cur_model.predict(x)
 
-            cur_eval_metics = evaluate_classifier(spec, df, verbose=False)
-            self.assertEquals(cur_eval_metics['num_errors'], 0)
+            if macos_version() >= (10, 13):
+                df['prediction'] = cur_model.predict(x)
 
+                cur_eval_metics = evaluate_classifier(spec, df, verbose=False)
+                self.assertEquals(cur_eval_metics['num_errors'], 0)

--- a/coremltools/test/test_imputer.py
+++ b/coremltools/test/test_imputer.py
@@ -7,7 +7,7 @@ import unittest
 from coremltools._deps import HAS_SKLEARN
 import numpy.random as rn
 import numpy as np
-from coremltools.models.utils import evaluate_transformer
+from coremltools.models.utils import evaluate_transformer, macos_version
 
 
 if HAS_SKLEARN:
@@ -47,13 +47,12 @@ class NumericalImputerTestCase(unittest.TestCase):
 
                 spec = converter.convert(model, scikit_data.feature_names, 'out')
 
-                input_data = [dict(zip(scikit_data.feature_names, row)) 
-                                for row in X]
+                if macos_version() >= (10, 13):
+                    input_data = [dict(zip(scikit_data.feature_names, row)) 
+                                    for row in X]
 
-                output_data = [{"out" : row} for row in tr_X]
+                    output_data = [{"out" : row} for row in tr_X]
 
-                result = evaluate_transformer(spec, input_data, output_data)
+                    result = evaluate_transformer(spec, input_data, output_data)
 
-                assert result["num_errors"] == 0
-                
-
+                    assert result["num_errors"] == 0

--- a/coremltools/test/test_io_types.py
+++ b/coremltools/test/test_io_types.py
@@ -5,6 +5,7 @@
 
 import coremltools
 from coremltools._deps import HAS_KERAS2_TF
+from coremltools.models.utils import macos_version
 import keras
 import sklearn
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
@@ -32,6 +33,7 @@ def create_model(spec):
     return coremltools.models.MLModel(spec)
 
 
+@unittest.skipIf(macos_version() < (10, 13), 'Only supported on macOS 10.13+')
 class TestIODataTypes(unittest.TestCase):
     """
     This class tests for different I/O feature data types for an .mlmodel

--- a/coremltools/test/test_keras_numeric.py
+++ b/coremltools/test/test_keras_numeric.py
@@ -10,6 +10,7 @@ import os, shutil
 import tempfile
 import pytest
 from coremltools._deps import HAS_KERAS_TF
+from coremltools.models.utils import macos_version
 
 if HAS_KERAS_TF:
     import keras.backend
@@ -147,34 +148,35 @@ class KerasNumericCorrectnessTest(unittest.TestCase):
         coreml_model = _get_coreml_model(model, model_path, input_names, 
                 output_names)
         
-        # Assuming coreml model output names are in the same order as Keras 
-        # Output list, put predictions into a list, sorted by output name
-        coreml_preds = coreml_model.predict(coreml_input)
-        c_preds = [coreml_preds[name] for name in output_names]
+        if macos_version() >= (10, 13):
+            # Assuming coreml model output names are in the same order as Keras 
+            # Output list, put predictions into a list, sorted by output name
+            coreml_preds = coreml_model.predict(coreml_input)
+            c_preds = [coreml_preds[name] for name in output_names]
+
+            # Run Keras predictions
+            keras_preds = model.predict(input_data)
+            k_preds = keras_preds if type(keras_preds) is list else [keras_preds]
+            
+            # Compare each output blob
+            for idx, k_pred in enumerate(k_preds):
+                if transpose_keras_result:
+                    kp = _keras_transpose(k_pred).flatten()
+                else:
+                    kp = k_pred.flatten()
+                cp = c_preds[idx].flatten()
+                # Compare predictions
+                self.assertEquals(len(kp), len(cp))
+                for i in range(len(kp)):
+                    max_den = max(1.0, kp[i], cp[i])
+                    self.assertAlmostEquals(kp[i]/max_den, 
+                                            cp[i]/max_den, 
+                                            delta=delta)
 
         # Cleanup files - models on disk no longer useful
         if use_tmp_folder and os.path.exists(model_dir):
             shutil.rmtree(model_dir)
         
-        # Run Keras predictions
-        keras_preds = model.predict(input_data)
-        k_preds = keras_preds if type(keras_preds) is list else [keras_preds]
-        
-        # Compare each output blob
-        for idx, k_pred in enumerate(k_preds):
-            if transpose_keras_result:
-                kp = _keras_transpose(k_pred).flatten()
-            else:
-                kp = k_pred.flatten()
-            cp = c_preds[idx].flatten()
-            # Compare predictions
-            self.assertEquals(len(kp), len(cp))
-            for i in range(len(kp)):
-                max_den = max(1.0, kp[i], cp[i])
-                self.assertAlmostEquals(kp[i]/max_den, 
-                                        cp[i]/max_den, 
-                                        delta=delta)
-
 
 @unittest.skipIf(not HAS_KERAS_TF, 'Missing keras. Skipping tests.')
 class KerasBasicNumericCorrectnessTest(KerasNumericCorrectnessTest):
@@ -2070,17 +2072,18 @@ class KerasNumericCorrectnessStressTest(KerasNumericCorrectnessTest):
         
         # Get the model
         coreml_model = _get_coreml_model(model, model_path, input_names, ['output'])
-        # get prediction
-        coreml_preds = coreml_model.predict(coreml_input)['output'].flatten() 
+        if macos_version() >= (10, 13):
+            # get prediction
+            coreml_preds = coreml_model.predict(coreml_input)['output'].flatten() 
 
-        if use_tmp_folder:
-            shutil.rmtree(model_dir)
-        self.assertEquals(len(coreml_preds), len(keras_preds),
-                msg = 'Failed test case %s. Lengths wrong (%s vs %s)' % (param, len(coreml_preds), len(keras_preds)))
-        for i in range(len(keras_preds)):
-            max_den = max(1.0, keras_preds[i], coreml_preds[i])
-            self.assertAlmostEquals(keras_preds[i]/max_den, coreml_preds[i]/max_den, delta = delta,
-                msg = 'Failed test case %s. Predictions wrong (%s vs %s)' % (param, coreml_preds[i], keras_preds[i]))
+            if use_tmp_folder:
+                shutil.rmtree(model_dir)
+            self.assertEquals(len(coreml_preds), len(keras_preds),
+                    msg = 'Failed test case %s. Lengths wrong (%s vs %s)' % (param, len(coreml_preds), len(keras_preds)))
+            for i in range(len(keras_preds)):
+                max_den = max(1.0, keras_preds[i], coreml_preds[i])
+                self.assertAlmostEquals(keras_preds[i]/max_den, coreml_preds[i]/max_den, delta = delta,
+                    msg = 'Failed test case %s. Predictions wrong (%s vs %s)' % (param, coreml_preds[i], keras_preds[i]))
 
     @pytest.mark.slow
     def test_activation_layer_params(self):

--- a/coremltools/test/test_linear_regression.py
+++ b/coremltools/test/test_linear_regression.py
@@ -7,7 +7,7 @@ import os
 import pandas as pd
 import unittest
 from coremltools._deps import HAS_SKLEARN
-from coremltools.models.utils import evaluate_regressor
+from coremltools.models.utils import evaluate_regressor, macos_version
 
 if HAS_SKLEARN:
     from sklearn.linear_model import LinearRegression
@@ -95,10 +95,11 @@ class LinearRegressionScikitTest(unittest.TestCase):
             cur_model.fit(self.scikit_data['data'], self.scikit_data['target'])
             spec = convert(cur_model, input_names, 'target')
 
-            df['prediction'] = cur_model.predict(self.scikit_data.data)
+            if macos_version() >= (10, 13):
+                df['prediction'] = cur_model.predict(self.scikit_data.data)
 
-            metrics = evaluate_regressor(spec, df)
-            self.assertAlmostEquals(metrics['max_error'], 0)
+                metrics = evaluate_regressor(spec, df)
+                self.assertAlmostEquals(metrics['max_error'], 0)
 
 
     def test_linear_svr_evaluation(self):
@@ -122,7 +123,8 @@ class LinearRegressionScikitTest(unittest.TestCase):
             cur_model.fit(self.scikit_data['data'], self.scikit_data['target'])
             spec = convert(cur_model, input_names, 'target')
 
-            df['prediction'] = cur_model.predict(self.scikit_data.data)
+            if macos_version() >= (10, 13):
+                df['prediction'] = cur_model.predict(self.scikit_data.data)
 
-            metrics = evaluate_regressor(spec, df)
-            self.assertAlmostEquals(metrics['max_error'], 0)
+                metrics = evaluate_regressor(spec, df)
+                self.assertAlmostEquals(metrics['max_error'], 0)

--- a/coremltools/test/test_model.py
+++ b/coremltools/test/test_model.py
@@ -7,7 +7,7 @@ import coremltools
 import unittest
 import tempfile
 from coremltools.proto import Model_pb2
-from coremltools.models.utils import rename_feature, save_spec
+from coremltools.models.utils import rename_feature, save_spec, macos_version
 from coremltools.models import MLModel
 
 
@@ -81,12 +81,14 @@ class MLModelTest(unittest.TestCase):
         self.assertEquals(model.input_description['feature_1'], 'This is feature 1')
         self.assertEquals(model.output_description['output'], 'This is output')
 
+    @unittest.skipIf(macos_version() < (10, 13), 'Only supported on macOS 10.13+')
     def test_predict_api(self):
         model = MLModel(self.spec)
         preds = model.predict({'feature_1': 1.0, 'feature_2': 1.0})
         self.assertIsNotNone(preds)
         self.assertEquals(preds['output'], 3.1)
 
+    @unittest.skipIf(macos_version() < (10, 13), 'Only supported on macOS 10.13+')
     def test_rename_input(self):
         rename_feature(self.spec, 'feature_1', 'renamed_feature', rename_inputs=True)
         model = MLModel(self.spec)
@@ -96,6 +98,7 @@ class MLModelTest(unittest.TestCase):
         # reset the spec for next run
         rename_feature(self.spec, 'renamed_feature', 'feature_1', rename_inputs=True)
 
+    @unittest.skipIf(macos_version() < (10, 13), 'Only supported on macOS 10.13+')
     def test_rename_input_bad(self):
         rename_feature(self.spec, 'blah', 'bad_name', rename_inputs=True)
         model = MLModel(self.spec)
@@ -103,6 +106,7 @@ class MLModelTest(unittest.TestCase):
         self.assertIsNotNone(preds)
         self.assertEquals(preds['output'], 3.1)
 
+    @unittest.skipIf(macos_version() < (10, 13), 'Only supported on macOS 10.13+')
     def test_rename_output(self):
         rename_feature(self.spec, 'output', 'renamed_output', rename_inputs=False, rename_outputs=True)
         model = MLModel(self.spec)
@@ -111,6 +115,7 @@ class MLModelTest(unittest.TestCase):
         self.assertEquals(preds['renamed_output'], 3.1)
         rename_feature(self.spec, 'renamed_output', 'output', rename_inputs=False, rename_outputs=True)
 
+    @unittest.skipIf(macos_version() < (10, 13), 'Only supported on macOS 10.13+')
     def test_rename_output_bad(self):
         rename_feature(self.spec, 'blah', 'bad_name', rename_inputs=False, rename_outputs=True)
         model = MLModel(self.spec)
@@ -118,6 +123,7 @@ class MLModelTest(unittest.TestCase):
         self.assertIsNotNone(preds)
         self.assertEquals(preds['output'], 3.1)
 
+    @unittest.skipIf(macos_version() < (10, 13), 'Only supported on macOS 10.13+')
     def test_future_version(self):
         self.spec.specificationVersion = 10000
         model = MLModel(self.spec)

--- a/coremltools/test/test_multiple_images_preprocessing.py
+++ b/coremltools/test/test_multiple_images_preprocessing.py
@@ -9,6 +9,7 @@ from subprocess import Popen
 import subprocess
 import numpy as np
 from coremltools.converters import caffe as caffe_converter
+from coremltools.models.utils import macos_version
 import coremltools
 import PIL.Image
 import pytest
@@ -124,20 +125,21 @@ class ManyImages(unittest.TestCase):
 
         #load and evaluate mlmodel
         mlmodel = coremltools.models.MLModel(path_mlmodel)
-        coreml_out = mlmodel.predict(coreml_input_dict)['output']
+        if macos_version() >= (10, 13):
+            coreml_out = mlmodel.predict(coreml_input_dict)['output']
 
-        caffe_preds = output_data.flatten()
-        coreml_preds = coreml_out.flatten()
-        if len(caffe_preds) != len(coreml_preds):
-            failed_tests_evaluation.append('single image mean preprocessing: evaluation failure')
-        
-        max_relative_error = compare_models(output_data.flatten(), coreml_out.flatten())
-        if max_relative_error > 0.001:
-            failed_tests_evaluation.append('single image mean preprocessing: evaluation failure')
-       
-        self.assertEqual(failed_tests_conversion,[])
-        self.assertEqual(failed_tests_load,[])
-        self.assertEqual(failed_tests_evaluation,[])
+            caffe_preds = output_data.flatten()
+            coreml_preds = coreml_out.flatten()
+            if len(caffe_preds) != len(coreml_preds):
+                failed_tests_evaluation.append('single image mean preprocessing: evaluation failure')
+            
+            max_relative_error = compare_models(output_data.flatten(), coreml_out.flatten())
+            if max_relative_error > 0.001:
+                failed_tests_evaluation.append('single image mean preprocessing: evaluation failure')
+           
+            self.assertEqual(failed_tests_conversion,[])
+            self.assertEqual(failed_tests_load,[])
+            self.assertEqual(failed_tests_evaluation,[])
         shutil.rmtree('{}nets/{}'.format(nets_path, FOLDER_NAME))    
         
     
@@ -172,38 +174,39 @@ class ManyImages(unittest.TestCase):
         if load_result is False:
             failed_tests_load.append('image bias preprocessing: load failure')
         
-
-        #load Caffe's input and output
-        with open('{}nets/{}/{}_bias/input.json'.format(nets_path, FOLDER_NAME, str(n))) as data_file:
-            input_data_dict = json.load(data_file)
-        with open('{}nets/{}/{}_bias/output.json'.format(nets_path, FOLDER_NAME, str(n))) as data_file:
-            output_data_dict = json.load(data_file)
+        if macos_version() >= (10, 13):
+            #load Caffe's input and output
+            with open('{}nets/{}/{}_bias/input.json'.format(nets_path, FOLDER_NAME, str(n))) as data_file:
+                input_data_dict = json.load(data_file)
+            with open('{}nets/{}/{}_bias/output.json'.format(nets_path, FOLDER_NAME, str(n))) as data_file:
+                output_data_dict = json.load(data_file)
+            
+            output_data = np.array(output_data_dict["output_data"])    
         
-        output_data = np.array(output_data_dict["output_data"])    
-    
-        coreml_input_dict = dict()
-    
-        for i in range(n):
-            input_data = np.array(input_data_dict["input_data{}".format(str(i+1))]).astype(np.uint8)
-            img = PIL.Image.fromarray(np.transpose(input_data[0,:,:,:],[1,2,0]))
-            coreml_input_dict["data{}".format(str(i+1))] = img
-
-        #load and evaluate mlmodel
-        mlmodel = coremltools.models.MLModel(path_mlmodel)
-        coreml_out = mlmodel.predict(coreml_input_dict)['output']
-
-        caffe_preds = output_data.flatten()
-        coreml_preds = coreml_out.flatten()
-        if len(caffe_preds) != len(coreml_preds):
-            failed_tests_evaluation.append('single image bias preprocessing: evaluation failure')
+            coreml_input_dict = dict()
         
-        max_relative_error = compare_models(output_data.flatten(), coreml_out.flatten())
-        if max_relative_error > 0.001:
-            failed_tests_evaluation.append('single image bias preprocessing: evaluation failure')
-       
-        self.assertEqual(failed_tests_conversion,[])
-        self.assertEqual(failed_tests_load,[])
-        self.assertEqual(failed_tests_evaluation,[])
+            for i in range(n):
+                input_data = np.array(input_data_dict["input_data{}".format(str(i+1))]).astype(np.uint8)
+                img = PIL.Image.fromarray(np.transpose(input_data[0,:,:,:],[1,2,0]))
+                coreml_input_dict["data{}".format(str(i+1))] = img
+
+            #load and evaluate mlmodel
+            mlmodel = coremltools.models.MLModel(path_mlmodel)
+            coreml_out = mlmodel.predict(coreml_input_dict)['output']
+
+            caffe_preds = output_data.flatten()
+            coreml_preds = coreml_out.flatten()
+            if len(caffe_preds) != len(coreml_preds):
+                failed_tests_evaluation.append('single image bias preprocessing: evaluation failure')
+            
+            max_relative_error = compare_models(output_data.flatten(), coreml_out.flatten())
+            if max_relative_error > 0.001:
+                failed_tests_evaluation.append('single image bias preprocessing: evaluation failure')
+           
+            self.assertEqual(failed_tests_conversion,[])
+            self.assertEqual(failed_tests_load,[])
+            self.assertEqual(failed_tests_evaluation,[])
+
         shutil.rmtree('{}nets/{}'.format(nets_path, FOLDER_NAME))    
 
     def test_1_mean_image(self):
@@ -268,14 +271,14 @@ class ManyImagesKeras(unittest.TestCase):
         #coreml_model.save(model_path)    
         #coreml_model = coremltools.models.MLModel(model_path)
         
-        coreml_input_dict = dict()
-        coreml_input_dict["data"] = PIL.Image.fromarray(data.astype(np.uint8))
-        coreml_preds = coreml_model.predict(coreml_input_dict)['output'].flatten()
-        
-        #compare    
-        self.assertEquals(len(keras_preds), len(coreml_preds))    
-        max_relative_error = compare_models(keras_preds, coreml_preds)
-        self.assertAlmostEquals(max(max_relative_error, .001), .001, delta = 1e-6)
+        if macos_version() >= (10, 13):
+            coreml_input_dict = dict()
+            coreml_input_dict["data"] = PIL.Image.fromarray(data.astype(np.uint8))
+            coreml_preds = coreml_model.predict(coreml_input_dict)['output'].flatten()
+
+            self.assertEquals(len(keras_preds), len(coreml_preds))    
+            max_relative_error = compare_models(keras_preds, coreml_preds)
+            self.assertAlmostEquals(max(max_relative_error, .001), .001, delta = 1e-6)
         
                                                             
         if os.path.exists(model_dir):
@@ -341,16 +344,16 @@ class ManyImagesKeras(unittest.TestCase):
         #coreml_model.save(model_path)
         #coreml_model = coremltools.models.MLModel(model_path)
 
-        coreml_input_dict = dict()
-        coreml_input_dict["data1"] = PIL.Image.fromarray(data1.astype(np.uint8))
-        coreml_input_dict["data2"] = PIL.Image.fromarray(data2.astype(np.uint8))
-        coreml_preds = coreml_model.predict(coreml_input_dict)['output'].flatten()
+        if macos_version() >= (10, 13):
+            coreml_input_dict = dict()
+            coreml_input_dict["data1"] = PIL.Image.fromarray(data1.astype(np.uint8))
+            coreml_input_dict["data2"] = PIL.Image.fromarray(data2.astype(np.uint8))
+            coreml_preds = coreml_model.predict(coreml_input_dict)['output'].flatten()
 
-        #compare
-        self.assertEquals(len(keras_preds), len(coreml_preds))
-        max_relative_error = compare_models(keras_preds, coreml_preds)
-        self.assertAlmostEquals(max(max_relative_error, .001), .001, delta = 1e-6)
-
+            #compare
+            self.assertEquals(len(keras_preds), len(coreml_preds))
+            max_relative_error = compare_models(keras_preds, coreml_preds)
+            self.assertAlmostEquals(max(max_relative_error, .001), .001, delta = 1e-6)
 
         if os.path.exists(model_dir):
             shutil.rmtree(model_dir)

--- a/coremltools/test/test_neural_networks.py
+++ b/coremltools/test/test_neural_networks.py
@@ -5,7 +5,7 @@ from coremltools.models import MLModel
 from coremltools._deps import HAS_KERAS_TF
 from coremltools.proto import Model_pb2
 from coremltools.models import MLModel
-from coremltools.models.utils import get_custom_layer_names, replace_custom_layer_name
+from coremltools.models.utils import get_custom_layer_names, replace_custom_layer_name, macos_version
 
 
 
@@ -40,10 +40,11 @@ class BasicNumericCorrectnessTest(unittest.TestCase):
         predicted_feature_name = 'pf'
         coremlmodel = keras_converter.convert(model, input_names, output_names, class_labels=class_labels, predicted_feature_name=predicted_feature_name, predicted_probabilities_output=output_names[0])
     
-        inputs = np.random.rand(input_dim)
-        outputs = coremlmodel.predict({'input': inputs})
-        # this checks that the dictionary got the right name and type
-        self.assertEquals(type(outputs[output_names[0]]), type({'a': 0.5}))
+        if macos_version() >= (10, 13):
+            inputs = np.random.rand(input_dim)
+            outputs = coremlmodel.predict({'input': inputs})
+            # this checks that the dictionary got the right name and type
+            self.assertEquals(type(outputs[output_names[0]]), type({'a': 0.5}))
     
     def test_classifier_no_name(self):
         np.random.seed(1988)
@@ -65,10 +66,11 @@ class BasicNumericCorrectnessTest(unittest.TestCase):
         predicted_feature_name = 'pf'
         coremlmodel = keras_converter.convert(model, input_names, output_names, class_labels=class_labels, predicted_feature_name=predicted_feature_name)
         
-        inputs = np.random.rand(input_dim)
-        outputs = coremlmodel.predict({'input': inputs})
-        # this checks that the dictionary got the right name and type
-        self.assertEquals(type(outputs[output_names[0]]), type({'a': 0.5}))
+        if macos_version() >= (10, 13):
+            inputs = np.random.rand(input_dim)
+            outputs = coremlmodel.predict({'input': inputs})
+            # this checks that the dictionary got the right name and type
+            self.assertEquals(type(outputs[output_names[0]]), type({'a': 0.5}))
     
     def test_internal_layer(self):
         
@@ -116,16 +118,16 @@ class BasicNumericCorrectnessTest(unittest.TestCase):
         
         coreml2 = keras_converter.convert(model2, input_names, ['output2'])
         
-        # generate input data
-        inputs = np.random.rand(input_dim)
+        if macos_version() >= (10, 13):
+            # generate input data
+            inputs = np.random.rand(input_dim)
 
-        fullOutputs = coremlfinal.predict({'input': inputs})
-        
-        partialOutput = coreml2.predict({'input': inputs})
-        
-        for i in range(0, num_channels2):
-            self.assertAlmostEquals(fullOutputs['middle_layer_output'][i], partialOutput['output2'][i], 2)
+            fullOutputs = coremlfinal.predict({'input': inputs})
             
+            partialOutput = coreml2.predict({'input': inputs})
+            
+            for i in range(0, num_channels2):
+                self.assertAlmostEquals(fullOutputs['middle_layer_output'][i], partialOutput['output2'][i], 2)
 
 
 class CustomLayerUtilsTest(unittest.TestCase):

--- a/coremltools/test/test_nn_builder.py
+++ b/coremltools/test/test_nn_builder.py
@@ -2,7 +2,9 @@ import unittest
 import numpy as np
 from coremltools.models import datatypes, MLModel
 from coremltools.models.neural_network import NeuralNetworkBuilder
+from coremltools.models.utils import macos_version
 
+@unittest.skipIf(macos_version() < (10, 13), 'Only supported on macOS 10.13+')
 class BasicNumericCorrectnessTest(unittest.TestCase):
             
     def test_undefined_shape_single_output(self):

--- a/coremltools/test/test_normalizer.py
+++ b/coremltools/test/test_normalizer.py
@@ -7,7 +7,7 @@ import numpy as _np
 import random
 import unittest
 
-from coremltools.models.utils import evaluate_transformer
+from coremltools.models.utils import evaluate_transformer, macos_version
 
 from coremltools._deps import HAS_SKLEARN
 if HAS_SKLEARN:
@@ -32,9 +32,10 @@ class NormalizerScikitTest(unittest.TestCase):
 
             spec = converter.convert(cur_model, ["a", 'b', 'c'], 'out')
 
-            metrics = evaluate_transformer(spec, 
-                    [dict(zip(["a", "b", "c"], row)) for row in X], 
-                    [{"out" : row} for row in output]) 
+            if macos_version() >= (10, 13):
+                metrics = evaluate_transformer(spec, 
+                        [dict(zip(["a", "b", "c"], row)) for row in X], 
+                        [{"out" : row} for row in output]) 
 
     def test_boston(self):
         from sklearn.datasets import load_boston
@@ -44,10 +45,10 @@ class NormalizerScikitTest(unittest.TestCase):
 
         spec = converter.convert(scikit_model, scikit_data.feature_names, 'out')
 
-        input_data = [dict(zip(scikit_data.feature_names, row)) 
-                for row in scikit_data.data]
+        if macos_version() >= (10, 13):
+            input_data = [dict(zip(scikit_data.feature_names, row)) 
+                    for row in scikit_data.data]
 
-        output_data = [{"out" : row} for row in scikit_model.transform(scikit_data.data)]
+            output_data = [{"out" : row} for row in scikit_model.transform(scikit_data.data)]
 
-        evaluate_transformer(spec, input_data, output_data)
-        
+            evaluate_transformer(spec, input_data, output_data)

--- a/coremltools/test/test_numpy_nn_layers.py
+++ b/coremltools/test/test_numpy_nn_layers.py
@@ -6,6 +6,7 @@ import shutil
 import tempfile
 import coremltools.models.datatypes as datatypes
 from coremltools.models import neural_network as neural_network
+from coremltools.models.utils import macos_version
 import coremltools
 import itertools
 
@@ -77,7 +78,10 @@ def get_coreml_predictions_slice(X, params):
         #preprare input and get predictions
         coreml_model = coremltools.models.MLModel(model_path)
         coreml_input = {'data': X}
-        coreml_preds = coreml_model.predict(coreml_input)['output']
+        if macos_version() >= (10, 13):
+            coreml_preds = coreml_model.predict(coreml_input)['output']
+        else:
+            coreml_preds = None
         if os.path.exists(model_dir):
             shutil.rmtree(model_dir)
     except RuntimeError as e:
@@ -126,7 +130,10 @@ def get_coreml_predictions_reduce(X, params):
         #preprare input and get predictions
         coreml_model = coremltools.models.MLModel(model_path)
         coreml_input = {'data': X}
-        coreml_preds = coreml_model.predict(coreml_input)['output']
+        if macos_version() >= (10, 13):
+            coreml_preds = coreml_model.predict(coreml_input)['output']
+        else:
+            coreml_preds = None
         if os.path.exists(model_dir):
             shutil.rmtree(model_dir)
     except RuntimeError as e:
@@ -154,8 +161,11 @@ def get_coreml_predictions_unary(x, mode, alpha = 1.0):
     
     #preprare input and get predictions
     coreml_model = coremltools.models.MLModel(model_path)
-    coreml_input = {'data': x}
-    coreml_preds = coreml_model.predict(coreml_input)['output']
+    if macos_version() >= (10, 13):
+        coreml_input = {'data': x}
+        coreml_preds = coreml_model.predict(coreml_input)['output']
+    else:
+        coreml_preds = None
     
     if os.path.exists(model_dir):
         shutil.rmtree(model_dir)
@@ -186,16 +196,17 @@ class SimpleTest(CorrectnessTest):
         
         #preprare input and get predictions
         coreml_model = coremltools.models.MLModel(model_path)
-        coreml_input = {'data': np.reshape(np.array([1.0,2.0,3.0]), (1,1,3))}
-        coreml_preds = coreml_model.predict(coreml_input)['output']
+        if macos_version() >= (10, 13):
+            coreml_input = {'data': np.reshape(np.array([1.0,2.0,3.0]), (1,1,3))}
+            coreml_preds = coreml_model.predict(coreml_input)['output']
         
-        #harcoded for this simple test case
-        numpy_preds = np.array([[1, 1.333, 1.666, 2, 2.333, 2.666, 3, 3, 3],\
-                [1, 1.333, 1.6666, 2, 2.33333, 2.6666, 3, 3, 3]])
-        #numpy_preds = np.array([[1, 1, 1, 2, 2, 2, 3, 3, 3],[1, 1, 1, 2, 2, 2, 3, 3, 3]])
-        #Test
-        self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
-        self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
+            #harcoded for this simple test case
+            numpy_preds = np.array([[1, 1.333, 1.666, 2, 2.333, 2.666, 3, 3, 3],\
+                    [1, 1.333, 1.6666, 2, 2.33333, 2.6666, 3, 3, 3]])
+            #numpy_preds = np.array([[1, 1, 1, 2, 2, 2, 3, 3, 3],[1, 1, 1, 2, 2, 2, 3, 3, 3]])
+            #Test
+            self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
+            self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
         
         if os.path.exists(model_dir):
             shutil.rmtree(model_dir)
@@ -220,13 +231,14 @@ class SimpleTest(CorrectnessTest):
         
         #preprare input and get predictions
         coreml_model = coremltools.models.MLModel(model_path)
-        coreml_input = {'data': np.ones((1,3,3))}
-        coreml_preds = coreml_model.predict(coreml_input)['output']
-        
-        #harcoded for this simple test case
-        numpy_preds = 1e-3 * np.ones((1,3,3))
-        self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
-        self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
+        if macos_version() >= (10, 13):
+            coreml_input = {'data': np.ones((1,3,3))}
+            coreml_preds = coreml_model.predict(coreml_input)['output']
+            
+            #harcoded for this simple test case
+            numpy_preds = 1e-3 * np.ones((1,3,3))
+            self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
+            self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
         
         if os.path.exists(model_dir):
             shutil.rmtree(model_dir)   
@@ -251,13 +263,14 @@ class SimpleTest(CorrectnessTest):
         
         #preprare input and get predictions
         coreml_model = coremltools.models.MLModel(model_path)
-        coreml_input = {'data': np.reshape(np.arange(8, dtype=np.float32), (2,2,2))}
-        coreml_preds = coreml_model.predict(coreml_input)['output']
-        
-        #harcoded for this simple test case
-        numpy_preds = np.reshape(np.arange(8) - np.array([1.5,1.5,1.5,1.5,5.5,5.5,5.5,5.5]),(2,2,2))
-        self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
-        self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
+        if macos_version() >= (10, 13):
+            coreml_input = {'data': np.reshape(np.arange(8, dtype=np.float32), (2,2,2))}
+            coreml_preds = coreml_model.predict(coreml_input)['output']
+            
+            #harcoded for this simple test case
+            numpy_preds = np.reshape(np.arange(8) - np.array([1.5,1.5,1.5,1.5,5.5,5.5,5.5,5.5]),(2,2,2))
+            self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
+            self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
         
         if os.path.exists(model_dir):
             shutil.rmtree(model_dir)  
@@ -281,13 +294,14 @@ class SimpleTest(CorrectnessTest):
         
         #preprare input and get predictions
         coreml_model = coremltools.models.MLModel(model_path)
-        coreml_input = {'data': np.reshape(np.arange(4, dtype=np.float32), (1,2,2))}
-        coreml_preds = coreml_model.predict(coreml_input)['output']
-        
-        #harcoded for this simple test case
-        numpy_preds = np.reshape(np.arange(4, dtype=np.float32), (1,2,2))/np.sqrt(14)
-        self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
-        self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
+        if macos_version() >= (10, 13):
+            coreml_input = {'data': np.reshape(np.arange(4, dtype=np.float32), (1,2,2))}
+            coreml_preds = coreml_model.predict(coreml_input)['output']
+            
+            #harcoded for this simple test case
+            numpy_preds = np.reshape(np.arange(4, dtype=np.float32), (1,2,2))/np.sqrt(14)
+            self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
+            self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
         
         if os.path.exists(model_dir):
             shutil.rmtree(model_dir)    
@@ -297,44 +311,52 @@ class SimpleTest(CorrectnessTest):
         x = np.reshape(np.arange(1,5, dtype=np.float32), (1,2,2))
         
         coreml_preds = get_coreml_predictions_unary(x, 'sqrt')
-        numpy_preds = np.sqrt(x)
-        self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
-        self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds)) 
+        if coreml_preds is not None:
+            numpy_preds = np.sqrt(x)
+            self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
+            self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds)) 
         
         coreml_preds = get_coreml_predictions_unary(x, 'rsqrt')
-        numpy_preds = 1/np.sqrt(x)
-        self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
-        self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
+        if coreml_preds is not None:
+            numpy_preds = 1/np.sqrt(x)
+            self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
+            self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
         
         coreml_preds = get_coreml_predictions_unary(x, 'inverse')
-        numpy_preds = 1/x
-        self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
-        self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
+        if coreml_preds is not None:
+            numpy_preds = 1/x
+            self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
+            self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
         
         coreml_preds = get_coreml_predictions_unary(x, 'power', 3)
-        numpy_preds = x ** 3
-        self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
-        self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
+        if coreml_preds is not None:
+            numpy_preds = x ** 3
+            self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
+            self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
         
         coreml_preds = get_coreml_predictions_unary(x, 'exp')
-        numpy_preds = np.exp(x)
-        self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
-        self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))   
+        if coreml_preds is not None:
+            numpy_preds = np.exp(x)
+            self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
+            self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))   
         
         coreml_preds = get_coreml_predictions_unary(x, 'log')
-        numpy_preds = np.log(x)
-        self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
-        self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds)) 
+        if coreml_preds is not None:
+            numpy_preds = np.log(x)
+            self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
+            self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds)) 
                                                       
         coreml_preds = get_coreml_predictions_unary(x, 'abs')
-        numpy_preds = np.abs(x)
-        self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
-        self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))   
+        if coreml_preds is not None:
+            numpy_preds = np.abs(x)
+            self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
+            self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))   
         
         coreml_preds = get_coreml_predictions_unary(x, 'threshold', alpha = 2)
-        numpy_preds = np.maximum(x, 2)
-        self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
-        self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds)) 
+        if coreml_preds is not None:
+            numpy_preds = np.maximum(x, 2)
+            self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
+            self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds)) 
         
     def test_split(self):
         
@@ -361,14 +383,15 @@ class SimpleTest(CorrectnessTest):
         
         #preprare input and get predictions
         coreml_model = coremltools.models.MLModel(model_path)
-        coreml_input = {'data': x}
-        coreml_preds_dict = coreml_model.predict(coreml_input)
-        
-        for i in range(3):
-            coreml_preds = coreml_preds_dict[output_names[i]]
-            numpy_preds = x[i*3:i*3+3,:,:]
-            self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
-            self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
+        if macos_version() >= (10, 13):
+            coreml_input = {'data': x}
+            coreml_preds_dict = coreml_model.predict(coreml_input)
+            
+            for i in range(3):
+                coreml_preds = coreml_preds_dict[output_names[i]]
+                numpy_preds = x[i*3:i*3+3,:,:]
+                self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
+                self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
         
         if os.path.exists(model_dir):
             shutil.rmtree(model_dir)   
@@ -391,14 +414,15 @@ class SimpleTest(CorrectnessTest):
         
         #preprare input and get predictions
         coreml_model = coremltools.models.MLModel(model_path)
-        x = np.reshape(np.arange(4, dtype=np.float32), (1,2,2))
-        coreml_input = {'data': x}
-        coreml_preds = coreml_model.predict(coreml_input)['output']
-        
-        #harcoded for this simple test case
-        numpy_preds = 5 * x + 45
-        self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
-        self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
+        if macos_version() >= (10, 13):
+            x = np.reshape(np.arange(4, dtype=np.float32), (1,2,2))
+            coreml_input = {'data': x}
+            coreml_preds = coreml_model.predict(coreml_input)['output']
+            
+            #harcoded for this simple test case
+            numpy_preds = 5 * x + 45
+            self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
+            self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
         
         if os.path.exists(model_dir):
             shutil.rmtree(model_dir)
@@ -424,14 +448,15 @@ class SimpleTest(CorrectnessTest):
         
         #preprare input and get predictions
         coreml_model = coremltools.models.MLModel(model_path)
-        x = np.reshape(np.arange(4, dtype=np.float32), (1,2,2))
-        coreml_input = {'data': x}
-        coreml_preds = coreml_model.predict(coreml_input)['output']
-        
-        #harcoded for this simple test case
-        numpy_preds = W * x
-        self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
-        self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
+        if macos_version() >= (10, 13):
+            x = np.reshape(np.arange(4, dtype=np.float32), (1,2,2))
+            coreml_input = {'data': x}
+            coreml_preds = coreml_model.predict(coreml_input)['output']
+            
+            #harcoded for this simple test case
+            numpy_preds = W * x
+            self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
+            self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
         
         if os.path.exists(model_dir):
             shutil.rmtree(model_dir)            
@@ -454,14 +479,15 @@ class SimpleTest(CorrectnessTest):
         
         #preprare input and get predictions
         coreml_model = coremltools.models.MLModel(model_path)
-        x = np.reshape(np.arange(4, dtype=np.float32), (1,2,2))
-        coreml_input = {'data': x}
-        coreml_preds = coreml_model.predict(coreml_input)['output']
-        
-        #harcoded for this simple test case
-        numpy_preds = x + 45
-        self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
-        self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
+        if macos_version() >= (10, 13):
+            x = np.reshape(np.arange(4, dtype=np.float32), (1,2,2))
+            coreml_input = {'data': x}
+            coreml_preds = coreml_model.predict(coreml_input)['output']
+            
+            #harcoded for this simple test case
+            numpy_preds = x + 45
+            self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
+            self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
         
         if os.path.exists(model_dir):
             shutil.rmtree(model_dir)
@@ -487,14 +513,15 @@ class SimpleTest(CorrectnessTest):
         
         #preprare input and get predictions
         coreml_model = coremltools.models.MLModel(model_path)
-        x = np.reshape(np.arange(4, dtype=np.float32), (1,2,2))
-        coreml_input = {'data': x}
-        coreml_preds = coreml_model.predict(coreml_input)['output']
-        
-        #harcoded for this simple test case
-        numpy_preds = x + b
-        self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
-        self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
+        if macos_version() >= (10, 13):
+            x = np.reshape(np.arange(4, dtype=np.float32), (1,2,2))
+            coreml_input = {'data': x}
+            coreml_preds = coreml_model.predict(coreml_input)['output']
+            
+            #harcoded for this simple test case
+            numpy_preds = x + b
+            self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
+            self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
         
         if os.path.exists(model_dir):
             shutil.rmtree(model_dir)   
@@ -520,14 +547,15 @@ class SimpleTest(CorrectnessTest):
         
         #preprare input and get predictions
         coreml_model = coremltools.models.MLModel(model_path)
-        x = np.reshape(np.arange(4, dtype=np.float32), (1,2,2))
-        coreml_input = {'data': x}
-        coreml_preds = coreml_model.predict(coreml_input)['output']
-        
-        #harcoded for this simple test case
-        numpy_preds = x + b
-        self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
-        self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
+        if macos_version() >= (10, 13):
+            x = np.reshape(np.arange(4, dtype=np.float32), (1,2,2))
+            coreml_input = {'data': x}
+            coreml_preds = coreml_model.predict(coreml_input)['output']
+            
+            #harcoded for this simple test case
+            numpy_preds = x + b
+            self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
+            self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
         
         if os.path.exists(model_dir):
             shutil.rmtree(model_dir)    
@@ -550,15 +578,16 @@ class SimpleTest(CorrectnessTest):
         
         #preprare input and get predictions
         coreml_model = coremltools.models.MLModel(model_path)
-        x1 = np.reshape(np.arange(4, dtype=np.float32), (1,2,2))
-        x2 = np.reshape(np.arange(2,6, dtype=np.float32), (1,2,2))
-        coreml_input = {'data_0': x1, 'data_1': x2}
-        coreml_preds = coreml_model.predict(coreml_input)['output']
-        
-        #harcoded for this simple test case
-        numpy_preds = np.minimum(x1,x2)
-        self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
-        self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
+        if macos_version() >= (10, 13):
+            x1 = np.reshape(np.arange(4, dtype=np.float32), (1,2,2))
+            x2 = np.reshape(np.arange(2,6, dtype=np.float32), (1,2,2))
+            coreml_input = {'data_0': x1, 'data_1': x2}
+            coreml_preds = coreml_model.predict(coreml_input)['output']
+            
+            #harcoded for this simple test case
+            numpy_preds = np.minimum(x1,x2)
+            self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
+            self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
         
         if os.path.exists(model_dir):
             shutil.rmtree(model_dir)     
@@ -588,13 +617,14 @@ class SimpleTest(CorrectnessTest):
         
         #preprare input and get predictions
         coreml_model = coremltools.models.MLModel(model_path)
-        x = np.random.rand(*input_dim)
-        coreml_input = {'data': x}
-        coreml_preds = coreml_model.predict(coreml_input)['output']
-        
-        #harcoded for this simple test case
-        numpy_preds = np.random.rand(20,8,8)
-        self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
+        if macos_version() >= (10, 13):
+            x = np.random.rand(*input_dim)
+            coreml_input = {'data': x}
+            coreml_preds = coreml_model.predict(coreml_input)['output']
+            
+            #harcoded for this simple test case
+            numpy_preds = np.random.rand(20,8,8)
+            self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
         
         if os.path.exists(model_dir):
             shutil.rmtree(model_dir)
@@ -625,13 +655,14 @@ class SimpleTest(CorrectnessTest):
         
         #preprare input and get predictions
         coreml_model = coremltools.models.MLModel(model_path)
-        x = np.random.rand(*input_dim)
-        coreml_input = {'data': x}
-        coreml_preds = coreml_model.predict(coreml_input)['output']
-        
-        #harcoded for this simple test case
-        numpy_preds = np.random.rand(20,26,26)
-        self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
+        if macos_version() >= (10, 13):
+            x = np.random.rand(*input_dim)
+            coreml_input = {'data': x}
+            coreml_preds = coreml_model.predict(coreml_input)['output']
+            
+            #harcoded for this simple test case
+            numpy_preds = np.random.rand(20,26,26)
+            self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
         
         if os.path.exists(model_dir):
             shutil.rmtree(model_dir)   
@@ -658,14 +689,15 @@ class SimpleTest(CorrectnessTest):
         
         #preprare input and get predictions
         coreml_model = coremltools.models.MLModel(model_path)
-        x = np.random.rand(*input_dim)
-        coreml_input = {'data': x}
-        coreml_preds = coreml_model.predict(coreml_input)['output']
-        
-        #harcoded for this simple test case
-        numpy_preds = 34.0 * x + 67.0
-        self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
-        self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
+        if macos_version() >= (10, 13):
+            x = np.random.rand(*input_dim)
+            coreml_input = {'data': x}
+            coreml_preds = coreml_model.predict(coreml_input)['output']
+            
+            #harcoded for this simple test case
+            numpy_preds = 34.0 * x + 67.0
+            self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
+            self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
         
         if os.path.exists(model_dir):
             shutil.rmtree(model_dir)
@@ -693,14 +725,15 @@ class SimpleTest(CorrectnessTest):
         
         #preprare input and get predictions
         coreml_model = coremltools.models.MLModel(model_path)
-        x = np.reshape(np.array([[1,2,3], [4,5,6]]), (1,2,3)).astype(np.float32)
-        coreml_input = {'data': x}
-        coreml_preds = coreml_model.predict(coreml_input)['output']
-        
-        #harcoded for this simple test case
-        numpy_preds = np.reshape(np.array([[-1,-1,-1,-1], [-1,-1,-1,-1], [-1,1,2,3], [-1,4,5,6]]), (1,4,4)).astype(np.float32)
-        self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
-        self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
+        if macos_version() >= (10, 13):
+            x = np.reshape(np.array([[1,2,3], [4,5,6]]), (1,2,3)).astype(np.float32)
+            coreml_input = {'data': x}
+            coreml_preds = coreml_model.predict(coreml_input)['output']
+            
+            #harcoded for this simple test case
+            numpy_preds = np.reshape(np.array([[-1,-1,-1,-1], [-1,-1,-1,-1], [-1,1,2,3], [-1,4,5,6]]), (1,4,4)).astype(np.float32)
+            self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
+            self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
         
         if os.path.exists(model_dir):
             shutil.rmtree(model_dir)     
@@ -727,14 +760,15 @@ class SimpleTest(CorrectnessTest):
         
         #preprare input and get predictions
         coreml_model = coremltools.models.MLModel(model_path)
-        x = np.reshape(np.array([[1,2,3], [4,5,6]]), (1,2,3)).astype(np.float32)
-        coreml_input = {'data': x}
-        coreml_preds = coreml_model.predict(coreml_input)['output']
-        
-        #harcoded for this simple test case
-        numpy_preds = np.reshape(np.array([[1,1,2,3], [1,1,2,3], [1,1,2,3], [4,4,5,6]]), (1,4,4)).astype(np.float32)
-        self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
-        self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
+        if macos_version() >= (10, 13):
+            x = np.reshape(np.array([[1,2,3], [4,5,6]]), (1,2,3)).astype(np.float32)
+            coreml_input = {'data': x}
+            coreml_preds = coreml_model.predict(coreml_input)['output']
+            
+            #harcoded for this simple test case
+            numpy_preds = np.reshape(np.array([[1,1,2,3], [1,1,2,3], [1,1,2,3], [4,4,5,6]]), (1,4,4)).astype(np.float32)
+            self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
+            self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
         
         if os.path.exists(model_dir):
             shutil.rmtree(model_dir)
@@ -758,14 +792,15 @@ class SimpleTest(CorrectnessTest):
         
         #preprare input and get predictions
         coreml_model = coremltools.models.MLModel(model_path)
-        x = np.random.rand(*input_dim)
-        coreml_input = {'data': x}
-        coreml_preds = coreml_model.predict(coreml_input)['output']
-        
-        #harcoded for this simple test case
-        numpy_preds = np.reshape(x, (10,1,1))
-        self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
-        self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
+        if macos_version() >= (10, 13):
+            x = np.random.rand(*input_dim)
+            coreml_input = {'data': x}
+            coreml_preds = coreml_model.predict(coreml_input)['output']
+            
+            #harcoded for this simple test case
+            numpy_preds = np.reshape(x, (10,1,1))
+            self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
+            self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
         
         if os.path.exists(model_dir):
             shutil.rmtree(model_dir) 
@@ -788,14 +823,15 @@ class SimpleTest(CorrectnessTest):
         
         #preprare input and get predictions
         coreml_model = coremltools.models.MLModel(model_path)
-        x = np.random.rand(*input_dim)
-        coreml_input = {'data': x}
-        coreml_preds = coreml_model.predict(coreml_input)['output']
-        
-        #harcoded for this simple test case
-        numpy_preds = np.reshape(x, (1,10,1,1))
-        self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
-        self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
+        if macos_version() >= (10, 13):
+            x = np.random.rand(*input_dim)
+            coreml_input = {'data': x}
+            coreml_preds = coreml_model.predict(coreml_input)['output']
+            
+            #harcoded for this simple test case
+            numpy_preds = np.reshape(x, (1,10,1,1))
+            self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
+            self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
         
         if os.path.exists(model_dir):
             shutil.rmtree(model_dir)           
@@ -824,14 +860,15 @@ class SimpleTestCPUOnly(CorrectnessTest):
         
         #preprare input and get predictions
         coreml_model = coremltools.models.MLModel(model_path)
-        x = np.reshape(np.arange(4, dtype=np.float32), (1,2,2))
-        coreml_input = {'data': x}
-        coreml_preds = coreml_model.predict(coreml_input, useCPUOnly = True)['output']
-        
-        #harcoded for this simple test case
-        numpy_preds = x + b
-        self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
-        self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
+        if macos_version() >= (10, 13):
+            x = np.reshape(np.arange(4, dtype=np.float32), (1,2,2))
+            coreml_input = {'data': x}
+            coreml_preds = coreml_model.predict(coreml_input, useCPUOnly = True)['output']
+            
+            #harcoded for this simple test case
+            numpy_preds = x + b
+            self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
+            self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
         
         if os.path.exists(model_dir):
             shutil.rmtree(model_dir)
@@ -858,14 +895,15 @@ class SimpleTestCPUOnly(CorrectnessTest):
         
         #preprare input and get predictions
         coreml_model = coremltools.models.MLModel(model_path)
-        x = np.random.rand(*input_dim)
-        coreml_input = {'data': x}
-        coreml_preds = coreml_model.predict(coreml_input, useCPUOnly = True)['output']
+        if macos_version() >= (10, 13):
+            x = np.random.rand(*input_dim)
+            coreml_input = {'data': x}
+            coreml_preds = coreml_model.predict(coreml_input, useCPUOnly = True)['output']
         
-        #harcoded for this simple test case
-        numpy_preds = 34.0 * x + 67.0
-        self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
-        self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
+            #harcoded for this simple test case
+            numpy_preds = 34.0 * x + 67.0
+            self.assertTrue(self._compare_shapes(numpy_preds, coreml_preds))
+            self.assertTrue(self._compare_predictions(numpy_preds, coreml_preds))
         
         if os.path.exists(model_dir):
             shutil.rmtree(model_dir)        
@@ -908,7 +946,7 @@ class StressTest(CorrectnessTest):
             coreml_preds, eval = get_coreml_predictions_slice(X, params)
             if eval is False:
                 failed_tests_compile.append(params)
-            else:
+            elif coreml_preds is not None:
                 if not self._compare_shapes(np_preds, coreml_preds):    
                     failed_tests_shape.append(params)
                 elif not self._compare_predictions(np_preds, coreml_preds):
@@ -958,7 +996,7 @@ class StressTest(CorrectnessTest):
             coreml_preds, eval = get_coreml_predictions_reduce(X, params)
             if eval is False:
                 failed_tests_compile.append(params)
-            else:
+            elif coreml_preds is not None:
                 if not self._compare_shapes(np_preds, coreml_preds):    
                     failed_tests_shape.append(params)
                 elif not self._compare_predictions(np_preds, coreml_preds):
@@ -967,7 +1005,3 @@ class StressTest(CorrectnessTest):
         self.assertEqual(failed_tests_compile,[])
         self.assertEqual(failed_tests_shape, [])
         self.assertEqual(failed_tests_numerical,[])    
-            
-            
-            
-            

--- a/coremltools/test/test_one_hot_encoder.py
+++ b/coremltools/test/test_one_hot_encoder.py
@@ -8,7 +8,7 @@ import unittest
 import numpy as np
 
 from coremltools._deps import HAS_SKLEARN
-from coremltools.models.utils import evaluate_transformer
+from coremltools.models.utils import evaluate_transformer, macos_version
 
 
 if HAS_SKLEARN:
@@ -47,39 +47,42 @@ class OneHotEncoderScikitTest(unittest.TestCase):
         scikit_model.fit(self.scikit_data)
         spec = sklearn.convert(scikit_model, 'single_feature', 'out').get_spec()
 
-        test_data = [{'single_feature' : row} for row in self.scikit_data]
-        scikit_output = [{'out' : row} for row in scikit_model.transform(self.scikit_data).toarray()]
-        metrics = evaluate_transformer(spec, test_data, scikit_output)
+        if macos_version() >= (10, 13):
+            test_data = [{'single_feature' : row} for row in self.scikit_data]
+            scikit_output = [{'out' : row} for row in scikit_model.transform(self.scikit_data).toarray()]
+            metrics = evaluate_transformer(spec, test_data, scikit_output)
 
-        self.assertIsNotNone(spec)
-        self.assertIsNotNone(spec.description)
-        self.assertEquals(metrics['num_errors'], 0)
+            self.assertIsNotNone(spec)
+            self.assertIsNotNone(spec.description)
+            self.assertEquals(metrics['num_errors'], 0)
 
     def test_conversion_many_columns(self):
         scikit_model = OneHotEncoder()
         scikit_model.fit(self.scikit_data_multiple_cols)
         spec = sklearn.convert(scikit_model, ['feature_1', 'feature_2'], 'out').get_spec()
 
-        test_data = [{'feature_1': row[0], 'feature_2': row[1]} for row in self.scikit_data_multiple_cols]
-        scikit_output = [{'out': row} for row in scikit_model.transform(self.scikit_data_multiple_cols).toarray()]
-        metrics = evaluate_transformer(spec, test_data, scikit_output)
+        if macos_version() >= (10, 13):
+            test_data = [{'feature_1': row[0], 'feature_2': row[1]} for row in self.scikit_data_multiple_cols]
+            scikit_output = [{'out': row} for row in scikit_model.transform(self.scikit_data_multiple_cols).toarray()]
+            metrics = evaluate_transformer(spec, test_data, scikit_output)
 
-        self.assertIsNotNone(spec)
-        self.assertIsNotNone(spec.description)
-        self.assertEquals(metrics['num_errors'], 0)
+            self.assertIsNotNone(spec)
+            self.assertIsNotNone(spec.description)
+            self.assertEquals(metrics['num_errors'], 0)
 
     def test_conversion_one_column_of_several(self):
         scikit_model = OneHotEncoder(categorical_features = [0])
         scikit_model.fit(copy(self.scikit_data_multiple_cols))
         spec = sklearn.convert(scikit_model, ['feature_1', 'feature_2'], 'out').get_spec()
 
-        test_data = [{'feature_1': row[0], 'feature_2': row[1]} for row in self.scikit_data_multiple_cols]
-        scikit_output = [{'out': row} for row in scikit_model.transform(self.scikit_data_multiple_cols).toarray()]
-        metrics = evaluate_transformer(spec, test_data, scikit_output)
+        if macos_version() >= (10, 13):
+            test_data = [{'feature_1': row[0], 'feature_2': row[1]} for row in self.scikit_data_multiple_cols]
+            scikit_output = [{'out': row} for row in scikit_model.transform(self.scikit_data_multiple_cols).toarray()]
+            metrics = evaluate_transformer(spec, test_data, scikit_output)
 
-        self.assertIsNotNone(spec)
-        self.assertIsNotNone(spec.description)
-        self.assertEquals(metrics['num_errors'], 0)
+            self.assertIsNotNone(spec)
+            self.assertIsNotNone(spec.description)
+            self.assertEquals(metrics['num_errors'], 0)
 
     def test_boston_OHE(self): 
         data = load_boston()
@@ -95,9 +98,10 @@ class OneHotEncoderScikitTest(unittest.TestCase):
             input_data = [dict(zip(data.feature_names, row)) for row in data.data]
             output_data = [{"out" : row} for row in model.transform(data.data)]
 
-            result = evaluate_transformer(spec, input_data, output_data)
+            if macos_version() >= (10, 13):
+                result = evaluate_transformer(spec, input_data, output_data)
 
-            assert result["num_errors"] == 0
+                assert result["num_errors"] == 0
 
     # This test still isn't working
     def test_boston_OHE_pipeline(self): 
@@ -116,12 +120,13 @@ class OneHotEncoderScikitTest(unittest.TestCase):
             # Convert the model
             spec = sklearn.convert(model, data.feature_names, 'out').get_spec()
 
-            input_data = [dict(zip(data.feature_names, row)) for row in data.data]
-            output_data = [{"out" : row} for row in model.transform(data.data.copy())]
+            if macos_version() >= (10, 13):
+                input_data = [dict(zip(data.feature_names, row)) for row in data.data]
+                output_data = [{"out" : row} for row in model.transform(data.data.copy())]
 
-            result = evaluate_transformer(spec, input_data, output_data)
+                result = evaluate_transformer(spec, input_data, output_data)
 
-            assert result["num_errors"] == 0
+                assert result["num_errors"] == 0
    
     def test_random_sparse_data(self): 
 
@@ -152,16 +157,17 @@ class OneHotEncoderScikitTest(unittest.TestCase):
                     # Convert the model
                     spec = sklearn.convert(model, [('data', Array(n_columns))], 'out')
 
-                    X_out = model.transform(X)
-                    if sparse:
-                        X_out = X_out.todense()
+                    if macos_version() >= (10, 13):
+                        X_out = model.transform(X)
+                        if sparse:
+                            X_out = X_out.todense()
 
-                    input_data = [{'data' : row} for row in X]
-                    output_data = [{"out" : row} for row in X_out]
+                        input_data = [{'data' : row} for row in X]
+                        output_data = [{"out" : row} for row in X_out]
 
-                    result = evaluate_transformer(spec, input_data, output_data)
+                        result = evaluate_transformer(spec, input_data, output_data)
 
-                    assert result["num_errors"] == 0
+                        assert result["num_errors"] == 0
 
             # Test normal data inside a pipeline
             for sparse in (True, False): 
@@ -176,16 +182,17 @@ class OneHotEncoderScikitTest(unittest.TestCase):
                     # Convert the model
                     spec = sklearn.convert(model, [('data', Array(n_columns))], 'out').get_spec()
                     
-                    X_out = model.transform(X)
-                    if sparse:
-                        X_out = X_out.todense()
+                    if macos_version() >= (10, 13):
+                        X_out = model.transform(X)
+                        if sparse:
+                            X_out = X_out.todense()
 
-                    input_data = [{'data' : row} for row in X]
-                    output_data = [{"out" : row} for row in X_out]
+                        input_data = [{'data' : row} for row in X]
+                        output_data = [{"out" : row} for row in X_out]
 
-                    result = evaluate_transformer(spec, input_data, output_data)
+                        result = evaluate_transformer(spec, input_data, output_data)
 
-                    assert result["num_errors"] == 0
+                        assert result["num_errors"] == 0
 
     def test_conversion_bad_inputs(self):
         # Error on converting an untrained model

--- a/coremltools/test/test_simple_recurrent_single_layer.py
+++ b/coremltools/test/test_simple_recurrent_single_layer.py
@@ -11,6 +11,7 @@ import tempfile
 import itertools
 import coremltools
 from coremltools._deps import HAS_KERAS_TF
+from coremltools.models.utils import macos_version
 import pytest
 
 
@@ -105,25 +106,26 @@ class SimpleRNNLayer(RecurrentLayerTest):
                 coreml_model_path = os.path.join(model_dir, 'keras.mlmodel')
                 model.save_weights(keras_model_path)
                 mlkitmodel = _get_mlkit_model_from_path(model, coreml_model_path)
-                keras_preds = model.predict(input_data).flatten()
-                input_data = np.transpose(input_data, [1, 0, 2])
-                coreml_preds = mlkitmodel.predict({'data': input_data})['output'].flatten()
-                try:
-                    self.assertEquals(coreml_preds.shape, keras_preds.shape)
-                except AssertionError:
-                    print("Shape error:\nbase_params: {}\nkeras_preds.shape: {}\ncoreml_preds.shape: {}".format(
-                        base_params, keras_preds.shape, coreml_preds.shape))
-                    shape_err_models.append(base_params)
-                    shutil.rmtree(model_dir)
-                    i += 1
-                    continue
-                try:
-                    for idx in range(0, len(coreml_preds)):
-                        relative_error = (coreml_preds[idx] - keras_preds[idx]) / coreml_preds[idx]
-                        self.assertAlmostEqual(relative_error, 0, places=2)
-                except AssertionError:
-                    print("Assertion error:\nbase_params: {}\nkeras_preds: {}\ncoreml_preds: {}".format(base_params, keras_preds, coreml_preds))
-                    numerical_err_models.append(base_params)
+                if macos_version() >= (10, 13):
+                    keras_preds = model.predict(input_data).flatten()
+                    input_data = np.transpose(input_data, [1, 0, 2])
+                    coreml_preds = mlkitmodel.predict({'data': input_data})['output'].flatten()
+                    try:
+                        self.assertEquals(coreml_preds.shape, keras_preds.shape)
+                    except AssertionError:
+                        print("Shape error:\nbase_params: {}\nkeras_preds.shape: {}\ncoreml_preds.shape: {}".format(
+                            base_params, keras_preds.shape, coreml_preds.shape))
+                        shape_err_models.append(base_params)
+                        shutil.rmtree(model_dir)
+                        i += 1
+                        continue
+                    try:
+                        for idx in range(0, len(coreml_preds)):
+                            relative_error = (coreml_preds[idx] - keras_preds[idx]) / coreml_preds[idx]
+                            self.assertAlmostEqual(relative_error, 0, places=2)
+                    except AssertionError:
+                        print("Assertion error:\nbase_params: {}\nkeras_preds: {}\ncoreml_preds: {}".format(base_params, keras_preds, coreml_preds))
+                        numerical_err_models.append(base_params)
                 shutil.rmtree(model_dir)
                 i += 1
 
@@ -190,27 +192,28 @@ class LSTMLayer(RecurrentLayerTest):
                 coreml_model_path = os.path.join(model_dir, 'keras.mlmodel')
                 model.save_weights(keras_model_path)
                 mlkitmodel = _get_mlkit_model_from_path(model, coreml_model_path)
-                keras_preds = model.predict(input_data).flatten()
-                input_data = np.transpose(input_data, [1, 0, 2])
-                coreml_preds = mlkitmodel.predict({'data': input_data})['output'].flatten()
-                try:
-                    self.assertEquals(coreml_preds.shape, keras_preds.shape)
-                except AssertionError:
-                    print("Shape error:\nbase_params: {}\nkeras_preds.shape: {}\ncoreml_preds.shape: {}".format(
-                        base_params, keras_preds.shape, coreml_preds.shape))
-                    shape_err_models.append(base_params)
-                    shutil.rmtree(model_dir)
-                    i += 1
-                    continue
-                try:
-                    for idx in range(0, len(coreml_preds)):
-                        relative_error = (coreml_preds[idx] - keras_preds[idx]) / coreml_preds[idx]
-                        self.assertAlmostEqual(relative_error, 0, places=2)
-                except AssertionError:
-                    print("Assertion error:\nbase_params: {}\nkeras_preds: {}\ncoreml_preds: {}".format(base_params,
-                                                                                                        keras_preds,
-                                                                                                        coreml_preds))
-                    numerical_err_models.append(base_params)
+                if macos_version() >= (10, 13):
+                    keras_preds = model.predict(input_data).flatten()
+                    input_data = np.transpose(input_data, [1, 0, 2])
+                    coreml_preds = mlkitmodel.predict({'data': input_data})['output'].flatten()
+                    try:
+                        self.assertEquals(coreml_preds.shape, keras_preds.shape)
+                    except AssertionError:
+                        print("Shape error:\nbase_params: {}\nkeras_preds.shape: {}\ncoreml_preds.shape: {}".format(
+                            base_params, keras_preds.shape, coreml_preds.shape))
+                        shape_err_models.append(base_params)
+                        shutil.rmtree(model_dir)
+                        i += 1
+                        continue
+                    try:
+                        for idx in range(0, len(coreml_preds)):
+                            relative_error = (coreml_preds[idx] - keras_preds[idx]) / coreml_preds[idx]
+                            self.assertAlmostEqual(relative_error, 0, places=2)
+                    except AssertionError:
+                        print("Assertion error:\nbase_params: {}\nkeras_preds: {}\ncoreml_preds: {}".format(base_params,
+                                                                                                            keras_preds,
+                                                                                                            coreml_preds))
+                        numerical_err_models.append(base_params)
                 shutil.rmtree(model_dir)
                 i += 1
 
@@ -271,27 +274,28 @@ class GRULayer(RecurrentLayerTest):
                 coreml_model_path = os.path.join(model_dir, 'keras.mlmodel')
                 model.save_weights(keras_model_path)
                 mlkitmodel = _get_mlkit_model_from_path(model, coreml_model_path)
-                keras_preds = model.predict(input_data).flatten()
-                input_data = np.transpose(input_data, [1, 0, 2])
-                coreml_preds = mlkitmodel.predict({'data': input_data})['output'].flatten()
-                try:
-                    self.assertEquals(coreml_preds.shape, keras_preds.shape)
-                except AssertionError:
-                    print("Shape error:\nbase_params: {}\nkeras_preds.shape: {}\ncoreml_preds.shape: {}".format(
-                        base_params, keras_preds.shape, coreml_preds.shape))
-                    shape_err_models.append(base_params)
-                    shutil.rmtree(model_dir)
-                    i += 1
-                    continue
-                try:
-                    for idx in range(0, len(coreml_preds)):
-                        relative_error = (coreml_preds[idx] - keras_preds[idx]) / coreml_preds[idx]
-                        self.assertAlmostEqual(relative_error, 0, places=2)
-                except AssertionError:
-                    print("Assertion error:\nbase_params: {}\nkeras_preds: {}\ncoreml_preds: {}".format(base_params,
-                                                                                                        keras_preds,
-                                                                                                        coreml_preds))
-                    numerical_err_models.append(base_params)
+                if macos_version() >= (10, 13):
+                    keras_preds = model.predict(input_data).flatten()
+                    input_data = np.transpose(input_data, [1, 0, 2])
+                    coreml_preds = mlkitmodel.predict({'data': input_data})['output'].flatten()
+                    try:
+                        self.assertEquals(coreml_preds.shape, keras_preds.shape)
+                    except AssertionError:
+                        print("Shape error:\nbase_params: {}\nkeras_preds.shape: {}\ncoreml_preds.shape: {}".format(
+                            base_params, keras_preds.shape, coreml_preds.shape))
+                        shape_err_models.append(base_params)
+                        shutil.rmtree(model_dir)
+                        i += 1
+                        continue
+                    try:
+                        for idx in range(0, len(coreml_preds)):
+                            relative_error = (coreml_preds[idx] - keras_preds[idx]) / coreml_preds[idx]
+                            self.assertAlmostEqual(relative_error, 0, places=2)
+                    except AssertionError:
+                        print("Assertion error:\nbase_params: {}\nkeras_preds: {}\ncoreml_preds: {}".format(base_params,
+                                                                                                            keras_preds,
+                                                                                                            coreml_preds))
+                        numerical_err_models.append(base_params)
                 shutil.rmtree(model_dir)
                 i += 1
 

--- a/coremltools/test/test_standard_scalar.py
+++ b/coremltools/test/test_standard_scalar.py
@@ -7,7 +7,7 @@ import unittest
 import numpy as _np
 from coremltools._deps import HAS_SKLEARN
 
-from coremltools.models.utils import evaluate_transformer
+from coremltools.models.utils import evaluate_transformer, macos_version
 
 if HAS_SKLEARN:
     from sklearn.preprocessing import StandardScaler
@@ -29,11 +29,12 @@ class StandardScalerTestCase(unittest.TestCase):
 
         spec = converter.convert(cur_model, ["a", 'b', 'c'], 'out').get_spec()
 
-        metrics = evaluate_transformer(spec, 
-                [dict(zip(["a", "b", "c"], row)) for row in X], 
-                [{"out" : row} for row in output]) 
+        if macos_version() >= (10, 13):
+            metrics = evaluate_transformer(spec, 
+                    [dict(zip(["a", "b", "c"], row)) for row in X], 
+                    [{"out" : row} for row in output]) 
 
-        assert metrics["num_errors"] == 0
+            assert metrics["num_errors"] == 0
 
     def test_boston(self):
         from sklearn.datasets import load_boston
@@ -43,12 +44,12 @@ class StandardScalerTestCase(unittest.TestCase):
 
         spec = converter.convert(scikit_model, scikit_data.feature_names, 'out').get_spec()
 
-        input_data = [dict(zip(scikit_data.feature_names, row)) 
-                for row in scikit_data.data]
+        if macos_version() >= (10, 13):
+            input_data = [dict(zip(scikit_data.feature_names, row)) 
+                    for row in scikit_data.data]
 
-        output_data = [{"out" : row} for row in scikit_model.transform(scikit_data.data)]
+            output_data = [{"out" : row} for row in scikit_model.transform(scikit_data.data)]
 
-        metrics = evaluate_transformer(spec, input_data, output_data)
+            metrics = evaluate_transformer(spec, input_data, output_data)
 
-        assert metrics["num_errors"] == 0
-        
+            assert metrics["num_errors"] == 0

--- a/coremltools/test/test_utils.py
+++ b/coremltools/test/test_utils.py
@@ -1,10 +1,8 @@
 # Copyright (c) 2017, Apple Inc. All rights reserved.
-#
-# Use of this source code is governed by a BSD-3-clause license that can be
-# found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+# # Use of this source code is governed by a BSD-3-clause license that can be # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
 import unittest
-from coremltools.models.utils import rename_feature
+from coremltools.models.utils import rename_feature, macos_version
 from coremltools.models import MLModel
 from coremltools._deps import HAS_SKLEARN
 import pandas as pd
@@ -15,6 +13,7 @@ if HAS_SKLEARN:
     from sklearn.linear_model import LinearRegression
     from sklearn.pipeline import Pipeline
     from coremltools.converters import sklearn as converter
+
 
 @unittest.skipIf(not HAS_SKLEARN, 'Missing scikit-learn. Skipping tests.')
 class PipeLineRenameTests(unittest.TestCase):
@@ -53,6 +52,6 @@ class PipeLineRenameTests(unittest.TestCase):
         renamed_model = MLModel(scikit_spec)
         
         # Check the predictions
-        self.assertEquals(model.predict({'input': sample_data}),
-                          renamed_model.predict({'renamed_input': sample_data}))
-                          
+        if macos_version() >= (10, 13):
+            self.assertEquals(model.predict({'input': sample_data}),
+                              renamed_model.predict({'renamed_input': sample_data}))


### PR DESCRIPTION
This removes the Core ML prediction from the unit tests on unsupported platforms. Instead of skipping the tests altogether, this PR tries to keep the conversion step and just eliminate the predict and asserts. Sometimes it's not entirely clear where to draw the line.

Occasionally I had to refactor a bit to make this easier. For instance, many `_train_convert_evaluate` got turned into `_train_convert_evaluate_assert`, which now includes the assert. That way I could more easily wrap an if statement around the prediction and the assert.

A few times this kind of refactor was not trivially possible, so I had to return `None` on unsupported platforms and then skip the assert if that's the return. In some special cases I decided to skip the whole test instead. Occasionally the clean-up of temporary files had to be moved around.