### PR TITLE
SeparableConv2D: dilations issue fixed

### DIFF
--- a/coremltools/converters/keras/_layers2.py
+++ b/coremltools/converters/keras/_layers2.py
@@ -428,7 +428,7 @@ def convert_separable_convolution(builder, layer, input_names, output_names, ker
     else:
         dilations = [keras_layer.dilation_rate, keras_layer.dilation_rate]
 
-    intermediate_name = input_name + '_intermin_'
+    intermediate_name = output_name + '_intermin_'
 
     builder.add_convolution(name = layer + '_step_1',
              kernel_channels = 1,

--- a/coremltools/converters/keras/_layers2.py
+++ b/coremltools/converters/keras/_layers2.py
@@ -422,6 +422,12 @@ def convert_separable_convolution(builder, layer, input_names, output_names, ker
 
     stride_height, stride_width = keras_layer.strides
 
+    # Dilations
+    if (type(keras_layer.dilation_rate) is list) or (type(keras_layer.dilation_rate) is tuple):
+        dilations = [keras_layer.dilation_rate[0], keras_layer.dilation_rate[1]]
+    else:
+        dilations = [keras_layer.dilation_rate, keras_layer.dilation_rate]
+
     intermediate_name = input_name + '_intermin_'
 
     builder.add_convolution(name = layer + '_step_1',
@@ -440,7 +446,7 @@ def convert_separable_convolution(builder, layer, input_names, output_names, ker
              output_shape = None,
              input_name = input_name,
              output_name = intermediate_name, 
-             dilation_factors = [1,1])
+             dilation_factors = dilations)
 
     builder.add_convolution(name = layer + '_step_2',
              kernel_channels = input_channels * depth_mult,

--- a/coremltools/test/test_keras2_numeric.py
+++ b/coremltools/test/test_keras2_numeric.py
@@ -751,6 +751,47 @@ class KerasBasicNumericCorrectnessTest(KerasNumericCorrectnessTest):
         return self.test_tiny_separable_conv_same_fancy_depth_multiplier(
             model_precision=_MLMODEL_HALF_PRECISION)
 
+    def test_tiny_separable_conv_dilated(self, model_precision=_MLMODEL_FULL_PRECISION):
+        np.random.seed(1988)
+        input_dim = 10
+        input_shape = (input_dim, input_dim, 1)
+        num_kernels, kernel_height, kernel_width = 3, 5, 5
+
+        # Define a model
+        model = Sequential()
+        model.add(SeparableConv2D(input_shape = input_shape, dilation_rate=(2, 2),
+                                  filters = num_kernels, kernel_size = (kernel_height, kernel_width)))
+
+        # Set some random weights
+        model.set_weights([np.random.rand(*w.shape) for w in model.get_weights()])
+
+        # Test the keras model
+        self._test_keras_model(model, model_precision=model_precision)
+
+    def test_tiny_separable_conv_dilated_half_precision(self):
+        return self.test_tiny_separable_conv_dilated(model_precision=_MLMODEL_HALF_PRECISION)
+
+    def test_tiny_separable_conv_dilated_rect_random(self, model_precision=_MLMODEL_FULL_PRECISION):
+        np.random.seed(1988)
+        input_shape = (32, 20, 3)
+        num_kernels = 2
+        kernel_height = 3
+        kernel_width = 3
+
+        # Define a model
+        model = Sequential()
+        model.add(SeparableConv2D(input_shape = input_shape, dilation_rate=(2,2),
+                                  filters = num_kernels, kernel_size = (kernel_height, kernel_width)))
+
+        # Set some random weights
+        model.set_weights([np.random.rand(*w.shape) for w in model.get_weights()])
+
+        # Test the keras model
+        self._test_keras_model(model, model_precision=model_precision)
+
+    def test_tiny_separable_conv_dilated_rect_random_half_precision(self):
+        return self.test_tiny_separable_conv_dilated_rect_random(model_precision=_MLMODEL_HALF_PRECISION)
+
     def test_max_pooling_no_overlap(self):
         # no_overlap: pool_size = strides
         model = Sequential()


### PR DESCRIPTION
Issue with Keras SeparableConv2D layer conversion fixed: added dilations to intermediate depthwise convolution.

Issue example (road scene segmentation):
1. Raw image
![image](https://user-images.githubusercontent.com/5019624/35685243-325a2952-077a-11e8-9611-dde7e02422bd.png)
2. Predicted segmentation mask on PC (model trained with Keras 2.1.3 and TensorFlow-1.5.0 backend, CUDA 9.0):
![image](https://user-images.githubusercontent.com/5019624/35685357-8b748df2-077a-11e8-8ced-b30271e7ed14.png)
3. Predicted segmentation mask on iPhone X (same model, converted with coremltools-0.8):
![image](https://user-images.githubusercontent.com/5019624/35685396-a92ae238-077a-11e8-97ba-341795e7df64.png)

After fixing "convert_separable_convolution" method predicted segmentation mask on device corresponds to predicted mask on PC:

![image](https://user-images.githubusercontent.com/5019624/35686575-a23433e6-077d-11e8-85d6-62c4f3b9d4cc.png)