### PR TITLE
Update imports for relu6 removal in Keras 2.2.2

### DIFF
--- a/coremltools/converters/keras/_layers2.py
+++ b/coremltools/converters/keras/_layers2.py
@@ -7,7 +7,10 @@ from distutils.version import StrictVersion as _StrictVersion
 
 if _keras.__version__ >= _StrictVersion('2.2.0'):
     from keras.layers import DepthwiseConv2D
-    from keras_applications.mobilenet import relu6
+    if _keras.__version__ <= _StrictVersion('2.2.1'):
+        from keras_applications.mobilenet import relu6
+    else:
+        relu6 = lambda x: _keras.activations.relu(x, max_value=6.0)
 else:
     from keras.applications.mobilenet import DepthwiseConv2D, relu6
 


### PR DESCRIPTION
Keras 2.2.2 doesn't have keras_applications.mobilenet.relu6 anymore, resulting in an ImportError if code is run with this and posterior versions. This PR checks for the appropriate Keras version and provides a dummy replacement for relu6.