### PR TITLE
Fixes to facilitate source drops into Turi Create

### DIFF
--- a/mlmodel/src/NeuralNetworkValidator.cpp
+++ b/mlmodel/src/NeuralNetworkValidator.cpp
@@ -1819,7 +1819,7 @@ namespace CoreML {
         // This isn't true for classifiers and regressors -- need to template specialize it to make these work
         if (!std::all_of(interface.output().begin(),
                          interface.output().end(),
-                         [](const auto& output) {
+                         [](const Specification::FeatureDescription& output) {
                              return output.type().Type_case() == Specification::FeatureType::kMultiArrayType ||
                                     output.type().Type_case() == Specification::FeatureType::kImageType;
                          })) {

--- a/mlmodel/src/NonMaximumSuppressionValidator.cpp
+++ b/mlmodel/src/NonMaximumSuppressionValidator.cpp
@@ -253,7 +253,7 @@ namespace CoreML {
         }
         
         // For now, require consistent usage of new/old
-        if (confUseOld && !coordsUseOld || confUseNew && !coordsUseNew) {
+        if ((confUseOld && !coordsUseOld) || (confUseNew && !coordsUseNew)) {
             return Result(ResultType::INVALID_MODEL_PARAMETERS,
                           "Confidence and coordinates cannot use a mix of shape (deprecated) and allowedShapes.");
         }

--- a/mlmodel/src/QuantizationValidationUtils.cpp
+++ b/mlmodel/src/QuantizationValidationUtils.cpp
@@ -8,7 +8,7 @@
 #include <stdio.h>
 #include <string>
 #include <vector>
-#include "MLModelSpecification.hpp"
+#include "ValidatorUtils-inl.hpp"
 #include "QuantizationValidationUtils.hpp"
 
 namespace CoreML {

--- a/mlmodel/src/QuantizationValidationUtils.hpp
+++ b/mlmodel/src/QuantizationValidationUtils.hpp
@@ -13,7 +13,7 @@
 #include <string>
 #include <vector>
 
-#include "MLModelSpecification.hpp"
+#include "Format.hpp"
 
 namespace CoreML {
     inline uint64_t bitsToBytesCeil(uint64_t nBits){

--- a/mlmodel/src/ValidatorUtils-inl.hpp
+++ b/mlmodel/src/ValidatorUtils-inl.hpp
@@ -11,6 +11,7 @@
 
 #include "Comparison.hpp"
 #include "Format.hpp"
+#include "Result.hpp"
 #include "../build/format/FeatureTypes_enums.h"
 #include <sstream>
 


### PR DESCRIPTION
- For compatibility with pre-C++14, don't use auto in lambda arguments
- To avoid a warning, use parentheses to make explicit the precedence of && over ||
- QuantizationValidationUtil.{hpp,cpp} can #include only files inside the MLModel directory (the portion dropped into Turi Create)
- ValidatorUtils-inl.hpp should include Result.hpp instead of relying on its clients to include Result.hpp first