### PR TITLE
Fix problem with output shape of model when output tensor has 2 dimensions

### DIFF
--- a/coremltools/converters/keras/_keras2_converter.py
+++ b/coremltools/converters/keras/_keras2_converter.py
@@ -267,7 +267,7 @@ def _convert(model,
         if len(dim) == 1:
             output_dims[idx] = dim
         elif len(dim) == 2:  # [Seq, D]
-            output_dims[idx] = (dim[1],)
+            output_dims[idx] = (dim[1], dim[0])
         elif len(dim) == 3:
             output_dims[idx] = (dim[2], dim[0], dim[1])
 


### PR DESCRIPTION
I have keras model with custom output layer and output shape [1,200,6]. When I converted model, I received the model with output shape (6,). 

I've found line where my problem arised:

    # Retrieve output shapes from model
    if type(model.output_shape) is list:
        output_dims = [filter(None, x) for x in model.output_shape]
    else:
        output_dims = [filter(None, model.output_shape[1:])]

    for idx, dim in enumerate(output_dims):
        dim = list(dim)
        if len(dim) == 1:
            output_dims[idx] = dim
        elif len(dim) == 2:  # [Seq, D]
            output_dims[idx] = (dim[1], ) # <--- HERE!!!
        elif len(dim) == 3:
            output_dims[idx] = (dim[2], dim[0], dim[1])

 I've change the line on another one  output_dims[idx] = (dim[1], dim[0]). In this case I've got right output shape. 