### PR TITLE
Fix a build break in gcc7

### DIFF
--- a/mlmodel/src/NeuralNetworkValidator.cpp
+++ b/mlmodel/src/NeuralNetworkValidator.cpp
@@ -14,6 +14,7 @@
 #include "QuantizationValidationUtils.hpp"
 
 #include <algorithm>
+#include <functional>
 #include <sstream>
 
 namespace CoreML {


### PR DESCRIPTION
gcc7+ seems stricter than previous releases, and now requires
`<functional>` to be included in order to use `std::function`.

See also apple/turicreate#1122