### PR TITLE
Fix bugs for keras models with outputs coming from nested models

### DIFF
--- a/coremltools/converters/keras/_topology2.py
+++ b/coremltools/converters/keras/_topology2.py
@@ -171,7 +171,18 @@ class NetGraph(object):
         if hasattr(self.model, 'output_layers'):
             # find corresponding output layers in CoreML model
             # assume output layers are not shared
-            for kl in self.model.output_layers:
+            # Helper function to recursively extract output layers
+            # even if the model has a layer which is a nested model
+            def extract_output_layers(keras_model):
+                output_layers = []
+                for layer in keras_model.output_layers:
+                    if hasattr(layer,'output_layers'):
+                        output_layers.extend(extract_output_layers(layer))
+                    else:
+                        output_layers.append(layer)
+                return output_layers
+
+            for kl in extract_output_layers(self.model):
                 coreml_layers = self.get_coreml_layers(kl)
                 if len(coreml_layers) > 0:
                     for cl in coreml_layers:

--- a/coremltools/test/test_keras2_numeric.py
+++ b/coremltools/test/test_keras2_numeric.py
@@ -2050,6 +2050,18 @@ class KerasTopologyCorrectnessTest(KerasNumericCorrectnessTest):
 
     def test_tiny_xception_half_precision(self):
         return self.test_tiny_xception(model_precision=_MLMODEL_HALF_PRECISION)
+        
+    def test_nested_model_giving_output(self):
+        base_model = Sequential()
+        base_model.add(Conv2D(32, (1, 1), input_shape=(4, 4, 3)))
+
+        top_model = Sequential()
+        top_model.add(Flatten(input_shape=base_model.output_shape[1:]))
+        top_model.add(Dense(16, activation='relu'))
+        top_model.add(Dense(1, activation='sigmoid'))
+
+        model = Model(inputs=base_model.input, outputs=top_model(base_model.output))
+        self._test_keras_model(model)
 
 @pytest.mark.slow
 @pytest.mark.keras2


### PR DESCRIPTION
Keras converter fails when a top-level model contains a nested model, and the top-level model's output layer is within the nested model. 
This PR fixes this issue. 