### PR TITLE
Enable Python sqlite module

### DIFF
--- a/docker/Dockerfile-python2.7-build
+++ b/docker/Dockerfile-python2.7-build
@@ -5,7 +5,7 @@ FROM centos:centos6
 
 # Update yum and install some standard dev tools and dependencies
 RUN yum -y update
-RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common lapack-devel blas-devel
+RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common lapack-devel blas-devel sqlite-devel
 RUN yum -y groupinstall 'development tools'
 
 # Create a directory for building deps from source code and set up env vars
@@ -53,7 +53,7 @@ WORKDIR /src
 RUN curl -O https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tgz
 RUN tar xvf Python-2.7.13.tgz
 WORKDIR /src/Python-2.7.13
-RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-shared
+RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-shared --enable-loadable-sqlite-extensions
 RUN make -j16
 RUN make install
 

--- a/docker/Dockerfile-python2.7-test
+++ b/docker/Dockerfile-python2.7-test
@@ -4,7 +4,7 @@ FROM centos:centos7
 
 # Update yum and install some standard dev tools and dependencies
 RUN yum -y update
-RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common which lapack-devel blas-devel
+RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common which lapack-devel blas-devel sqlite-devel
 RUN yum -y groupinstall 'development tools'
 
 # Create a directory for building deps from source code and set up env vars
@@ -52,7 +52,7 @@ WORKDIR /src
 RUN curl -O https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tgz
 RUN tar xvf Python-2.7.13.tgz
 WORKDIR /src/Python-2.7.13
-RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-shared
+RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-shared --enable-loadable-sqlite-extensions
 RUN make -j16
 RUN make install
 

--- a/docker/Dockerfile-python3.5-build
+++ b/docker/Dockerfile-python3.5-build
@@ -5,7 +5,7 @@ FROM centos:centos6
 
 # Update yum and install some standard dev tools and dependencies
 RUN yum -y update
-RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common lapack-devel blas-devel
+RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common lapack-devel blas-devel sqlite-devel
 RUN yum -y groupinstall 'development tools'
 
 # Create a directory for building deps from source code and set up env vars
@@ -53,7 +53,7 @@ WORKDIR /src
 RUN curl -O https://www.python.org/ftp/python/3.5.4/Python-3.5.4.tgz
 RUN tar xvf Python-3.5.4.tgz
 WORKDIR /src/Python-3.5.4
-RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-shared
+RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-shared --enable-loadable-sqlite-extensions
 RUN make -j16
 RUN make install
 

--- a/docker/Dockerfile-python3.5-test
+++ b/docker/Dockerfile-python3.5-test
@@ -4,7 +4,7 @@ FROM centos:centos7
 
 # Update yum and install some standard dev tools and dependencies
 RUN yum -y update
-RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common which lapack-devel blas-devel
+RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common which lapack-devel blas-devel sqlite-devel
 RUN yum -y groupinstall 'development tools'
 
 # Create a directory for building deps from source code and set up env vars
@@ -52,7 +52,7 @@ WORKDIR /src
 RUN curl -O https://www.python.org/ftp/python/3.5.4/Python-3.5.4.tgz
 RUN tar xvf Python-3.5.4.tgz
 WORKDIR /src/Python-3.5.4
-RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-shared
+RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-shared --enable-loadable-sqlite-extensions
 RUN make -j16
 RUN make install
 

--- a/docker/Dockerfile-python3.6-build
+++ b/docker/Dockerfile-python3.6-build
@@ -5,7 +5,7 @@ FROM centos:centos6
 
 # Update yum and install some standard dev tools and dependencies
 RUN yum -y update
-RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common lapack-devel blas-devel
+RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common lapack-devel blas-devel sqlite-devel
 RUN yum -y groupinstall 'development tools'
 
 # Create a directory for building deps from source code and set up env vars
@@ -53,7 +53,7 @@ WORKDIR /src
 RUN curl -O https://www.python.org/ftp/python/3.6.4/Python-3.6.4.tgz
 RUN tar xvf Python-3.6.4.tgz
 WORKDIR /src/Python-3.6.4
-RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-shared
+RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-shared --enable-loadable-sqlite-extensions
 RUN make -j16
 RUN make install
 

--- a/docker/Dockerfile-python3.6-test
+++ b/docker/Dockerfile-python3.6-test
@@ -4,7 +4,7 @@ FROM centos:centos7
 
 # Update yum and install some standard dev tools and dependencies
 RUN yum -y update
-RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common which lapack-devel blas-devel
+RUN yum -y install git.x86_64 openssl-devel zlib-devel* bzip2-devel vim-common which lapack-devel blas-devel sqlite-devel
 RUN yum -y groupinstall 'development tools'
 
 # Create a directory for building deps from source code and set up env vars
@@ -52,7 +52,7 @@ WORKDIR /src
 RUN curl -O https://www.python.org/ftp/python/3.6.4/Python-3.6.4.tgz
 RUN tar xvf Python-3.6.4.tgz
 WORKDIR /src/Python-3.6.4
-RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-shared
+RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-shared --enable-loadable-sqlite-extensions
 RUN make -j16
 RUN make install
 


### PR DESCRIPTION
This fixes `import sqlite3` in Python; without compatible
dependencies and build flags, Python excludes this capability by
default.

See https://stackoverflow.com/questions/1210664/no-module-named-sqlite3