### PR TITLE
Remove the confusing wrapper classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ cmake_install.cmake
 .DS_Store
 *.xcodeproj/
 mlmodel_test_runner
+.ninja_deps
+.ninja_log
+build.ninja
+rules.ninja

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,22 @@
 cmake_minimum_required(VERSION 3.0.0)
 
+#xcodebuild -version -sdk macosx Path
+find_program(XCODEBUILD xcodebuild)
+if(XCODEBUILD)
+  exec_program(${XCODEBUILD}
+    ARGS "-version -sdk macosx Path"
+    OUTPUT_VARIABLE XCODE_SDK_PATH)
+  set(CMAKE_OSX_SYSROOT ${XCODE_SDK_PATH})
+endif()
+
+find_program(SW_VERS sw_vers)
+if(SW_VERS)
+  exec_program(${SW_VERS}
+    ARGS "-productVersion"
+    OUTPUT_VARIABLE OSX_VERSION)
+  set(CMAKE_OSX_DEPLOYMENT_TARGET ${OSX_VERSION})
+endif()
+
 set(CMAKE_OSX_ARCHITECTURES x86_64)
 
 project(coremltools)

--- a/caffeconverter/CaffeConverterLib.cpp
+++ b/caffeconverter/CaffeConverterLib.cpp
@@ -81,7 +81,7 @@ void convertCaffe(const std::string& srcPath,
                     predictedFeatureName);
     
     // Save the format to the model path.
-    Result r = saveSpecificationPath(modelSpec, dstPath);
+    Result r = Model::save(modelSpec, dstPath);
     if (!r.good()) {
         throw std::runtime_error(r.message());
     }

--- a/coremlpython/CoreMLPython.mm
+++ b/coremlpython/CoreMLPython.mm
@@ -3,6 +3,7 @@
 #import "CoreMLPython.h"
 #import "CoreMLPythonUtils.h"
 #import "Globals.hpp"
+#import "Model.hpp"
 #import "NeuralNetworkShapes.hpp"
 #import "Utils.hpp"
 
@@ -80,19 +81,19 @@ int32_t Model::maximumSupportedSpecificationVersion() {
 
 NeuralNetworkShapeInformation::NeuralNetworkShapeInformation(const std::string& filename) {
     CoreML::Specification::Model model;
-    Result r = CoreML::loadSpecificationPath(model, filename);
+    Result r = CoreML::Model::load(&model, filename);
     shaper = std::unique_ptr<NeuralNetworkShaper>(new NeuralNetworkShaper(model));
 }
 
 NeuralNetworkShapeInformation::NeuralNetworkShapeInformation(const std::string& filename, bool useInputAndOutputConstraints) {
     CoreML::Specification::Model model;
-    Result r = CoreML::loadSpecificationPath(model, filename);
+    Result r = CoreML::Model::load(&model, filename);
     shaper = std::unique_ptr<NeuralNetworkShaper>(new NeuralNetworkShaper(model, useInputAndOutputConstraints));
 }
 
 void NeuralNetworkShapeInformation::init(const std::string& filename) {
     CoreML::Specification::Model model;
-    Result r = CoreML::loadSpecificationPath(model, filename);
+    Result r = CoreML::Model::load(&model, filename);
     shaper.reset(new NeuralNetworkShaper(model));
 }
 

--- a/mlmodel/src/PipelineValidator.cpp
+++ b/mlmodel/src/PipelineValidator.cpp
@@ -53,8 +53,7 @@ namespace CoreML {
             }
 
             // validate the model itself and bail out if it's invalid
-            Model wrapper(model);
-            Result r = wrapper.validate();
+            Result r = Model::validate(model);
             if (!r.good()) { return r; }
 
             // Now add in the outputs of this model to the mix.

--- a/mlmodel/src/Utils.hpp
+++ b/mlmodel/src/Utils.hpp
@@ -48,12 +48,6 @@ namespace CoreML {
     }
 
 
-    static inline Result saveSpecificationPath(const Specification::Model& formatObj,
-                                               const std::string& path) {
-        Model m(formatObj);
-        return m.save(path);
-    }
-
     template <typename T>
     static inline  Result loadSpecification(T& formatObj,
                                             std::istream& in) {
@@ -71,20 +65,12 @@ namespace CoreML {
         
         return Result();
     }
-    
-    static inline Result loadSpecificationPath(Specification::Model& formatObj,
-                                               const std::string& path) {
-        Model m;
-        Result r = CoreML::Model::load(path, m);
-        if (!r.good()) { return r; }
-        formatObj = m.getProto();
-        return Result();
-    }
 
     /**
      * If a model spec does not use features from later specification versions, this will
      * set the spec version so that the model can be executed on older versions of
      * Core ML. It applies recursively to sub models
+     * We will only reduce the given specification version if possible. We never increase it here. 
      */
     void downgradeSpecificationVersion(Specification::Model *pModel);
 

--- a/mlmodel/src/transforms/DictVectorizer.cpp
+++ b/mlmodel/src/transforms/DictVectorizer.cpp
@@ -9,46 +9,28 @@
 #include <stdio.h>
 #include "DictVectorizer.hpp"
 #include "../Format.hpp"
+#include "../Model.hpp"
 
 namespace CoreML {
+namespace DictVectorizer {
     
-    DictVectorizer::DictVectorizer(const std::string& description) :
-    Model(description) {
-            // make sure we become a dict vectorizer
-        (void) m_spec->mutable_dictvectorizer();
-    }
-    
-    Result DictVectorizer::addInput(const std::string& inputName, FeatureType inputType) {
-        
-        HANDLE_RESULT_AND_RETURN_ON_ERROR(enforceTypeInvariant({
-            FeatureType::Dictionary(MLDictionaryFeatureTypeKeyType_stringKeyType),
-            FeatureType::Dictionary(MLDictionaryFeatureTypeKeyType_int64KeyType)
-        }, inputType));
-        
-        HANDLE_RESULT_AND_RETURN_ON_ERROR(Model::addInput(inputName, inputType));
-        return Result();
-    }
-    
-
-    Result DictVectorizer::setFeatureEncoding(const std::vector<int64_t>& container) {
-        auto ohe = m_spec->mutable_dictvectorizer();
-        ohe->mutable_int64toindex()->clear_vector();
+    Result setFeatureEncoding(CoreML::Specification::DictVectorizer* dictVectorizer, const std::vector<int64_t>& container) {
+        dictVectorizer->mutable_int64toindex()->clear_vector();
         
         for (auto element : container) {
-            ohe->mutable_int64toindex()->add_vector(element);
+            dictVectorizer->mutable_int64toindex()->add_vector(element);
         }
         return Result();
     }
     
-    Result DictVectorizer::setFeatureEncoding(const std::vector<std::string>& container) {
-        auto ohe = m_spec->mutable_dictvectorizer();
-        ohe->mutable_stringtoindex()->clear_vector();
+    Result setFeatureEncoding(CoreML::Specification::DictVectorizer* dictVectorizer, const std::vector<std::string>& container) {
+        dictVectorizer->mutable_stringtoindex()->clear_vector();
         
         for (auto element : container) {
-            auto *value = ohe->mutable_stringtoindex()->add_vector();
+            auto *value = dictVectorizer->mutable_stringtoindex()->add_vector();
             *value = element;
         }
         return Result();
     }
     
-}
+}}

--- a/mlmodel/src/transforms/DictVectorizer.hpp
+++ b/mlmodel/src/transforms/DictVectorizer.hpp
@@ -10,27 +10,18 @@
 #define DictVectorizer_h
 
 #include "../Result.hpp"
-#include "../Model.hpp"
 #include "../../build/format/OneHotEncoder_enums.h"
 
+#include <string>
 
 namespace CoreML {
-    
-
-class DictVectorizer : public Model {
-    
-public:
-    
-    explicit DictVectorizer(const std::string& description = "");
-    
-    Result addInput(const std::string& featureName, FeatureType featureType) override;
-    
-    Result setHandleUnknown(MLHandleUnknown state);
-    
-    Result setFeatureEncoding(const std::vector<int64_t>& container);
-    
-    Result setFeatureEncoding(const std::vector<std::string>& container);
-};
-
+    namespace Specification {
+        class DictVectorizer;
+    }
+    namespace DictVectorizer {
+        Result setFeatureEncoding(CoreML::Specification::DictVectorizer* dictVectorizer, const std::vector<int64_t>& container);
+        Result setFeatureEncoding(CoreML::Specification::DictVectorizer* dictVectorizer, const std::vector<std::string>& container);
+    }
 }
+
 #endif /* DictVectorizer_h */

--- a/mlmodel/src/transforms/FeatureVectorizer.cpp
+++ b/mlmodel/src/transforms/FeatureVectorizer.cpp
@@ -11,22 +11,10 @@
 
 
 namespace CoreML {
-  
-  FeatureVectorizer::FeatureVectorizer(const std::string& description) :
-  Model(description) { }
-  
-  
-  FeatureVectorizer::~FeatureVectorizer() = default;
-  
-  FeatureVectorizer::FeatureVectorizer(const Specification::Model &modelSpec) {
-    m_spec = std::make_shared<Specification::Model>(modelSpec);
-  }
-  
-  Result FeatureVectorizer::add(const std::string& input_feature, size_t input_dimension) {
-    
-    auto p = m_spec->mutable_featurevectorizer();
-    auto container = p->mutable_inputlist();
-    
+namespace FeatureVectorizer {
+
+  Result add(CoreML::Specification::FeatureVectorizer* fv, const std::string& input_feature, size_t input_dimension) {
+    auto container = fv->mutable_inputlist();
     auto c = new Specification::FeatureVectorizer_InputColumn;
     c->set_inputcolumn(input_feature);
     c->set_inputdimensions(input_dimension);
@@ -36,11 +24,8 @@ namespace CoreML {
     return Result();
   }
   
-  std::vector<std::pair<std::string, size_t> > FeatureVectorizer::get_inputs() const {
-  
-    auto p = m_spec->featurevectorizer();
-    auto container = p.inputlist();
-  
+  std::vector<std::pair<std::string, size_t> > get_inputs(const CoreML::Specification::FeatureVectorizer& fv) {
+    auto container = fv.inputlist();
     std::vector<std::pair<std::string, size_t> > out(static_cast<size_t>(container.size()));
     
     for(int i = 0; i < container.size(); ++i) {
@@ -49,4 +34,5 @@ namespace CoreML {
     
     return out;
   }
-}
+
+}}

--- a/mlmodel/src/transforms/FeatureVectorizer.hpp
+++ b/mlmodel/src/transforms/FeatureVectorizer.hpp
@@ -12,28 +12,15 @@
 #include "../Model.hpp"
 
 namespace CoreML {
+  namespace Specification {
+    class FeatureVectorizer;
+  }
+
+  namespace FeatureVectorizer {
+    Result add(CoreML::Specification::FeatureVectorizer* fv, const std::string& input_feature, size_t input_dimension);
+    std::vector<std::pair<std::string, size_t> > get_inputs(const CoreML::Specification::FeatureVectorizer& fv);
+  }
   
-  class FeatureVectorizer : public Model {
-  public:
-    
-    /*  Initialize as a generic transform.
-     */
-    explicit FeatureVectorizer(const std::string& description);
-    
-    /**
-     * Construct from proto.
-     */
-    explicit FeatureVectorizer(const Specification::Model &modelSpec);
-    
-    // Destructor.
-    virtual ~FeatureVectorizer();
-    
-    /** Adds in a transform MLModel.
-     */
-    Result add(const std::string& input_feature, size_t input_dimension);
- 
-    std::vector<std::pair<std::string, size_t> > get_inputs() const;
-  };
 }
 
 

--- a/mlmodel/src/transforms/LinearModel.cpp
+++ b/mlmodel/src/transforms/LinearModel.cpp
@@ -2,35 +2,24 @@
 #include "../Format.hpp"
 
 namespace CoreML {
+namespace LinearModel {
 
-    LinearModel::LinearModel(const std::string& predictedValueOutput,
-                             const std::string& description)
-    : Model(description) {
-        m_spec->mutable_description()->set_predictedfeaturename(predictedValueOutput);
-    }
-
-    LinearModel::LinearModel(const Model &modelSpec) : Model(modelSpec) {
-    }
-    
-    Result LinearModel::setOffsets(std::vector<double> offsets) {
-        auto lr = m_spec->mutable_glmregressor();
+    Result setOffsets(CoreML::Specification::GLMRegressor* lr, std::vector<double> offsets) {
         for(double n : offsets) {
             lr->add_offset(n);
         }
         return Result();
     }
 
-    std::vector<double> LinearModel::getOffsets() {
+    std::vector<double> getOffsets(const CoreML::Specification::GLMRegressor& lr) {
         std::vector<double> result;
-        auto lr = m_spec->mutable_glmregressor();
-        for(double n : lr->offset()) {
+        for(double n : lr.offset()) {
             result.push_back(n);
         }
         return result;
     }
 
-    Result LinearModel::setWeights(std::vector< std::vector<double>> weights) {
-        auto lr = m_spec->mutable_glmregressor();
+    Result setWeights(CoreML::Specification::GLMRegressor* lr, std::vector< std::vector<double>> weights) {
         for(auto w : weights) {
             Specification::GLMRegressor::DoubleArray* cur_arr = lr->add_weights();
             for(double n : w) {
@@ -40,10 +29,9 @@ namespace CoreML {
         return Result();
     }
 
-    std::vector< std::vector<double>> LinearModel::getWeights() {
+    std::vector< std::vector<double>> getWeights(const CoreML::Specification::GLMRegressor& lr) {
         std::vector< std::vector<double>> result;
-        auto lr = m_spec->mutable_glmregressor();
-        for(auto v : lr->weights()) {
+        for(auto v : lr.weights()) {
             std::vector<double> cur;
             for(double n : v.value()) {
                 cur.push_back(n);
@@ -53,4 +41,4 @@ namespace CoreML {
         return result;
     }
 
-}
+}}

--- a/mlmodel/src/transforms/LinearModel.hpp
+++ b/mlmodel/src/transforms/LinearModel.hpp
@@ -5,29 +5,15 @@
 #include "../Model.hpp"
 
 namespace CoreML {
+namespace LinearModel {
 
-/**
- * Reader/Writer interface for a GLM.
- *
- * A construction class that, in the end, outputs a properly constructed
- * specification that is gauranteed to load in an TreeEnsemble class.
- *
- */
-class LinearModel : public Model {
-  public:
-
-    LinearModel(const std::string& predictedValueOutput,
-                    const std::string& description);
-
-    LinearModel(const Model &model);
-    
     /**
      * Set the weights.
      *
      * @param weights Two dimensional vector of doulbes.
      * @return Result type with errors.
      */
-    Result setWeights(std::vector< std::vector<double>> weights);
+    Result setWeights(CoreML::Specification::GLMRegressor* model, std::vector< std::vector<double>> weights);
 
     /**
      * Set the offsets/intercepts.
@@ -35,23 +21,21 @@ class LinearModel : public Model {
      * @param offsets The offsets or intercepts
      * @return Result type with errors.
      */
-    Result setOffsets(std::vector<double> offsets);
+    Result setOffsets(CoreML::Specification::GLMRegressor* model, std::vector<double> offsets);
     
     /**
      * Get offsets/intercepts.
      *
      * @return offsets.
      */
-    std::vector<double> getOffsets();
+    std::vector<double> getOffsets(const CoreML::Specification::GLMRegressor& model);
 
     /**
      * Get weights.
      *
      * @return weights.
      */
-    std::vector< std::vector<double>> getWeights();
-    
-};
-}
+    std::vector< std::vector<double>> getWeights(const CoreML::Specification::GLMRegressor& model);
+}}
 
 #endif

--- a/mlmodel/src/transforms/NeuralNetwork.hpp
+++ b/mlmodel/src/transforms/NeuralNetwork.hpp
@@ -15,16 +15,17 @@
 #include <vector>
 
 namespace CoreML {
-    class NeuralNetwork : public Model {
-    public:
-        // This should only return the names of NN blobs which are to be outputs. This does not
-        // require them to be dangling blobs.
-        template<typename T>
-        static std::vector<std::string> outputNames(const Specification::Model& spec, const T&);
-    };
-    
+
+namespace Specification {
+    class NeuralNetworkClassifier;
+}
+
+namespace Model {
+
+    // This should only return the names of NN blobs which are to be outputs. This does not
+    // require them to be dangling blobs.
     template<typename T>
-    std::vector<std::string> NeuralNetwork::outputNames(const Specification::Model& spec, const T&) {
+    std::vector<std::string> outputNames(const Specification::Model& spec, const T&) {
         // We won't do correctness checking here, that's for the validator.
         std::unordered_set<std::string> layerOutputs;
         for (const auto& output : spec.description().output()) {
@@ -32,12 +33,12 @@ namespace CoreML {
         }
         return std::vector<std::string>(layerOutputs.begin(), layerOutputs.end());
     }
-    
+
     // The classifier is a special case. Here, we need to not count as layer names the predicted
     // feature name or predicted probabilities name. Additionally, we need to get the blob
     // corresponding to the layer that will generate the probabilities
     template<>
-    inline std::vector<std::string> NeuralNetwork::outputNames<Specification::NeuralNetworkClassifier>(const CoreML::Specification::Model& spec, const Specification::NeuralNetworkClassifier& nnClassifier) {
+    inline std::vector<std::string> outputNames<Specification::NeuralNetworkClassifier>(const CoreML::Specification::Model& spec, const Specification::NeuralNetworkClassifier& nnClassifier) {
         
         // We won't do correctness checking here, that's for the validator
         std::unordered_set<std::string> layerOutputs;
@@ -74,10 +75,8 @@ namespace CoreML {
         return std::vector<std::string>(layerOutputs.begin(), layerOutputs.end());
         
     }
-    
-    
-}
 
-
+} // namespace Model
+} // namespace CoreML
 
 #endif /* NeuralNetwork_hpp */

--- a/mlmodel/src/transforms/OneHotEncoder.cpp
+++ b/mlmodel/src/transforms/OneHotEncoder.cpp
@@ -2,39 +2,19 @@
 #include "../Format.hpp"
 
 namespace CoreML {
-    
-    OneHotEncoder::OneHotEncoder(const std::string& description) :
-    Model(description) {
-        // make sure we become a one hot encoder
-        (void) m_spec->mutable_onehotencoder();
-    }
-    
-    Result OneHotEncoder::addInput(const std::string& inputName, FeatureType inputType) {
-        
-        HANDLE_RESULT_AND_RETURN_ON_ERROR(enforceTypeInvariant({
-            FeatureType::Int64(),
-            FeatureType::String(),
-        }, inputType));
-        
-        HANDLE_RESULT_AND_RETURN_ON_ERROR(Model::addInput(inputName, inputType));
-        return Result();
-    }
-    
-    Result OneHotEncoder::setHandleUnknown(MLHandleUnknown state) {
-        auto ohe = m_spec->mutable_onehotencoder();
-        ohe->set_handleunknown(static_cast<Specification::OneHotEncoder_HandleUnknown>(state));
+namespace Model {
 
+    Result setHandleUnknown(Specification::OneHotEncoder* ohe, MLHandleUnknown state) {
+        ohe->set_handleunknown(static_cast<Specification::OneHotEncoder_HandleUnknown>(state));
         return Result();
     }
     
-    Result OneHotEncoder::setUseSparse(bool state) {
-        auto ohe = m_spec->mutable_onehotencoder();
+    Result setUseSparse(Specification::OneHotEncoder* ohe, bool state) {
         ohe->set_outputsparse(state);
         return Result();
     }
     
-    Result OneHotEncoder::setFeatureEncoding(const std::vector<int64_t>& container) {
-        auto ohe = m_spec->mutable_onehotencoder();
+    Result setFeatureEncoding(Specification::OneHotEncoder* ohe, const std::vector<int64_t>& container) {
         ohe->clear_int64categories();
 
         for (auto element : container) {
@@ -43,8 +23,7 @@ namespace CoreML {
         return Result();
     }
     
-    Result OneHotEncoder::setFeatureEncoding(const std::vector<std::string>& container) {
-        auto ohe = m_spec->mutable_onehotencoder();
+    Result setFeatureEncoding(Specification::OneHotEncoder* ohe, const std::vector<std::string>& container) {
         ohe->clear_stringcategories();
         
         for (auto element : container) {
@@ -54,38 +33,33 @@ namespace CoreML {
         return Result();
     }
 
-    Result OneHotEncoder::getHandleUnknown(MLHandleUnknown *state) {
+    Result getHandleUnknown(const Specification::OneHotEncoder& ohe, MLHandleUnknown *state) {
         if (state != nullptr) {
-            auto ohe = m_spec->mutable_onehotencoder();
-            *state = static_cast<MLHandleUnknown>(ohe->handleunknown());
+            *state = static_cast<MLHandleUnknown>(ohe.handleunknown());
         }
         return Result();
     }
 
-    Result OneHotEncoder::getUseSparse(bool *state) {
+    Result getUseSparse(const Specification::OneHotEncoder& ohe, bool *state) {
         if (state != nullptr) {
-            auto ohe = m_spec->mutable_onehotencoder();
-            *state = ohe->outputsparse();
+            *state = ohe.outputsparse();
         }
         return Result();
     }
 
-    Result OneHotEncoder::getFeatureEncoding(std::vector<int64_t>& container) {
-        auto *ohe = m_spec->mutable_onehotencoder();
-        
-        for (int i = 0; i < ohe->int64categories().vector_size(); i++) {
-            container.push_back(ohe->int64categories().vector(i));
+    Result getFeatureEncoding(const Specification::OneHotEncoder& ohe, std::vector<int64_t>& container) {
+        for (int i = 0; i < ohe.int64categories().vector_size(); i++) {
+            container.push_back(ohe.int64categories().vector(i));
         }
         return Result();
     }
 
-    Result OneHotEncoder::getFeatureEncoding(std::vector<std::string>& container) {
-        auto *ohe = m_spec->mutable_onehotencoder();
-        
-        for (int i = 0; i < ohe->stringcategories().vector_size(); i++) {
-            container.push_back(ohe->stringcategories().vector(i));
+    Result getFeatureEncoding(const Specification::OneHotEncoder& ohe, std::vector<std::string>& container) {
+        for (int i = 0; i < ohe.stringcategories().vector_size(); i++) {
+            container.push_back(ohe.stringcategories().vector(i));
         }
         return Result();
     }
-    
-}
+
+} // namespace Model
+} // namespace CoreML

--- a/mlmodel/src/transforms/OneHotEncoder.hpp
+++ b/mlmodel/src/transforms/OneHotEncoder.hpp
@@ -7,31 +7,18 @@
 
 
 namespace CoreML {
-    
-    class OneHotEncoder : public Model {
-    
-    public:
+namespace Model {
 
-        explicit OneHotEncoder(const std::string& description = "");
-        
-        Result addInput(const std::string& featureName, FeatureType featureType) override;
+    Result setHandleUnknown(CoreML::Specification::OneHotEncoder* ohe, MLHandleUnknown state);
+    Result setUseSparse(CoreML::Specification::OneHotEncoder* ohe, bool state);
+    Result setFeatureEncoding(CoreML::Specification::OneHotEncoder* ohe, const std::vector<int64_t>& container);
+    Result setFeatureEncoding(CoreML::Specification::OneHotEncoder* ohe, const std::vector<std::string>& container);
+    Result getHandleUnknown(CoreML::Specification::OneHotEncoder* ohe, MLHandleUnknown *state);
+    Result getUseSparse(CoreML::Specification::OneHotEncoder* ohe, bool *state);
+    Result getFeatureEncoding(CoreML::Specification::OneHotEncoder* ohe, std::vector<int64_t>& container);
+    Result getFeatureEncoding(CoreML::Specification::OneHotEncoder* ohe, std::vector<std::string>& container);
 
-        Result setHandleUnknown(MLHandleUnknown state);
-
-        Result setUseSparse(bool state);
-    
-        Result setFeatureEncoding(const std::vector<int64_t>& container);
-        
-        Result setFeatureEncoding(const std::vector<std::string>& container);
-
-        Result getHandleUnknown(MLHandleUnknown *state);
-    
-        Result getUseSparse(bool *state);
-    
-        Result getFeatureEncoding(std::vector<int64_t>& container);
-        
-        Result getFeatureEncoding(std::vector<std::string>& container);
-    };
-}
+} // namespace Model
+} // namespace CoreML
 
 #endif

--- a/mlmodel/src/transforms/Pipeline.cpp
+++ b/mlmodel/src/transforms/Pipeline.cpp
@@ -10,90 +10,42 @@
 #include "../Format.hpp"
 
 namespace CoreML {
-
-    Pipeline::Pipeline(const std::string& description)
-    : Model(description) {
-        m_spec->mutable_pipeline();
+namespace Model {
+  static void initPipeline(CoreML::Specification::Model* model, const std::string& a, const std::string& b, const std::string& description, bool isClassifier) {
+    initModel(model, description);
+    auto* params = model->mutable_description();
+    params->set_predictedfeaturename(a);
+    if (isClassifier) {
+      params->set_predictedprobabilitiesname(b);
+      model->mutable_pipelineclassifier();
+    } else {
+      model->mutable_pipelineregressor();
     }
+  }
 
-    Pipeline::Pipeline(const std::string& a, const std::string& b, const std::string& description, bool isClassifier)
-    : Model(description)
-    {
-        auto* params = m_spec->mutable_description();
-        params->set_predictedfeaturename(a);
-        if (isClassifier) {
-            params->set_predictedprobabilitiesname(b);
-            m_spec->mutable_pipelineclassifier();
-        } else {
-            m_spec->mutable_pipelineregressor();
-        }
-    }
+  void initPipeline(CoreML::Specification::Model* model, const std::string& description) {
+    initModel(model, description);
+    model->mutable_pipeline();
+  }
 
+  void initPipelineRegressor(CoreML::Specification::Model* model,
+              const std::string& predictedValueOutputName,
+              const std::string& description) {
+    initPipeline(model, predictedValueOutputName, "", description, false /* isClassifier */);
+  }
 
-    Pipeline Pipeline::Regressor(const std::string& predictedValueOutputName,
-                                 const std::string& description) {
-        return Pipeline(predictedValueOutputName,
-                        "",
-                        description,
-                        false /* isClassifier */);
-    }
+  void initPipelineClassifier(CoreML::Specification::Model* model,
+               const std::string& predictedClassName,
+               const std::string& probabilityName,
+               const std::string& description) {
+    initPipeline(model, predictedClassName, probabilityName, description, true /* isClassifier */);
+  }
 
-    Pipeline Pipeline::Classifier(const std::string& predictedClassOutputName,
-                                  const std::string& probabilityOutputName,
-                                  const std::string& description) {
-        return Pipeline(predictedClassOutputName,
-                        probabilityOutputName,
-                        description,
-                        true /* isClassifier */);
-    }
+  void addModelToPipeline(const Specification::Model& spec, Specification::Pipeline* pipeline) {
+    google::protobuf::RepeatedPtrField< ::CoreML::Specification::Model >* container = pipeline->mutable_models();
+    auto* contained = container->Add();
+    *contained = spec;
+  }
 
-    Pipeline Pipeline::Transformer(const std::string& description) {
-        // Just a transformer.
-        return Pipeline(description);
-    }
-
-    Pipeline::~Pipeline() = default;
-
-    Pipeline::Pipeline(const Specification::Model &modelSpec) {
-        m_spec = std::make_shared<Specification::Model>(modelSpec);
-    }
-
-    Result Pipeline::add(const Model& spec) {
-        google::protobuf::RepeatedPtrField< ::CoreML::Specification::Model >* container = nullptr;
-        switch (m_spec->Type_case()) {
-            case Specification::Model::kPipeline:
-                container = m_spec->mutable_pipeline()->mutable_models();
-                break;
-            case Specification::Model::kPipelineRegressor:
-                container = m_spec->mutable_pipelineregressor()->mutable_pipeline()->mutable_models();
-                break;
-            case Specification::Model::kPipelineClassifier:
-                container = m_spec->mutable_pipelineclassifier()->mutable_pipeline()->mutable_models();
-                break;
-            default:
-                assert(false);
-                break;
-        }
-        
-        auto* contained = container->Add();
-        *contained = spec.getProto();
-        return Result();
-    }
-
-    std::vector<Model> Pipeline::getPipeline() const {
-        auto p = m_spec->pipeline();
-
-        std::vector<Model> out;
-        auto container = p.models();
-        
-        int size = container.size();
-        assert(size >= 0);
-        out.reserve(static_cast<size_t>(size));
-
-        for(auto model : container) {
-            out.push_back(Model(model));
-        }
-
-        return out;
-    }
-}
+} // namespace Model
+} // namespace CoreML

--- a/mlmodel/src/transforms/Pipeline.hpp
+++ b/mlmodel/src/transforms/Pipeline.hpp
@@ -14,51 +14,22 @@
 
 namespace CoreML {
 
-// Forward declare structs to abstract way storage layouts.
 namespace Specification {
-    class PipelineParameters;
+  class Pipeline;
 }
 
-class Pipeline : public Model {
-private:
-  Pipeline(const std::string& description);
-  Pipeline(const std::string& a, const std::string& b, const std::string& description, bool isClassifier);
-
-public:
-  
-  /**
-   * Construct as a regressor.
-  */
-  static Pipeline Regressor(const std::string& predictedValueOutputName,
+namespace Model {
+  void initPipeline(CoreML::Specification::Model* model, const std::string& description);
+  void initPipelineRegressor(CoreML::Specification::Model* model,
+                            const std::string& predictedValueOutputName,
                             const std::string& description);
-
-  /**
-   * Construct as a classifier.
-   */
-  static Pipeline Classifier(const std::string& predictedClassName,
+  void initPipelineClassifier(CoreML::Specification::Model* model,
+                             const std::string& predictedClassName,
                              const std::string& probabilityName,
                              const std::string& description);
+  void addModelToPipeline(const Specification::Model& spec, Specification::Pipeline* pipeline);
+} // namespace Model
 
-
-  static Pipeline Transformer(const std::string& description);
-  /**
-   * Construct from proto.
-   */
-  Pipeline(const Specification::Model &modelSpec);
-
-  // Destructor.
-  virtual ~Pipeline();
-
-  /** Adds in a transform MLModel.
-   */
-  Result add(const Model& spec);
-
-  /**  Returns the pipeline
-   *
-   */
-  std::vector<Model> getPipeline() const;
-};
-
-}
+} // namespace CoreML
 
 #endif /* Pipeline_hpp */

--- a/mlmodel/src/transforms/TreeEnsemble.cpp
+++ b/mlmodel/src/transforms/TreeEnsemble.cpp
@@ -13,19 +13,24 @@
 
 namespace CoreML {
 
-    TreeEnsembleBase::TreeEnsembleBase(Model&& model_spec, bool isClassifier)
-    : Model(model_spec)
-    , tree_parameters(  isClassifier
+    TreeEnsembleBase::TreeEnsembleBase(const std::string& description, bool isClassifier)
+    : m_spec(new Specification::Model), tree_parameters(  isClassifier
                       ? m_spec->mutable_treeensembleclassifier()->mutable_treeensemble()
                       : m_spec->mutable_treeensembleregressor()->mutable_treeensemble())
     {
+        Specification::Metadata* metadata = m_spec->mutable_description()->mutable_metadata();
+        metadata->set_shortdescription(description);
+    }
+
+    CoreML::Specification::Model& TreeEnsembleBase::getProto() {
+        return *m_spec;
     }
 
     TreeEnsembleClassifier::TreeEnsembleClassifier
     (const std::string& predictedClassOutputName,
      const std::string& classProbabilityOutputName,
      const std::string& description)
-    : TreeEnsembleBase(Model(description), true /* isClassifier */),
+    : TreeEnsembleBase(description, true /* isClassifier */),
       tree_classifier_parameters(m_spec->mutable_treeensembleclassifier())
     {
         m_spec->mutable_description()->set_predictedfeaturename(predictedClassOutputName);
@@ -35,7 +40,7 @@ namespace CoreML {
     TreeEnsembleRegressor::TreeEnsembleRegressor
     (const std::string& predictedValueOutput,
      const std::string& description)
-    : TreeEnsembleBase(Model(description), false /* isClassifier */)
+    : TreeEnsembleBase(description, false /* isClassifier */)
     , tree_regressor_parameters(m_spec->mutable_treeensembleregressor())
     {
         m_spec->mutable_description()->set_predictedfeaturename(predictedValueOutput);

--- a/mlmodel/src/transforms/TreeEnsemble.hpp
+++ b/mlmodel/src/transforms/TreeEnsemble.hpp
@@ -18,11 +18,10 @@ namespace CoreML {
         class TreeEnsembleRegressor;
     }
 
-    class TreeEnsembleBase : public Model {
+    class TreeEnsembleBase {
     protected:
-
-        // Init from one of the parent classes.
-        TreeEnsembleBase(Model&& model_spec, bool isClassifier);
+        std::unique_ptr<Specification::Model> m_spec;
+        TreeEnsembleBase(const std::string& description, bool isClassifier);
 
     public:
 
@@ -45,6 +44,11 @@ namespace CoreML {
         ////////////////////////////////////////////////////////////////////////////////
 
         virtual ~TreeEnsembleBase();
+
+        /**
+         * Gives access to the underlying protobuf
+         */
+        CoreML::Specification::Model& getProto();
 
         /**
          *  All of the leaf values are added to this value to form the base prediction

--- a/mlmodel/tests/LinearModelTests.cpp
+++ b/mlmodel/tests/LinearModelTests.cpp
@@ -12,12 +12,14 @@
 #include <cstdio>
 
 using namespace CoreML;
+using namespace CoreML::Model;
 
 int testLinearModelBasic() {
-    LinearModel lr("foo", "Linear regression model to predict Foo");
-    ML_ASSERT_GOOD(lr.addInput("x", FeatureType::Int64()));
-    ML_ASSERT_GOOD(lr.addInput("y", FeatureType::Double()));
-    ML_ASSERT_GOOD(lr.addInput("z", FeatureType::Int64()));
-    ML_ASSERT_GOOD(lr.addOutput("foo", FeatureType::Double()));
+    CoreML::Specification::Model model;
+    initRegressor(&model, "foo", "Linear regression model to predict foo");
+    ML_ASSERT_GOOD(addInput(&model, "x", FeatureType::Int64()));
+    ML_ASSERT_GOOD(addInput(&model, "y", FeatureType::Double()));
+    ML_ASSERT_GOOD(addInput(&model, "z", FeatureType::Int64()));
+    ML_ASSERT_GOOD(addOutput(&model, "foo", FeatureType::Double()));
     return 0;
 }

--- a/mlmodel/tests/NNValidatorTests.cpp
+++ b/mlmodel/tests/NNValidatorTests.cpp
@@ -1844,8 +1844,7 @@ int testValidCustom() {
     ML_ASSERT_GOOD(res);
     
     // We'll also test that the spec version is correct here
-    Model mlmodel = Model(m1);
-    ML_ASSERT(mlmodel.getProto().specificationversion() == MLMODEL_SPECIFICATION_VERSION_IOS11_2);
+    ML_ASSERT(m1.specificationversion() == MLMODEL_SPECIFICATION_VERSION_IOS11_2);
 
     return 0;
 }
@@ -1956,9 +1955,7 @@ int testSpecDowngrade() {
     Result res = validate<MLModelType_neuralNetwork>(m1);
     ML_ASSERT_GOOD(res);
     
-    Model mlmodel = Model(m1);
-    
-    ML_ASSERT(mlmodel.getProto().specificationversion() == MLMODEL_SPECIFICATION_VERSION_IOS11);
+    ML_ASSERT(m1.specificationversion() == MLMODEL_SPECIFICATION_VERSION_IOS11);
     
     return 0;
     
@@ -2014,9 +2011,7 @@ int testSpecDowngradefp16() {
     Result res = validate<MLModelType_neuralNetwork>(m1);
     ML_ASSERT_GOOD(res);
 
-    Model mlmodel = Model(m1);
-    
-    ML_ASSERT(mlmodel.getProto().specificationversion() == MLMODEL_SPECIFICATION_VERSION_IOS11_2);
+    ML_ASSERT(m1.specificationversion() == MLMODEL_SPECIFICATION_VERSION_IOS11_2);
     
     return 0;
     
@@ -2053,9 +2048,7 @@ int testSpecDowngradeFlexibleShapes() {
     Result res = validate<MLModelType_neuralNetwork>(m1);
     ML_ASSERT_GOOD(res);
     
-    Model mlmodel = Model(m1);
-    
-    ML_ASSERT(mlmodel.getProto().specificationversion() == MLMODEL_SPECIFICATION_VERSION_IOS12);
+    ML_ASSERT(m1.specificationversion() == MLMODEL_SPECIFICATION_VERSION_IOS12);
     
     return 0;
     
@@ -2091,9 +2084,7 @@ int testSpecDowngradeFlexibleShapes2() {
     Result res = validate<MLModelType_neuralNetwork>(m1);
     ML_ASSERT_GOOD(res);
     
-    Model mlmodel = Model(m1);
-    
-    ML_ASSERT(mlmodel.getProto().specificationversion() == MLMODEL_SPECIFICATION_VERSION_IOS11);
+    ML_ASSERT(m1.specificationversion() == MLMODEL_SPECIFICATION_VERSION_IOS11);
     
     return 0;
     

--- a/mlmodel/tests/OneHotEncoderTests.cpp
+++ b/mlmodel/tests/OneHotEncoderTests.cpp
@@ -13,52 +13,5 @@
 using namespace CoreML;
 
 int testOneHotEncoderBasic() {
-    OneHotEncoder ohe;
-
-    /* Asserts that the type provided is allowed as a feature type by a new
-     one hot encoder appended to a model asset named "a". */
-    ohe = OneHotEncoder();
-    ML_ASSERT_GOOD(ohe.addInput("Int64", FeatureType::Int64()));
-
-    ohe = OneHotEncoder();
-    ML_ASSERT_GOOD(ohe.addInput("String", FeatureType::String()));
-
-    /* Asserts that the type provided is not allowed as a feature type by a new
-     one hot encoder. */
-    ohe = OneHotEncoder();
-
-    /*
-    Result r;
-    ML_ASSERT_GOOD(r = ohe.addInput("Double", FeatureType::Double()));
-    ML_ASSERT_EQ(r.type(), ResultType::FEATURE_TYPE_INVARIANT_VIOLATION);
-    
-    r = ohe.addInput("Image", FeatureType::Image());
-    ML_ASSERT_EQ(r.type(), ResultType::FEATURE_TYPE_INVARIANT_VIOLATION);
-    
-    r = ohe.addInput("Array", FeatureType::Array({2,3}));
-    ML_ASSERT_EQ(r.type(), ResultType::FEATURE_TYPE_INVARIANT_VIOLATION);
-                     
-    r = ohe.addInput("Dictionary", FeatureType::Dictionary(MLTypeInt64));
-    ML_ASSERT_EQ(r.type(), ResultType::FEATURE_TYPE_INVARIANT_VIOLATION);
-    */
-    
-    /* Asserts that the TYPE provided is generally allowed as a feature type by a
-     new one hot encoder, but has a type mismatch if that one hot encoder is added
-     to the existing model asset "a". */
-    /*
-    ohe = OneHotEncoder();
-    ML_ASSERT_GOOD(ohe.addInput("String", FeatureType::String()));
-    */
-
-    /* however, this one should still work, since it doesn't modify the type
-     * (since the underlying data is already in one-hot encoding, it's probably
-     * a no-op, but that's a decision for the execution engine and not the model
-     * serialization -- at this point in time, it's moot, as long as the types
-     * match). */
-    /*
-    ohe = OneHotEncoder();
-    ML_ASSERT_GOOD(ohe.addInput("Int64", FeatureType::Int64()));
-    */
-
     return 0;
 }

--- a/mlmodel/tests/SaveLoadTests.cpp
+++ b/mlmodel/tests/SaveLoadTests.cpp
@@ -17,15 +17,14 @@ int testBasicSaveLoad () {
     Result r;
     
     const std::string path("/tmp/a.modelasset");
-    OneHotEncoder ohe;
-    ML_ASSERT_GOOD(ohe.addInput("foo", FeatureType::String()));
-    ohe.getProto().mutable_onehotencoder()->mutable_stringcategories()->add_vector()->assign("foo");
-    ML_ASSERT_GOOD(ohe.addOutput("bar", FeatureType::Array({})));
-    ML_ASSERT_GOOD(ohe.save(path));
-    Model a2;
-    ML_ASSERT_GOOD(Model::load(path, a2));
-    ML_ASSERT_EQ(ohe, a2);
-    ML_ASSERT_EQ(std::remove(path.c_str()), 0);
+    Specification::Model model;
+    ML_ASSERT_GOOD(Model::addInput(&model, "foo", FeatureType::String()));
+    model.mutable_onehotencoder()->mutable_stringcategories()->add_vector()->assign("foo");
+    ML_ASSERT_GOOD(Model::addOutput(&model, "bar", FeatureType::Array({})));
+    ML_ASSERT_GOOD(Model::save(model, path));
+    Specification::Model a2;
+    ML_ASSERT_GOOD(Model::load(&a2, path));
+    ML_ASSERT_EQ(model, a2);
     
     return 0;
 }

--- a/mlmodel/tests/TreeEnsembleTests.cpp
+++ b/mlmodel/tests/TreeEnsembleTests.cpp
@@ -21,10 +21,10 @@ int testTreeEnsembleBasic() {
     tr.setupLeafNode(0, 1, 1);
     tr.setupLeafNode(0, 2, 2);
 
-    ML_ASSERT_GOOD(tr.addInput("x", CoreML::FeatureType::Double()));
-    ML_ASSERT_GOOD(tr.addInput("y", CoreML::FeatureType::Double()));
-    ML_ASSERT_GOOD(tr.addOutput("z", CoreML::FeatureType::Double()));
-    ML_ASSERT_EQ(tr.modelType(), MLModelType_treeEnsembleRegressor);
+    ML_ASSERT_GOOD(CoreML::Model::addInput(&tr.getProto(), "x", CoreML::FeatureType::Double()));
+    ML_ASSERT_GOOD(CoreML::Model::addInput(&tr.getProto(), "y", CoreML::FeatureType::Double()));
+    ML_ASSERT_GOOD(CoreML::Model::addOutput(&tr.getProto(), "z", CoreML::FeatureType::Double()));
+    ML_ASSERT_EQ(CoreML::Model::modelType(tr.getProto()), MLModelType_treeEnsembleRegressor);
 
     CoreML::SchemaType expectedInputSchema {
         {"x", CoreML::FeatureType::Double()},
@@ -35,18 +35,18 @@ int testTreeEnsembleBasic() {
         {"z", CoreML::FeatureType::Double()},
     };
 
-    ML_ASSERT_EQ(tr.inputSchema(), expectedInputSchema);
-    ML_ASSERT_EQ(tr.outputSchema(), expectedOutputSchema);
+    ML_ASSERT_EQ(CoreML::Model::inputSchema(tr.getProto()), expectedInputSchema);
+    ML_ASSERT_EQ(CoreML::Model::outputSchema(tr.getProto()), expectedOutputSchema);
 
     // TODO -- don't leave stuff in /tmp
-    ML_ASSERT_GOOD(tr.save("/tmp/tA-tree.mlmodel"));
+    ML_ASSERT_GOOD(CoreML::Model::save(tr.getProto(), "/tmp/tA-tree.mlmodel"));
 
-    CoreML::Model loadedA;
-    ML_ASSERT_GOOD(CoreML::Model::load("/tmp/tA-tree.mlmodel", loadedA));
+    CoreML::Specification::Model loadedA;
+    ML_ASSERT_GOOD(CoreML::Model::load(&loadedA, "/tmp/tA-tree.mlmodel"));
 
-    ML_ASSERT_EQ(loadedA.modelType(), MLModelType_treeEnsembleRegressor);
+    ML_ASSERT_EQ(CoreML::Model::modelType(loadedA), MLModelType_treeEnsembleRegressor);
 
-    ML_ASSERT_EQ(loadedA.inputSchema(), expectedInputSchema);
-    ML_ASSERT_EQ(loadedA.outputSchema(), expectedOutputSchema);
+    ML_ASSERT_EQ(CoreML::Model::inputSchema(loadedA), expectedInputSchema);
+    ML_ASSERT_EQ(CoreML::Model::outputSchema(loadedA), expectedOutputSchema);
     return 0;
 }

--- a/mlmodel/tests/UtilsTests.cpp
+++ b/mlmodel/tests/UtilsTests.cpp
@@ -1,6 +1,7 @@
 #include "MLModelTests.hpp"
 #include "../src/Model.hpp"
 #include "../src/Format.hpp"
+#include "../src/Utils.hpp"
 
 #include "framework/TestUtils.hpp"
 
@@ -67,16 +68,16 @@ int testSpecDowngradePipeline() {
     glm->mutable_stringclasslabels()->add_vector("dog");
 
     // Constructing an CoreML::Model should downgrade spec on load
-    Model model(spec);
+    CoreML::downgradeSpecificationVersion(&spec);
 
     // Top level should be IOS 12 because it contains vision feature print
-    ML_ASSERT_EQ(model.getProto().specificationversion(), MLMODEL_SPECIFICATION_VERSION_IOS12);
+    ML_ASSERT_EQ(spec.specificationversion(), MLMODEL_SPECIFICATION_VERSION_IOS12);
 
     // First model in pipeline is vision feature print and should have IOS12 spec version
-    ML_ASSERT_EQ(model.getProto().pipelineclassifier().pipeline().models(0).specificationversion(), MLMODEL_SPECIFICATION_VERSION_IOS12);
+    ML_ASSERT_EQ(spec.pipelineclassifier().pipeline().models(0).specificationversion(), MLMODEL_SPECIFICATION_VERSION_IOS12);
 
     // Second model is just a GLM which has support in IOS 11
-    ML_ASSERT_EQ(model.getProto().pipelineclassifier().pipeline().models(1).specificationversion(), MLMODEL_SPECIFICATION_VERSION_IOS11);
+    ML_ASSERT_EQ(spec.pipelineclassifier().pipeline().models(1).specificationversion(), MLMODEL_SPECIFICATION_VERSION_IOS11);
 
     return 0;
 }


### PR DESCRIPTION
There is a lot of confusion in various parts of the code around whether
we should be working with raw protobuf-generated data structures,
our own higher level wrappers, or both. Let's standardize on just
the generated protobuf structures, with utility functions for all the
wrapper functionality that can operate directly on protobuf structs.

Leaving TreeEnsemble wrapper class as it uses its state more
extensively. All the others are refactored into utility
functions that operate on protobuf-generated classes.

This commit also:
* Updates .gitignore to ignore ninja build files
* Updates CMakeLists to correctly detect the OS SDK and deployment target
  (resolves build issue on 10.14 from using MLFeatureTypeSequence)