### PR TITLE
Fix Keras support version

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Dependencies
 In addition, it has the following soft dependencies that are only needed when
 you are converting models of these formats:
 
-- Keras (1.2.2, 2.0.4+) with corresponding Tensorflow version
+- Keras (1.2.2, 2.0.6+) with corresponding Tensorflow version
 - Xgboost (0.7+)
 - scikit-learn (0.17+)
 - libSVM


### PR DESCRIPTION
[_keras2_converter.py](https://github.com/apple/coremltools/blob/master/coremltools/converters/keras/_keras2_converter.py#L70) require `keras.applications.mobilenet` module.

It added to Keras v2.0.6.
https://github.com/keras-team/keras/releases/tag/2.0.6

But `README.md` say coremltools support Keras 2.0.4+. 
I fixed it.