### PR TITLE
Bump min numpy version to 1.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Dependencies
 
 *coremltools* has the following dependencies:
 
-- numpy (1.12.1+)
+- numpy (1.10.0+)
 - protobuf (3.1.0+)
 
 In addition, it has the following soft dependencies that are only needed when
@@ -96,7 +96,7 @@ Additionally, running unit-tests would require more packages (like
 libsvm)
 
 ```shell
-pip install numpy scipy scikit-learn
+pip install -r test_requirements.pip
 ```
 
 To install libsvm

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Dependencies
 
 :code:`coremltools` has the following dependencies:
 
-- numpy (1.12.1+)
+- numpy (1.10.0+)
 - protobuf (3.1.0+)
 
 In addition, it has the following soft dependencies that are only needed when

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(name='coremltools',
                                   'graph_visualization/icons/*']
                   },
     install_requires=[
-        'numpy >= 1.6.2',
+        'numpy >= 1.10.0',
         'protobuf >= 3.1.0',
         'six==1.10.0'
     ],


### PR DESCRIPTION
Tested across a variety of Python distributions and versions; 1.10.0
seems to be the minimum version that is API- and ABI-compatible with
current versions of numpy for our purposes.