### PR TITLE
keras_application -> keras.applications typo

### DIFF
--- a/coremltools/converters/keras/_layers2.py
+++ b/coremltools/converters/keras/_layers2.py
@@ -9,7 +9,7 @@ if _keras.__version__ >= _StrictVersion('2.2.1'):
     from keras.layers import DepthwiseConv2D
 elif _keras.__version__ >= _StrictVersion('2.2.0'):
     from keras.layers import DepthwiseConv2D
-    from keras_applications.mobilenet import relu6
+    from keras.applications.mobilenet import relu6
 else:
     from keras.applications.mobilenet import DepthwiseConv2D, relu6
 


### PR DESCRIPTION
Fix for when conversion fails for a Keras version >= 2.2.0
e.g:
```
/usr/local/lib/python2.7/dist-packages/coremltools/converters/keras/_layers2.py in <module>()
      8 if _keras.__version__ >= _StrictVersion('2.2.0'):
      9     from keras.layers import DepthwiseConv2D
---> 10     from keras_applications.mobilenet import relu6
     11 else:
     12     from keras.applications.mobilenet import DepthwiseConv2D, relu6

ImportError: cannot import name relu6
```