### PR TITLE
Prepare 0.8 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,12 +13,38 @@ endif()
 add_subdirectory(deps)
 add_subdirectory(mlmodel)
 
-exec_program(python-config
+if("${PYTHON}" STREQUAL "")
+  find_program(PYTHON NAMES python3 python)
+endif()
+if("${PYTHON_MAJOR_VERSION}" STREQUAL "")
+  exec_program(${PYTHON}
+    ARGS "-c 'import sys; print(sys.version_info.major)'"
+    OUTPUT_VARIABLE PYTHON_MAJOR_VERSION)
+endif()
+if("${PYTHON_MINOR_VERSION}" STREQUAL "")
+  exec_program(${PYTHON}
+    ARGS "-c 'import sys; print(sys.version_info.minor)'"
+    OUTPUT_VARIABLE PYTHON_MINOR_VERSION)
+endif()
+if("${PYTHON_VERSION}" STREQUAL "")
+  set(PYTHON_VERSION "${PYTHON_MAJOR_VERSION}.${PYTHON_MINOR_VERSION}")
+endif()
+
+if("${PYTHON_CONFIG}" STREQUAL "")
+  find_program(PYTHON_CONFIG NAMES python3-config python-config)
+endif()
+exec_program(${PYTHON_CONFIG}
   ARGS "--includes"
-  OUTPUT_VARIABLE PYTHON_FLAGS)
-exec_program(python-config
-  ARGS "--libs"
-  OUTPUT_VARIABLE PYTHON_LIBS)
+  OUTPUT_VARIABLE PYTHON_CFLAGS)
+exec_program(${PYTHON_CONFIG}
+  ARGS "--ldflags"
+  OUTPUT_VARIABLE PYTHON_LDFLAGS)
+
+message("Found python at ${PYTHON}")
+message("Found python version ${PYTHON_VERSION}")
+message("Found python-config at ${PYTHON_CONFIG}")
+message("Found python includes ${PYTHON_CFLAGS}")
+message("Found python libs ${PYTHON_LDFLAGS}")
 
 include_directories(
   .
@@ -31,27 +57,28 @@ include_directories(
 
 set(CMAKE_CXX_FLAGS " \
   ${CMAKE_CXX_FLAGS} \
-  ${PYTHON_FLAGS} \
+  ${PYTHON_CFLAGS} \
   --std=c++14 \
 ")
 
 if(APPLE)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fobjc-arc ")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fobjc-arc ")
+  include_directories(/Library/Frameworks/Python.framework/Versions/${PYTHON_VERSION}/lib/python${PYTHON_VERSION}/site-packages/numpy/core/include)
 endif()
 
 set(CMAKE_EXE_LINKER_FLAGS " \
   ${CMAKE_EXE_LINKER_FLAGS} \
-  ${PYTHON_LIBS} \
+  ${PYTHON_LDFLAGS} \
   --std=c++14 \
 ")
 set(CMAKE_MODULE_LINKER_FLAGS " \
   ${CMAKE_MODULE_LINKER_FLAGS} \
-  ${PYTHON_LIBS} \
+  ${PYTHON_LDFLAGS} \
   --std=c++14 \
 ")
 set(CMAKE_SHARED_LINKER_FLAGS " \
   ${CMAKE_SHARED_LINKER_FLAGS} \
-  ${PYTHON_LIBS} \
+  ${PYTHON_LDFLAGS} \
   --std=c++14 \
 ")
 
@@ -107,8 +134,8 @@ if(APPLE)
     TARGET caffeconverter
     POST_BUILD
     COMMAND cp $<TARGET_FILE:caffeconverter> coremltools/libcaffeconverter.so
-    COMMAND install_name_tool coremltools/libcaffeconverter.so -change libpython2.7.dylib @rpath/libpython2.7.dylib
-    COMMAND install_name_tool coremltools/libcaffeconverter.so -change /System/Library/Frameworks/Python.framework/Versions/2.7/Python @rpath/libpython2.7.dylib
+    COMMAND install_name_tool coremltools/libcaffeconverter.so -change libpython${PYTHON_VERSION}.dylib @rpath/libpython${PYTHON_VERSION}.dylib
+    COMMAND install_name_tool coremltools/libcaffeconverter.so -change /System/Library/Frameworks/Python.framework/Versions/${PYTHON_VERSION}/Python @rpath/libpython${PYTHON_VERSION}.dylib
   )
 else()
   add_custom_command(
@@ -140,8 +167,8 @@ if (APPLE AND CORE_VIDEO AND CORE_ML AND FOUNDATION)
     TARGET coremlpython
     POST_BUILD
     COMMAND cp $<TARGET_FILE:coremlpython> coremltools/libcoremlpython.so
-    COMMAND install_name_tool coremltools/libcoremlpython.so -change libpython2.7.dylib @rpath/libpython2.7.dylib
-    COMMAND install_name_tool coremltools/libcoremlpython.so -change /System/Library/Frameworks/Python.framework/Versions/2.7/Python @rpath/libpython2.7.dylib
+    COMMAND install_name_tool coremltools/libcoremlpython.so -change libpython${PYTHON_VERSION}.dylib @rpath/libpython${PYTHON_VERSION}.dylib
+    COMMAND install_name_tool coremltools/libcoremlpython.so -change /System/Library/Frameworks/Python.framework/Versions/${PYTHON_VERSION}/Python @rpath/libpython${PYTHON_VERSION}.dylib
   )
 else()
   message(STATUS "CoreML.framework and dependent frameworks not found. Skipping libcoremlpython build.")
@@ -149,10 +176,10 @@ endif()
 
 if(APPLE)
   set(PLAT_NAME "macosx_10_13_intel;macosx_10_12_intel")
-  set(PYTHON_TAG "cp27")
+  set(PYTHON_TAG "cp${PYTHON_MAJOR_VERSION}${PYTHON_MINOR_VERSION}")
 elseif("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
   set(PLAT_NAME "manylinux1_x86_64")
-  set(PYTHON_TAG "py2.7")
+  set(PYTHON_TAG "py${PYTHON_VERSION}")
 else()
   message(FATAL_ERROR "Unsupported build platform. Supported platforms are Linux and macOS.")
 endif()
@@ -160,7 +187,7 @@ endif()
 add_custom_target(dist
   # Workaround for building multiple platform versions since python setuptools only take in one platform via '--plat-name' argument
   # and cmake 'foreach' does not seem to work inside add_custom_target
-  COMMAND for SUPP_PLATFORM in ${PLAT_NAME}$<SEMICOLON> do python setup.py bdist_wheel --plat-name=$$SUPP_PLATFORM --python-tag=${PYTHON_TAG}$<SEMICOLON> done$<SEMICOLON>
+  COMMAND for SUPP_PLATFORM in ${PLAT_NAME}$<SEMICOLON> do ${PYTHON} setup.py bdist_wheel --plat-name=$$SUPP_PLATFORM --python-tag=${PYTHON_TAG}$<SEMICOLON> done$<SEMICOLON>
   DEPENDS caffeconverter coremlpython
   COMMENT "Building Python wheel for coremltools under dist/"
   )

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Dependencies
 In addition, it has the following soft dependencies that are only needed when
 you are converting models of these formats:
 
-- Keras (1.2.2, 2.0.4+) with Tensorflow (1.0.x, 1.1.x)
+- Keras (1.2.2, 2.0.4+) with corresponding Tensorflow version
 - Xgboost (0.7+)
 - scikit-learn (0.17+)
 - libSVM

--- a/README.rst
+++ b/README.rst
@@ -42,9 +42,9 @@ Dependencies
 In addition, it has the following soft dependencies that are only needed when
 you are converting models of these formats:
 
-- Keras (1.2.2, 2.0.4+) with Tensorflow (1.0.x, 1.1.x)
-- Xgboost (0.6+)
-- scikit-learn (0.15+)
+- Keras (1.2.2, 2.0.4+) with corresponding Tensorflow version
+- Xgboost (0.7+)
+- scikit-learn (0.17+)
 - libSVM
 
 More Information
@@ -56,7 +56,7 @@ More Information
 
 License
 -------
-Copyright (c) 2017, Apple Inc. All rights reserved.
+Copyright (c) 2018, Apple Inc. All rights reserved.
 
 Use of this source code is governed by the 
 `3-Clause BSD License <https://opensource.org/licenses/BSD-3-Clause>`_

--- a/coremltools/_deps/__init__.py
+++ b/coremltools/_deps/__init__.py
@@ -20,7 +20,7 @@ def __get_version(version):
 # ---------------------------------------------------------------------------------------
 HAS_SKLEARN = True
 SKLEARN_VERSION = None
-SKLEARN_MIN_VERSION = '0.15'
+SKLEARN_MIN_VERSION = '0.17'
 def __get_sklearn_version(version):
     # matching 0.15b, 0.16bf, etc
     version_regex = '^\d+\.\d+'
@@ -56,9 +56,9 @@ except:
 HAS_KERAS_TF = True
 HAS_KERAS2_TF = True
 KERAS_MIN_VERSION = '1.2.2'
-KERAS_MAX_VERSION = '2.0.6'
+KERAS_MAX_VERSION = '2.1.3'
 TF_MIN_VERSION = '1.0.0'
-TF_MAX_VERSION = '1.2.1'
+TF_MAX_VERSION = '1.5.0'
 
 try:
     # Prevent keras from printing things that are not errors to standard error.

--- a/coremltools/test/test_multiple_images_preprocessing.py
+++ b/coremltools/test/test_multiple_images_preprocessing.py
@@ -22,8 +22,11 @@ if HAS_KERAS2_TF:
     from keras.layers import Activation, GlobalMaxPooling2D, Input
     from coremltools.converters import keras as kerasConverter
 
-nets_path = os.environ["CAFFE_MODELS_PATH"]
-nets_path = nets_path + '/'
+try:
+    nets_path = os.environ["CAFFE_MODELS_PATH"]
+    nets_path = nets_path + '/'
+except:
+    nets_path = None
 
 FOLDER_NAME = 'multiple_images_preprocessing'
 
@@ -61,7 +64,8 @@ def compare_models(caffe_preds, coreml_preds):
     #print('caffe preds : ', caffe_preds)
     #print('coreml preds: ', coreml_preds)
     return max_relative_error 
-    
+
+@unittest.skipIf(nets_path is None, "Unable to find CAFFE_MODELS_PATH")
 class ManyImages(unittest.TestCase):
     """
     Unit test case for caffe layers

--- a/docker/Dockerfile-python2.7-build
+++ b/docker/Dockerfile-python2.7-build
@@ -1,0 +1,85 @@
+# vim: set ft=dockerfile:
+
+# Based on Centos 6 for compatibility with older glibc versions
+FROM centos:centos6
+
+# Update yum and install some standard dev tools and dependencies
+RUN yum -y update
+RUN yum -y install git.x86_64 openssl-devel zlib-devel*
+RUN yum -y groupinstall 'development tools'
+
+# Create a directory for building deps from source code and set up env vars
+WORKDIR /
+RUN mkdir src
+ENV PATH="/usr/local/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
+
+# Install gcc dependencies
+WORKDIR /src
+RUN curl -O https://ftp.gnu.org/gnu/binutils/binutils-2.29.1.tar.gz
+RUN tar xvf binutils-2.29.1.tar.gz
+WORKDIR /src/binutils-2.29.1
+RUN ./configure --prefix=/usr/local
+RUN make -j16
+RUN make install
+
+WORKDIR /src
+RUN curl -O https://gmplib.org/download/gmp/gmp-6.1.2.tar.bz2
+RUN tar xvf gmp-6.1.2.tar.bz2
+WORKDIR /src/gmp-6.1.2
+RUN ./configure --prefix=/usr/local
+RUN make -j16
+RUN make install
+
+WORKDIR /src
+RUN curl -O http://www.mpfr.org/mpfr-current/mpfr-4.0.0.tar.gz
+RUN tar xvf mpfr-4.0.0.tar.gz
+WORKDIR /src/mpfr-4.0.0
+RUN ./configure --prefix=/usr/local
+RUN make -j16
+RUN make install
+
+WORKDIR /src
+RUN curl -O https://ftp.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz
+RUN tar xvf mpc-1.1.0.tar.gz
+WORKDIR /src/mpc-1.1.0
+RUN ./configure --prefix=/usr/local
+RUN make -j16
+RUN make install
+
+# Install gcc 5.5.0 from source
+WORKDIR /src
+RUN curl -O https://ftp.gnu.org/gnu/gcc/gcc-5.5.0/gcc-5.5.0.tar.gz
+RUN tar xvf gcc-5.5.0.tar.gz
+WORKDIR /src/gcc-5.5.0
+RUN ./configure --prefix=/usr/local --with-system-zlib --disable-multilib
+RUN make -j16
+RUN make install
+
+# Install Python 2.7 from source
+WORKDIR /src
+RUN curl -O https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tgz
+RUN tar xvf Python-2.7.13.tgz
+WORKDIR /src/Python-2.7.13
+RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-optimizations
+RUN make -j16
+RUN make install
+
+# Install cmake from binary release
+WORKDIR /opt
+RUN curl -O https://cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.tar.gz
+RUN tar xvf cmake-3.10.2-Linux-x86_64.tar.gz
+ENV PATH="/opt/cmake-3.10.2-Linux-x86_64/bin:${PATH}"
+
+# Set compiler binary paths for CMake to pick up
+ENV CC="/usr/local/bin/gcc"
+ENV CXX="/usr/local/bin/g++"
+
+# Install pip and virtualenv
+WORKDIR /src
+RUN curl -O https://bootstrap.pypa.io/get-pip.py
+RUN python get-pip.py
+RUN pip install virtualenv
+
+# Start at home directory
+WORKDIR /root

--- a/docker/Dockerfile-python2.7-test
+++ b/docker/Dockerfile-python2.7-test
@@ -1,0 +1,84 @@
+# vim: set ft=dockerfile:
+
+FROM centos:centos7
+
+# Update yum and install some standard dev tools and dependencies
+RUN yum -y update
+RUN yum -y install git.x86_64 openssl-devel zlib-devel*
+RUN yum -y groupinstall 'development tools'
+
+# Create a directory for building deps from source code and set up env vars
+WORKDIR /
+RUN mkdir src
+ENV PATH="/usr/local/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
+
+# Install gcc dependencies
+WORKDIR /src
+RUN curl -O https://ftp.gnu.org/gnu/binutils/binutils-2.29.1.tar.gz
+RUN tar xvf binutils-2.29.1.tar.gz
+WORKDIR /src/binutils-2.29.1
+RUN ./configure --prefix=/usr/local
+RUN make -j16
+RUN make install
+
+WORKDIR /src
+RUN curl -O https://gmplib.org/download/gmp/gmp-6.1.2.tar.bz2
+RUN tar xvf gmp-6.1.2.tar.bz2
+WORKDIR /src/gmp-6.1.2
+RUN ./configure --prefix=/usr/local
+RUN make -j16
+RUN make install
+
+WORKDIR /src
+RUN curl -O http://www.mpfr.org/mpfr-current/mpfr-4.0.0.tar.gz
+RUN tar xvf mpfr-4.0.0.tar.gz
+WORKDIR /src/mpfr-4.0.0
+RUN ./configure --prefix=/usr/local
+RUN make -j16
+RUN make install
+
+WORKDIR /src
+RUN curl -O https://ftp.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz
+RUN tar xvf mpc-1.1.0.tar.gz
+WORKDIR /src/mpc-1.1.0
+RUN ./configure --prefix=/usr/local
+RUN make -j16
+RUN make install
+
+# Install gcc 5.5.0 from source
+WORKDIR /src
+RUN curl -O https://ftp.gnu.org/gnu/gcc/gcc-5.5.0/gcc-5.5.0.tar.gz
+RUN tar xvf gcc-5.5.0.tar.gz
+WORKDIR /src/gcc-5.5.0
+RUN ./configure --prefix=/usr/local --with-system-zlib --disable-multilib
+RUN make -j16
+RUN make install
+
+# Install Python 2.7 from source
+WORKDIR /src
+RUN curl -O https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tgz
+RUN tar xvf Python-2.7.13.tgz
+WORKDIR /src/Python-2.7.13
+RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-optimizations
+RUN make -j16
+RUN make install
+
+# Install cmake from binary release
+WORKDIR /opt
+RUN curl -O https://cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.tar.gz
+RUN tar xvf cmake-3.10.2-Linux-x86_64.tar.gz
+ENV PATH="/opt/cmake-3.10.2-Linux-x86_64/bin:${PATH}"
+
+# Set compiler binary paths for CMake to pick up
+ENV CC="/usr/local/bin/gcc"
+ENV CXX="/usr/local/bin/g++"
+
+# Install pip and virtualenv
+WORKDIR /src
+RUN curl -O https://bootstrap.pypa.io/get-pip.py
+RUN python get-pip.py
+RUN pip install virtualenv
+
+# Start at home directory
+WORKDIR /root

--- a/docker/Dockerfile-python3.5-build
+++ b/docker/Dockerfile-python3.5-build
@@ -1,0 +1,85 @@
+# vim: set ft=dockerfile:
+
+# Based on Centos 6 for compatibility with older glibc versions
+FROM centos:centos6
+
+# Update yum and install some standard dev tools and dependencies
+RUN yum -y update
+RUN yum -y install git.x86_64 openssl-devel zlib-devel*
+RUN yum -y groupinstall 'development tools'
+
+# Create a directory for building deps from source code and set up env vars
+WORKDIR /
+RUN mkdir src
+ENV PATH="/usr/local/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
+
+# Install gcc dependencies
+WORKDIR /src
+RUN curl -O https://ftp.gnu.org/gnu/binutils/binutils-2.29.1.tar.gz
+RUN tar xvf binutils-2.29.1.tar.gz
+WORKDIR /src/binutils-2.29.1
+RUN ./configure --prefix=/usr/local
+RUN make -j16
+RUN make install
+
+WORKDIR /src
+RUN curl -O https://gmplib.org/download/gmp/gmp-6.1.2.tar.bz2
+RUN tar xvf gmp-6.1.2.tar.bz2
+WORKDIR /src/gmp-6.1.2
+RUN ./configure --prefix=/usr/local
+RUN make -j16
+RUN make install
+
+WORKDIR /src
+RUN curl -O http://www.mpfr.org/mpfr-current/mpfr-4.0.0.tar.gz
+RUN tar xvf mpfr-4.0.0.tar.gz
+WORKDIR /src/mpfr-4.0.0
+RUN ./configure --prefix=/usr/local
+RUN make -j16
+RUN make install
+
+WORKDIR /src
+RUN curl -O https://ftp.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz
+RUN tar xvf mpc-1.1.0.tar.gz
+WORKDIR /src/mpc-1.1.0
+RUN ./configure --prefix=/usr/local
+RUN make -j16
+RUN make install
+
+# Install gcc 5.5.0 from source
+WORKDIR /src
+RUN curl -O https://ftp.gnu.org/gnu/gcc/gcc-5.5.0/gcc-5.5.0.tar.gz
+RUN tar xvf gcc-5.5.0.tar.gz
+WORKDIR /src/gcc-5.5.0
+RUN ./configure --prefix=/usr/local --with-system-zlib --disable-multilib
+RUN make -j16
+RUN make install
+
+# Install Python 3.5 from source
+WORKDIR /src
+RUN curl -O https://www.python.org/ftp/python/3.5.4/Python-3.5.4.tgz
+RUN tar xvf Python-3.5.4.tgz
+WORKDIR /src/Python-3.5.4
+RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-optimizations
+RUN make -j16
+RUN make install
+
+# Install cmake from binary release
+WORKDIR /opt
+RUN curl -O https://cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.tar.gz
+RUN tar xvf cmake-3.10.2-Linux-x86_64.tar.gz
+ENV PATH="/opt/cmake-3.10.2-Linux-x86_64/bin:${PATH}"
+
+# Set compiler binary paths for CMake to pick up
+ENV CC="/usr/local/bin/gcc"
+ENV CXX="/usr/local/bin/g++"
+
+# Install pip and virtualenv
+WORKDIR /src
+RUN curl -O https://bootstrap.pypa.io/get-pip.py
+RUN python3 get-pip.py
+RUN pip3 install virtualenv
+
+# Start at home directory
+WORKDIR /root

--- a/docker/Dockerfile-python3.5-test
+++ b/docker/Dockerfile-python3.5-test
@@ -1,0 +1,84 @@
+# vim: set ft=dockerfile:
+
+FROM centos:centos7
+
+# Update yum and install some standard dev tools and dependencies
+RUN yum -y update
+RUN yum -y install git.x86_64 openssl-devel zlib-devel*
+RUN yum -y groupinstall 'development tools'
+
+# Create a directory for building deps from source code and set up env vars
+WORKDIR /
+RUN mkdir src
+ENV PATH="/usr/local/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
+
+# Install gcc dependencies
+WORKDIR /src
+RUN curl -O https://ftp.gnu.org/gnu/binutils/binutils-2.29.1.tar.gz
+RUN tar xvf binutils-2.29.1.tar.gz
+WORKDIR /src/binutils-2.29.1
+RUN ./configure --prefix=/usr/local
+RUN make -j16
+RUN make install
+
+WORKDIR /src
+RUN curl -O https://gmplib.org/download/gmp/gmp-6.1.2.tar.bz2
+RUN tar xvf gmp-6.1.2.tar.bz2
+WORKDIR /src/gmp-6.1.2
+RUN ./configure --prefix=/usr/local
+RUN make -j16
+RUN make install
+
+WORKDIR /src
+RUN curl -O http://www.mpfr.org/mpfr-current/mpfr-4.0.0.tar.gz
+RUN tar xvf mpfr-4.0.0.tar.gz
+WORKDIR /src/mpfr-4.0.0
+RUN ./configure --prefix=/usr/local
+RUN make -j16
+RUN make install
+
+WORKDIR /src
+RUN curl -O https://ftp.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz
+RUN tar xvf mpc-1.1.0.tar.gz
+WORKDIR /src/mpc-1.1.0
+RUN ./configure --prefix=/usr/local
+RUN make -j16
+RUN make install
+
+# Install gcc 5.5.0 from source
+WORKDIR /src
+RUN curl -O https://ftp.gnu.org/gnu/gcc/gcc-5.5.0/gcc-5.5.0.tar.gz
+RUN tar xvf gcc-5.5.0.tar.gz
+WORKDIR /src/gcc-5.5.0
+RUN ./configure --prefix=/usr/local --with-system-zlib --disable-multilib
+RUN make -j16
+RUN make install
+
+# Install Python 3.5 from source
+WORKDIR /src
+RUN curl -O https://www.python.org/ftp/python/3.5.4/Python-3.5.4.tgz
+RUN tar xvf Python-3.5.4.tgz
+WORKDIR /src/Python-3.5.4
+RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-optimizations
+RUN make -j16
+RUN make install
+
+# Install cmake from binary release
+WORKDIR /opt
+RUN curl -O https://cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.tar.gz
+RUN tar xvf cmake-3.10.2-Linux-x86_64.tar.gz
+ENV PATH="/opt/cmake-3.10.2-Linux-x86_64/bin:${PATH}"
+
+# Set compiler binary paths for CMake to pick up
+ENV CC="/usr/local/bin/gcc"
+ENV CXX="/usr/local/bin/g++"
+
+# Install pip and virtualenv
+WORKDIR /src
+RUN curl -O https://bootstrap.pypa.io/get-pip.py
+RUN python3 get-pip.py
+RUN pip3 install virtualenv
+
+# Start at home directory
+WORKDIR /root

--- a/docker/Dockerfile-python3.6-build
+++ b/docker/Dockerfile-python3.6-build
@@ -1,0 +1,85 @@
+# vim: set ft=dockerfile:
+
+# Based on Centos 6 for compatibility with older glibc versions
+FROM centos:centos6
+
+# Update yum and install some standard dev tools and dependencies
+RUN yum -y update
+RUN yum -y install git.x86_64 openssl-devel zlib-devel*
+RUN yum -y groupinstall 'development tools'
+
+# Create a directory for building deps from source code and set up env vars
+WORKDIR /
+RUN mkdir src
+ENV PATH="/usr/local/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
+
+# Install gcc dependencies
+WORKDIR /src
+RUN curl -O https://ftp.gnu.org/gnu/binutils/binutils-2.29.1.tar.gz
+RUN tar xvf binutils-2.29.1.tar.gz
+WORKDIR /src/binutils-2.29.1
+RUN ./configure --prefix=/usr/local
+RUN make -j16
+RUN make install
+
+WORKDIR /src
+RUN curl -O https://gmplib.org/download/gmp/gmp-6.1.2.tar.bz2
+RUN tar xvf gmp-6.1.2.tar.bz2
+WORKDIR /src/gmp-6.1.2
+RUN ./configure --prefix=/usr/local
+RUN make -j16
+RUN make install
+
+WORKDIR /src
+RUN curl -O http://www.mpfr.org/mpfr-current/mpfr-4.0.0.tar.gz
+RUN tar xvf mpfr-4.0.0.tar.gz
+WORKDIR /src/mpfr-4.0.0
+RUN ./configure --prefix=/usr/local
+RUN make -j16
+RUN make install
+
+WORKDIR /src
+RUN curl -O https://ftp.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz
+RUN tar xvf mpc-1.1.0.tar.gz
+WORKDIR /src/mpc-1.1.0
+RUN ./configure --prefix=/usr/local
+RUN make -j16
+RUN make install
+
+# Install gcc 5.5.0 from source
+WORKDIR /src
+RUN curl -O https://ftp.gnu.org/gnu/gcc/gcc-5.5.0/gcc-5.5.0.tar.gz
+RUN tar xvf gcc-5.5.0.tar.gz
+WORKDIR /src/gcc-5.5.0
+RUN ./configure --prefix=/usr/local --with-system-zlib --disable-multilib
+RUN make -j16
+RUN make install
+
+# Install Python 3.6 from source
+WORKDIR /src
+RUN curl -O https://www.python.org/ftp/python/3.6.4/Python-3.6.4.tgz
+RUN tar xvf Python-3.6.4.tgz
+WORKDIR /src/Python-3.6.4
+RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-optimizations
+RUN make -j16
+RUN make install
+
+# Install cmake from binary release
+WORKDIR /opt
+RUN curl -O https://cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.tar.gz
+RUN tar xvf cmake-3.10.2-Linux-x86_64.tar.gz
+ENV PATH="/opt/cmake-3.10.2-Linux-x86_64/bin:${PATH}"
+
+# Set compiler binary paths for CMake to pick up
+ENV CC="/usr/local/bin/gcc"
+ENV CXX="/usr/local/bin/g++"
+
+# Install pip and virtualenv
+WORKDIR /src
+RUN curl -O https://bootstrap.pypa.io/get-pip.py
+RUN python3 get-pip.py
+RUN pip3 install virtualenv
+
+# Start at home directory
+WORKDIR /root

--- a/docker/Dockerfile-python3.6-test
+++ b/docker/Dockerfile-python3.6-test
@@ -1,0 +1,84 @@
+# vim: set ft=dockerfile:
+
+FROM centos:centos7
+
+# Update yum and install some standard dev tools and dependencies
+RUN yum -y update
+RUN yum -y install git.x86_64 openssl-devel zlib-devel*
+RUN yum -y groupinstall 'development tools'
+
+# Create a directory for building deps from source code and set up env vars
+WORKDIR /
+RUN mkdir src
+ENV PATH="/usr/local/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
+
+# Install gcc dependencies
+WORKDIR /src
+RUN curl -O https://ftp.gnu.org/gnu/binutils/binutils-2.29.1.tar.gz
+RUN tar xvf binutils-2.29.1.tar.gz
+WORKDIR /src/binutils-2.29.1
+RUN ./configure --prefix=/usr/local
+RUN make -j16
+RUN make install
+
+WORKDIR /src
+RUN curl -O https://gmplib.org/download/gmp/gmp-6.1.2.tar.bz2
+RUN tar xvf gmp-6.1.2.tar.bz2
+WORKDIR /src/gmp-6.1.2
+RUN ./configure --prefix=/usr/local
+RUN make -j16
+RUN make install
+
+WORKDIR /src
+RUN curl -O http://www.mpfr.org/mpfr-current/mpfr-4.0.0.tar.gz
+RUN tar xvf mpfr-4.0.0.tar.gz
+WORKDIR /src/mpfr-4.0.0
+RUN ./configure --prefix=/usr/local
+RUN make -j16
+RUN make install
+
+WORKDIR /src
+RUN curl -O https://ftp.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz
+RUN tar xvf mpc-1.1.0.tar.gz
+WORKDIR /src/mpc-1.1.0
+RUN ./configure --prefix=/usr/local
+RUN make -j16
+RUN make install
+
+# Install gcc 5.5.0 from source
+WORKDIR /src
+RUN curl -O https://ftp.gnu.org/gnu/gcc/gcc-5.5.0/gcc-5.5.0.tar.gz
+RUN tar xvf gcc-5.5.0.tar.gz
+WORKDIR /src/gcc-5.5.0
+RUN ./configure --prefix=/usr/local --with-system-zlib --disable-multilib
+RUN make -j16
+RUN make install
+
+# Install Python 3.6 from source
+WORKDIR /src
+RUN curl -O https://www.python.org/ftp/python/3.6.4/Python-3.6.4.tgz
+RUN tar xvf Python-3.6.4.tgz
+WORKDIR /src/Python-3.6.4
+RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-optimizations
+RUN make -j16
+RUN make install
+
+# Install cmake from binary release
+WORKDIR /opt
+RUN curl -O https://cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.tar.gz
+RUN tar xvf cmake-3.10.2-Linux-x86_64.tar.gz
+ENV PATH="/opt/cmake-3.10.2-Linux-x86_64/bin:${PATH}"
+
+# Set compiler binary paths for CMake to pick up
+ENV CC="/usr/local/bin/gcc"
+ENV CXX="/usr/local/bin/g++"
+
+# Install pip and virtualenv
+WORKDIR /src
+RUN curl -O https://bootstrap.pypa.io/get-pip.py
+RUN python3 get-pip.py
+RUN pip3 install virtualenv
+
+# Start at home directory
+WORKDIR /root

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,7 +56,7 @@ import pkg_resources
 try:
     version = pkg_resources.require("coremltools")[0].version
 except:
-    version = "0.7"
+    version = "0.8"
 
 # The short X.Y version.
 version = version

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(README) as f:
     long_description = f.read()
 
 setup(name='coremltools',
-    version='0.7',
+    version='0.8',
     description='Community Tools for CoreML',
     long_description=long_description,
     author='Apple Inc.',
@@ -52,6 +52,8 @@ setup(name='coremltools',
           'Intended Audience :: Developers',
           'Operating System :: MacOS :: MacOS X',
           'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
           'Topic :: Scientific/Engineering',
           'Topic :: Software Development'
           ],

--- a/test_requirements.pip
+++ b/test_requirements.pip
@@ -1,0 +1,8 @@
+olefile==0.44
+Keras==2.1.3
+tensorflow==1.4.1
+pytest==3.2.1
+Pillow==4.2.1
+pandas==0.19.1
+scikit-learn==0.19.1
+h5py==2.7.1


### PR DESCRIPTION
* Tweak CMakeLists.txt to work with multiple Python versions on the same
  machine (using env variables to distinguish).
* Allow tests to run without CAFFE_MODELS_PATH env variable set.
* Add test_requirements.pip to pin specific versions of dependent
  packages used in testing.
* Add Dockerfiles to denote a consistent and reproducable environment
  for building and testing releases.