### PR TITLE
Add some useful utilities for debugging builds

### DIFF
--- a/docker/Dockerfile-python2.7-build
+++ b/docker/Dockerfile-python2.7-build
@@ -12,17 +12,9 @@ RUN yum -y groupinstall 'development tools'
 WORKDIR /
 RUN mkdir src
 ENV PATH="/usr/local/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib64:${LD_LIBRARY_PATH}"
 
 # Install gcc dependencies
-WORKDIR /src
-RUN curl -O https://ftp.gnu.org/gnu/binutils/binutils-2.29.1.tar.gz
-RUN tar xvf binutils-2.29.1.tar.gz
-WORKDIR /src/binutils-2.29.1
-RUN ./configure --prefix=/usr/local
-RUN make -j16
-RUN make install
-
 WORKDIR /src
 RUN curl -O https://gmplib.org/download/gmp/gmp-6.1.2.tar.bz2
 RUN tar xvf gmp-6.1.2.tar.bz2
@@ -61,7 +53,7 @@ WORKDIR /src
 RUN curl -O https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tgz
 RUN tar xvf Python-2.7.13.tgz
 WORKDIR /src/Python-2.7.13
-RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-optimizations
+RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-shared
 RUN make -j16
 RUN make install
 

--- a/docker/Dockerfile-python2.7-build
+++ b/docker/Dockerfile-python2.7-build
@@ -5,7 +5,7 @@ FROM centos:centos6
 
 # Update yum and install some standard dev tools and dependencies
 RUN yum -y update
-RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common
+RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common lapack-devel blas-devel
 RUN yum -y groupinstall 'development tools'
 
 # Create a directory for building deps from source code and set up env vars

--- a/docker/Dockerfile-python2.7-build
+++ b/docker/Dockerfile-python2.7-build
@@ -5,7 +5,7 @@ FROM centos:centos6
 
 # Update yum and install some standard dev tools and dependencies
 RUN yum -y update
-RUN yum -y install git.x86_64 openssl-devel zlib-devel*
+RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common
 RUN yum -y groupinstall 'development tools'
 
 # Create a directory for building deps from source code and set up env vars

--- a/docker/Dockerfile-python2.7-test
+++ b/docker/Dockerfile-python2.7-test
@@ -11,17 +11,9 @@ RUN yum -y groupinstall 'development tools'
 WORKDIR /
 RUN mkdir src
 ENV PATH="/usr/local/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib64:${LD_LIBRARY_PATH}"
 
 # Install gcc dependencies
-WORKDIR /src
-RUN curl -O https://ftp.gnu.org/gnu/binutils/binutils-2.29.1.tar.gz
-RUN tar xvf binutils-2.29.1.tar.gz
-WORKDIR /src/binutils-2.29.1
-RUN ./configure --prefix=/usr/local
-RUN make -j16
-RUN make install
-
 WORKDIR /src
 RUN curl -O https://gmplib.org/download/gmp/gmp-6.1.2.tar.bz2
 RUN tar xvf gmp-6.1.2.tar.bz2
@@ -60,7 +52,7 @@ WORKDIR /src
 RUN curl -O https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tgz
 RUN tar xvf Python-2.7.13.tgz
 WORKDIR /src/Python-2.7.13
-RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-optimizations
+RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-shared
 RUN make -j16
 RUN make install
 

--- a/docker/Dockerfile-python2.7-test
+++ b/docker/Dockerfile-python2.7-test
@@ -4,7 +4,7 @@ FROM centos:centos7
 
 # Update yum and install some standard dev tools and dependencies
 RUN yum -y update
-RUN yum -y install git.x86_64 openssl-devel zlib-devel*
+RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common which
 RUN yum -y groupinstall 'development tools'
 
 # Create a directory for building deps from source code and set up env vars

--- a/docker/Dockerfile-python2.7-test
+++ b/docker/Dockerfile-python2.7-test
@@ -4,7 +4,7 @@ FROM centos:centos7
 
 # Update yum and install some standard dev tools and dependencies
 RUN yum -y update
-RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common which
+RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common which lapack-devel blas-devel
 RUN yum -y groupinstall 'development tools'
 
 # Create a directory for building deps from source code and set up env vars

--- a/docker/Dockerfile-python3.5-build
+++ b/docker/Dockerfile-python3.5-build
@@ -5,7 +5,7 @@ FROM centos:centos6
 
 # Update yum and install some standard dev tools and dependencies
 RUN yum -y update
-RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common
+RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common lapack-devel blas-devel
 RUN yum -y groupinstall 'development tools'
 
 # Create a directory for building deps from source code and set up env vars

--- a/docker/Dockerfile-python3.5-build
+++ b/docker/Dockerfile-python3.5-build
@@ -12,17 +12,9 @@ RUN yum -y groupinstall 'development tools'
 WORKDIR /
 RUN mkdir src
 ENV PATH="/usr/local/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib64:${LD_LIBRARY_PATH}"
 
 # Install gcc dependencies
-WORKDIR /src
-RUN curl -O https://ftp.gnu.org/gnu/binutils/binutils-2.29.1.tar.gz
-RUN tar xvf binutils-2.29.1.tar.gz
-WORKDIR /src/binutils-2.29.1
-RUN ./configure --prefix=/usr/local
-RUN make -j16
-RUN make install
-
 WORKDIR /src
 RUN curl -O https://gmplib.org/download/gmp/gmp-6.1.2.tar.bz2
 RUN tar xvf gmp-6.1.2.tar.bz2
@@ -61,7 +53,7 @@ WORKDIR /src
 RUN curl -O https://www.python.org/ftp/python/3.5.4/Python-3.5.4.tgz
 RUN tar xvf Python-3.5.4.tgz
 WORKDIR /src/Python-3.5.4
-RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-optimizations
+RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-shared
 RUN make -j16
 RUN make install
 

--- a/docker/Dockerfile-python3.5-build
+++ b/docker/Dockerfile-python3.5-build
@@ -5,7 +5,7 @@ FROM centos:centos6
 
 # Update yum and install some standard dev tools and dependencies
 RUN yum -y update
-RUN yum -y install git.x86_64 openssl-devel zlib-devel*
+RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common
 RUN yum -y groupinstall 'development tools'
 
 # Create a directory for building deps from source code and set up env vars

--- a/docker/Dockerfile-python3.5-test
+++ b/docker/Dockerfile-python3.5-test
@@ -11,17 +11,9 @@ RUN yum -y groupinstall 'development tools'
 WORKDIR /
 RUN mkdir src
 ENV PATH="/usr/local/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib64:${LD_LIBRARY_PATH}"
 
 # Install gcc dependencies
-WORKDIR /src
-RUN curl -O https://ftp.gnu.org/gnu/binutils/binutils-2.29.1.tar.gz
-RUN tar xvf binutils-2.29.1.tar.gz
-WORKDIR /src/binutils-2.29.1
-RUN ./configure --prefix=/usr/local
-RUN make -j16
-RUN make install
-
 WORKDIR /src
 RUN curl -O https://gmplib.org/download/gmp/gmp-6.1.2.tar.bz2
 RUN tar xvf gmp-6.1.2.tar.bz2
@@ -60,7 +52,7 @@ WORKDIR /src
 RUN curl -O https://www.python.org/ftp/python/3.5.4/Python-3.5.4.tgz
 RUN tar xvf Python-3.5.4.tgz
 WORKDIR /src/Python-3.5.4
-RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-optimizations
+RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-shared
 RUN make -j16
 RUN make install
 

--- a/docker/Dockerfile-python3.5-test
+++ b/docker/Dockerfile-python3.5-test
@@ -4,7 +4,7 @@ FROM centos:centos7
 
 # Update yum and install some standard dev tools and dependencies
 RUN yum -y update
-RUN yum -y install git.x86_64 openssl-devel zlib-devel*
+RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common which
 RUN yum -y groupinstall 'development tools'
 
 # Create a directory for building deps from source code and set up env vars

--- a/docker/Dockerfile-python3.5-test
+++ b/docker/Dockerfile-python3.5-test
@@ -4,7 +4,7 @@ FROM centos:centos7
 
 # Update yum and install some standard dev tools and dependencies
 RUN yum -y update
-RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common which
+RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common which lapack-devel blas-devel
 RUN yum -y groupinstall 'development tools'
 
 # Create a directory for building deps from source code and set up env vars

--- a/docker/Dockerfile-python3.6-build
+++ b/docker/Dockerfile-python3.6-build
@@ -12,17 +12,9 @@ RUN yum -y groupinstall 'development tools'
 WORKDIR /
 RUN mkdir src
 ENV PATH="/usr/local/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib64:${LD_LIBRARY_PATH}"
 
 # Install gcc dependencies
-WORKDIR /src
-RUN curl -O https://ftp.gnu.org/gnu/binutils/binutils-2.29.1.tar.gz
-RUN tar xvf binutils-2.29.1.tar.gz
-WORKDIR /src/binutils-2.29.1
-RUN ./configure --prefix=/usr/local
-RUN make -j16
-RUN make install
-
 WORKDIR /src
 RUN curl -O https://gmplib.org/download/gmp/gmp-6.1.2.tar.bz2
 RUN tar xvf gmp-6.1.2.tar.bz2
@@ -61,7 +53,7 @@ WORKDIR /src
 RUN curl -O https://www.python.org/ftp/python/3.6.4/Python-3.6.4.tgz
 RUN tar xvf Python-3.6.4.tgz
 WORKDIR /src/Python-3.6.4
-RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-optimizations
+RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-shared
 RUN make -j16
 RUN make install
 

--- a/docker/Dockerfile-python3.6-build
+++ b/docker/Dockerfile-python3.6-build
@@ -5,7 +5,7 @@ FROM centos:centos6
 
 # Update yum and install some standard dev tools and dependencies
 RUN yum -y update
-RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common
+RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common lapack-devel blas-devel
 RUN yum -y groupinstall 'development tools'
 
 # Create a directory for building deps from source code and set up env vars

--- a/docker/Dockerfile-python3.6-build
+++ b/docker/Dockerfile-python3.6-build
@@ -5,7 +5,7 @@ FROM centos:centos6
 
 # Update yum and install some standard dev tools and dependencies
 RUN yum -y update
-RUN yum -y install git.x86_64 openssl-devel zlib-devel*
+RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common
 RUN yum -y groupinstall 'development tools'
 
 # Create a directory for building deps from source code and set up env vars

--- a/docker/Dockerfile-python3.6-test
+++ b/docker/Dockerfile-python3.6-test
@@ -4,7 +4,7 @@ FROM centos:centos7
 
 # Update yum and install some standard dev tools and dependencies
 RUN yum -y update
-RUN yum -y install git.x86_64 openssl-devel zlib-devel*
+RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common which
 RUN yum -y groupinstall 'development tools'
 
 # Create a directory for building deps from source code and set up env vars

--- a/docker/Dockerfile-python3.6-test
+++ b/docker/Dockerfile-python3.6-test
@@ -11,17 +11,9 @@ RUN yum -y groupinstall 'development tools'
 WORKDIR /
 RUN mkdir src
 ENV PATH="/usr/local/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib64:${LD_LIBRARY_PATH}"
 
 # Install gcc dependencies
-WORKDIR /src
-RUN curl -O https://ftp.gnu.org/gnu/binutils/binutils-2.29.1.tar.gz
-RUN tar xvf binutils-2.29.1.tar.gz
-WORKDIR /src/binutils-2.29.1
-RUN ./configure --prefix=/usr/local
-RUN make -j16
-RUN make install
-
 WORKDIR /src
 RUN curl -O https://gmplib.org/download/gmp/gmp-6.1.2.tar.bz2
 RUN tar xvf gmp-6.1.2.tar.bz2
@@ -60,7 +52,7 @@ WORKDIR /src
 RUN curl -O https://www.python.org/ftp/python/3.6.4/Python-3.6.4.tgz
 RUN tar xvf Python-3.6.4.tgz
 WORKDIR /src/Python-3.6.4
-RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-optimizations
+RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-shared
 RUN make -j16
 RUN make install
 

--- a/docker/Dockerfile-python3.6-test
+++ b/docker/Dockerfile-python3.6-test
@@ -4,7 +4,7 @@ FROM centos:centos7
 
 # Update yum and install some standard dev tools and dependencies
 RUN yum -y update
-RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common which
+RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common which lapack-devel blas-devel
 RUN yum -y groupinstall 'development tools'
 
 # Create a directory for building deps from source code and set up env vars


### PR DESCRIPTION
* vim-common for some reason provides `config`, needed for
  `python-config`.
* bzip2-devel is needed to `import bz2` in Python; may be useful for
  manual testing.
* On CentOS 7, `which` is not provided by default.