### PR TITLE
Switch to __attribute__((__unused__))

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ add_subdirectory(deps)
 add_subdirectory(mlmodel)
 
 if("${PYTHON}" STREQUAL "")
-  find_program(PYTHON NAMES python3 python)
+  find_program(PYTHON NAMES python python3)
 endif()
 if("${PYTHON_MAJOR_VERSION}" STREQUAL "")
   exec_program(${PYTHON}
@@ -31,7 +31,7 @@ if("${PYTHON_VERSION}" STREQUAL "")
 endif()
 
 if("${PYTHON_CONFIG}" STREQUAL "")
-  find_program(PYTHON_CONFIG NAMES python3-config python-config)
+  find_program(PYTHON_CONFIG NAMES python-config python3-config)
 endif()
 exec_program(${PYTHON_CONFIG}
   ARGS "--includes"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ add_subdirectory(deps)
 add_subdirectory(mlmodel)
 
 if("${PYTHON}" STREQUAL "")
-  find_program(PYTHON NAMES python python3)
+  find_program(PYTHON NAMES python3 python)
 endif()
 if("${PYTHON_MAJOR_VERSION}" STREQUAL "")
   exec_program(${PYTHON}
@@ -31,7 +31,7 @@ if("${PYTHON_VERSION}" STREQUAL "")
 endif()
 
 if("${PYTHON_CONFIG}" STREQUAL "")
-  find_program(PYTHON_CONFIG NAMES python-config python3-config)
+  find_program(PYTHON_CONFIG NAMES python3-config python-config)
 endif()
 exec_program(${PYTHON_CONFIG}
   ARGS "--includes"

--- a/mlmodel/build/format/ArrayFeatureExtractor_enums.h
+++ b/mlmodel/build/format/ArrayFeatureExtractor_enums.h
@@ -1,6 +1,3 @@
 #ifndef __ARRAYFEATUREEXTRACTOR_ENUMS_H
 #define __ARRAYFEATUREEXTRACTOR_ENUMS_H
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
-#pragma clang diagnostic pop
 #endif

--- a/mlmodel/build/format/BayesianProbitRegressor_enums.h
+++ b/mlmodel/build/format/BayesianProbitRegressor_enums.h
@@ -1,6 +1,3 @@
 #ifndef __BAYESIANPROBITREGRESSOR_ENUMS_H
 #define __BAYESIANPROBITREGRESSOR_ENUMS_H
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
-#pragma clang diagnostic pop
 #endif

--- a/mlmodel/build/format/CategoricalMapping_enums.h
+++ b/mlmodel/build/format/CategoricalMapping_enums.h
@@ -1,13 +1,12 @@
 #ifndef __CATEGORICALMAPPING_ENUMS_H
 #define __CATEGORICALMAPPING_ENUMS_H
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
 enum MLCategoricalMappingMappingType: int {
     MLCategoricalMappingMappingType_stringToInt64Map = 1,
     MLCategoricalMappingMappingType_int64ToStringMap = 2,
     MLCategoricalMappingMappingType_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLCategoricalMappingMappingType_Name(MLCategoricalMappingMappingType x) {
     switch (x) {
         case MLCategoricalMappingMappingType_stringToInt64Map:
@@ -25,6 +24,7 @@ enum MLCategoricalMappingValueOnUnknown: int {
     MLCategoricalMappingValueOnUnknown_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLCategoricalMappingValueOnUnknown_Name(MLCategoricalMappingValueOnUnknown x) {
     switch (x) {
         case MLCategoricalMappingValueOnUnknown_strValue:
@@ -36,5 +36,4 @@ static const char * MLCategoricalMappingValueOnUnknown_Name(MLCategoricalMapping
     }
 }
 
-#pragma clang diagnostic pop
 #endif

--- a/mlmodel/build/format/CustomModel_enums.h
+++ b/mlmodel/build/format/CustomModel_enums.h
@@ -1,7 +1,5 @@
 #ifndef __CUSTOMMODEL_ENUMS_H
 #define __CUSTOMMODEL_ENUMS_H
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
 enum MLCustomModelParamValuevalue: int {
     MLCustomModelParamValuevalue_doubleValue = 10,
     MLCustomModelParamValuevalue_stringValue = 20,
@@ -12,6 +10,7 @@ enum MLCustomModelParamValuevalue: int {
     MLCustomModelParamValuevalue_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLCustomModelParamValuevalue_Name(MLCustomModelParamValuevalue x) {
     switch (x) {
         case MLCustomModelParamValuevalue_doubleValue:
@@ -31,5 +30,4 @@ static const char * MLCustomModelParamValuevalue_Name(MLCustomModelParamValueval
     }
 }
 
-#pragma clang diagnostic pop
 #endif

--- a/mlmodel/build/format/DataStructures_enums.h
+++ b/mlmodel/build/format/DataStructures_enums.h
@@ -1,6 +1,3 @@
 #ifndef __DATASTRUCTURES_ENUMS_H
 #define __DATASTRUCTURES_ENUMS_H
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
-#pragma clang diagnostic pop
 #endif

--- a/mlmodel/build/format/DictVectorizer_enums.h
+++ b/mlmodel/build/format/DictVectorizer_enums.h
@@ -1,13 +1,12 @@
 #ifndef __DICTVECTORIZER_ENUMS_H
 #define __DICTVECTORIZER_ENUMS_H
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
 enum MLDictVectorizerMap: int {
     MLDictVectorizerMap_stringToIndex = 1,
     MLDictVectorizerMap_int64ToIndex = 2,
     MLDictVectorizerMap_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLDictVectorizerMap_Name(MLDictVectorizerMap x) {
     switch (x) {
         case MLDictVectorizerMap_stringToIndex:
@@ -19,5 +18,4 @@ static const char * MLDictVectorizerMap_Name(MLDictVectorizerMap x) {
     }
 }
 
-#pragma clang diagnostic pop
 #endif

--- a/mlmodel/build/format/FeatureTypes_enums.h
+++ b/mlmodel/build/format/FeatureTypes_enums.h
@@ -1,7 +1,5 @@
 #ifndef __FEATURETYPES_ENUMS_H
 #define __FEATURETYPES_ENUMS_H
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
 enum MLColorSpace: int {
     MLColorSpaceINVALID_COLOR_SPACE = 0,
     MLColorSpaceGRAYSCALE = 10,
@@ -15,6 +13,7 @@ enum MLImageFeatureTypeSizeFlexibility: int {
     MLImageFeatureTypeSizeFlexibility_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLImageFeatureTypeSizeFlexibility_Name(MLImageFeatureTypeSizeFlexibility x) {
     switch (x) {
         case MLImageFeatureTypeSizeFlexibility_enumeratedSizes:
@@ -39,6 +38,7 @@ enum MLArrayFeatureTypeShapeFlexibility: int {
     MLArrayFeatureTypeShapeFlexibility_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLArrayFeatureTypeShapeFlexibility_Name(MLArrayFeatureTypeShapeFlexibility x) {
     switch (x) {
         case MLArrayFeatureTypeShapeFlexibility_enumeratedShapes:
@@ -56,6 +56,7 @@ enum MLDictionaryFeatureTypeKeyType: int {
     MLDictionaryFeatureTypeKeyType_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLDictionaryFeatureTypeKeyType_Name(MLDictionaryFeatureTypeKeyType x) {
     switch (x) {
         case MLDictionaryFeatureTypeKeyType_int64KeyType:
@@ -73,6 +74,7 @@ enum MLSequenceFeatureTypeType: int {
     MLSequenceFeatureTypeType_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLSequenceFeatureTypeType_Name(MLSequenceFeatureTypeType x) {
     switch (x) {
         case MLSequenceFeatureTypeType_int64Type:
@@ -95,6 +97,7 @@ enum MLFeatureTypeType: int {
     MLFeatureTypeType_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLFeatureTypeType_Name(MLFeatureTypeType x) {
     switch (x) {
         case MLFeatureTypeType_int64Type:
@@ -116,5 +119,4 @@ static const char * MLFeatureTypeType_Name(MLFeatureTypeType x) {
     }
 }
 
-#pragma clang diagnostic pop
 #endif

--- a/mlmodel/build/format/FeatureVectorizer_enums.h
+++ b/mlmodel/build/format/FeatureVectorizer_enums.h
@@ -1,6 +1,3 @@
 #ifndef __FEATUREVECTORIZER_ENUMS_H
 #define __FEATUREVECTORIZER_ENUMS_H
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
-#pragma clang diagnostic pop
 #endif

--- a/mlmodel/build/format/GLMClassifier_enums.h
+++ b/mlmodel/build/format/GLMClassifier_enums.h
@@ -1,7 +1,5 @@
 #ifndef __GLMCLASSIFIER_ENUMS_H
 #define __GLMCLASSIFIER_ENUMS_H
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
 enum MLPostEvaluationTransform: int {
     MLPostEvaluationTransformLogit = 0,
     MLPostEvaluationTransformProbit = 1,
@@ -18,6 +16,7 @@ enum MLGLMClassifierClassLabels: int {
     MLGLMClassifierClassLabels_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLGLMClassifierClassLabels_Name(MLGLMClassifierClassLabels x) {
     switch (x) {
         case MLGLMClassifierClassLabels_stringClassLabels:
@@ -29,5 +28,4 @@ static const char * MLGLMClassifierClassLabels_Name(MLGLMClassifierClassLabels x
     }
 }
 
-#pragma clang diagnostic pop
 #endif

--- a/mlmodel/build/format/GLMRegressor_enums.h
+++ b/mlmodel/build/format/GLMRegressor_enums.h
@@ -1,12 +1,9 @@
 #ifndef __GLMREGRESSOR_ENUMS_H
 #define __GLMREGRESSOR_ENUMS_H
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
 enum MLPostEvaluationTransform: int {
     MLPostEvaluationTransformNoTransform = 0,
     MLPostEvaluationTransformLogit = 1,
     MLPostEvaluationTransformProbit = 2,
 };
 
-#pragma clang diagnostic pop
 #endif

--- a/mlmodel/build/format/Identity_enums.h
+++ b/mlmodel/build/format/Identity_enums.h
@@ -1,6 +1,3 @@
 #ifndef __IDENTITY_ENUMS_H
 #define __IDENTITY_ENUMS_H
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
-#pragma clang diagnostic pop
 #endif

--- a/mlmodel/build/format/Imputer_enums.h
+++ b/mlmodel/build/format/Imputer_enums.h
@@ -1,7 +1,5 @@
 #ifndef __IMPUTER_ENUMS_H
 #define __IMPUTER_ENUMS_H
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
 enum MLImputerImputedValue: int {
     MLImputerImputedValue_imputedDoubleValue = 1,
     MLImputerImputedValue_imputedInt64Value = 2,
@@ -13,6 +11,7 @@ enum MLImputerImputedValue: int {
     MLImputerImputedValue_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLImputerImputedValue_Name(MLImputerImputedValue x) {
     switch (x) {
         case MLImputerImputedValue_imputedDoubleValue:
@@ -41,6 +40,7 @@ enum MLImputerReplaceValue: int {
     MLImputerReplaceValue_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLImputerReplaceValue_Name(MLImputerReplaceValue x) {
     switch (x) {
         case MLImputerReplaceValue_replaceDoubleValue:
@@ -54,5 +54,4 @@ static const char * MLImputerReplaceValue_Name(MLImputerReplaceValue x) {
     }
 }
 
-#pragma clang diagnostic pop
 #endif

--- a/mlmodel/build/format/Model_enums.h
+++ b/mlmodel/build/format/Model_enums.h
@@ -1,7 +1,5 @@
 #ifndef __MODEL_ENUMS_H
 #define __MODEL_ENUMS_H
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
 enum MLModelType: int {
     MLModelType_pipelineClassifier = 200,
     MLModelType_pipelineRegressor = 201,
@@ -33,6 +31,7 @@ enum MLModelType: int {
     MLModelType_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLModelType_Name(MLModelType x) {
     switch (x) {
         case MLModelType_pipelineClassifier:
@@ -94,5 +93,4 @@ static const char * MLModelType_Name(MLModelType x) {
     }
 }
 
-#pragma clang diagnostic pop
 #endif

--- a/mlmodel/build/format/NeuralNetwork_enums.h
+++ b/mlmodel/build/format/NeuralNetwork_enums.h
@@ -1,13 +1,12 @@
 #ifndef __NEURALNETWORK_ENUMS_H
 #define __NEURALNETWORK_ENUMS_H
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
 enum MLNeuralNetworkPreprocessingpreprocessor: int {
     MLNeuralNetworkPreprocessingpreprocessor_scaler = 10,
     MLNeuralNetworkPreprocessingpreprocessor_meanImage = 11,
     MLNeuralNetworkPreprocessingpreprocessor_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLNeuralNetworkPreprocessingpreprocessor_Name(MLNeuralNetworkPreprocessingpreprocessor x) {
     switch (x) {
         case MLNeuralNetworkPreprocessingpreprocessor_scaler:
@@ -36,6 +35,7 @@ enum MLActivationParamsNonlinearityType: int {
     MLActivationParamsNonlinearityType_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLActivationParamsNonlinearityType_Name(MLActivationParamsNonlinearityType x) {
     switch (x) {
         case MLActivationParamsNonlinearityType_linear:
@@ -112,6 +112,7 @@ enum MLNeuralNetworkLayerlayer: int {
     MLNeuralNetworkLayerlayer_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLNeuralNetworkLayerlayer_Name(MLNeuralNetworkLayerlayer x) {
     switch (x) {
         case MLNeuralNetworkLayerlayer_convolution:
@@ -222,6 +223,7 @@ enum MLQuantizationParamsQuantizationType: int {
     MLQuantizationParamsQuantizationType_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLQuantizationParamsQuantizationType_Name(MLQuantizationParamsQuantizationType x) {
     switch (x) {
         case MLQuantizationParamsQuantizationType_linearQuantization:
@@ -239,6 +241,7 @@ enum MLConvolutionLayerParamsConvolutionPaddingType: int {
     MLConvolutionLayerParamsConvolutionPaddingType_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLConvolutionLayerParamsConvolutionPaddingType_Name(MLConvolutionLayerParamsConvolutionPaddingType x) {
     switch (x) {
         case MLConvolutionLayerParamsConvolutionPaddingType_valid:
@@ -263,6 +266,7 @@ enum MLPoolingLayerParamsPoolingPaddingType: int {
     MLPoolingLayerParamsPoolingPaddingType_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLPoolingLayerParamsPoolingPaddingType_Name(MLPoolingLayerParamsPoolingPaddingType x) {
     switch (x) {
         case MLPoolingLayerParamsPoolingPaddingType_valid:
@@ -283,6 +287,7 @@ enum MLPaddingLayerParamsPaddingType: int {
     MLPaddingLayerParamsPaddingType_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLPaddingLayerParamsPaddingType_Name(MLPaddingLayerParamsPaddingType x) {
     switch (x) {
         case MLPaddingLayerParamsPaddingType_constant:
@@ -363,6 +368,7 @@ enum MLCustomLayerParamValuevalue: int {
     MLCustomLayerParamValuevalue_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLCustomLayerParamValuevalue_Name(MLCustomLayerParamValuevalue x) {
     switch (x) {
         case MLCustomLayerParamValuevalue_doubleValue:
@@ -386,6 +392,7 @@ enum MLNeuralNetworkClassifierClassLabels: int {
     MLNeuralNetworkClassifierClassLabels_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLNeuralNetworkClassifierClassLabels_Name(MLNeuralNetworkClassifierClassLabels x) {
     switch (x) {
         case MLNeuralNetworkClassifierClassLabels_stringClassLabels:
@@ -397,5 +404,4 @@ static const char * MLNeuralNetworkClassifierClassLabels_Name(MLNeuralNetworkCla
     }
 }
 
-#pragma clang diagnostic pop
 #endif

--- a/mlmodel/build/format/NonMaximumSuppression_enums.h
+++ b/mlmodel/build/format/NonMaximumSuppression_enums.h
@@ -1,12 +1,11 @@
 #ifndef __NONMAXIMUMSUPPRESSION_ENUMS_H
 #define __NONMAXIMUMSUPPRESSION_ENUMS_H
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
 enum MLNonMaximumSuppressionSuppressionMethod: int {
     MLNonMaximumSuppressionSuppressionMethod_pickTop = 1,
     MLNonMaximumSuppressionSuppressionMethod_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLNonMaximumSuppressionSuppressionMethod_Name(MLNonMaximumSuppressionSuppressionMethod x) {
     switch (x) {
         case MLNonMaximumSuppressionSuppressionMethod_pickTop:
@@ -22,6 +21,7 @@ enum MLNonMaximumSuppressionClassLabels: int {
     MLNonMaximumSuppressionClassLabels_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLNonMaximumSuppressionClassLabels_Name(MLNonMaximumSuppressionClassLabels x) {
     switch (x) {
         case MLNonMaximumSuppressionClassLabels_stringClassLabels:
@@ -33,5 +33,4 @@ static const char * MLNonMaximumSuppressionClassLabels_Name(MLNonMaximumSuppress
     }
 }
 
-#pragma clang diagnostic pop
 #endif

--- a/mlmodel/build/format/Normalizer_enums.h
+++ b/mlmodel/build/format/Normalizer_enums.h
@@ -1,12 +1,9 @@
 #ifndef __NORMALIZER_ENUMS_H
 #define __NORMALIZER_ENUMS_H
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
 enum MLNormType: int {
     MLNormTypeLMax = 0,
     MLNormTypeL1 = 1,
     MLNormTypeL2 = 2,
 };
 
-#pragma clang diagnostic pop
 #endif

--- a/mlmodel/build/format/OneHotEncoder_enums.h
+++ b/mlmodel/build/format/OneHotEncoder_enums.h
@@ -1,7 +1,5 @@
 #ifndef __ONEHOTENCODER_ENUMS_H
 #define __ONEHOTENCODER_ENUMS_H
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
 enum MLHandleUnknown: int {
     MLHandleUnknownErrorOnUnknown = 0,
     MLHandleUnknownIgnoreUnknown = 1,
@@ -13,6 +11,7 @@ enum MLOneHotEncoderCategoryType: int {
     MLOneHotEncoderCategoryType_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLOneHotEncoderCategoryType_Name(MLOneHotEncoderCategoryType x) {
     switch (x) {
         case MLOneHotEncoderCategoryType_stringCategories:
@@ -24,5 +23,4 @@ static const char * MLOneHotEncoderCategoryType_Name(MLOneHotEncoderCategoryType
     }
 }
 
-#pragma clang diagnostic pop
 #endif

--- a/mlmodel/build/format/SVM_enums.h
+++ b/mlmodel/build/format/SVM_enums.h
@@ -1,7 +1,5 @@
 #ifndef __SVM_ENUMS_H
 #define __SVM_ENUMS_H
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
 enum MLKernelkernel: int {
     MLKernelkernel_linearKernel = 1,
     MLKernelkernel_rbfKernel = 2,
@@ -10,6 +8,7 @@ enum MLKernelkernel: int {
     MLKernelkernel_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLKernelkernel_Name(MLKernelkernel x) {
     switch (x) {
         case MLKernelkernel_linearKernel:
@@ -31,6 +30,7 @@ enum MLSupportVectorRegressorsupportVectors: int {
     MLSupportVectorRegressorsupportVectors_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLSupportVectorRegressorsupportVectors_Name(MLSupportVectorRegressorsupportVectors x) {
     switch (x) {
         case MLSupportVectorRegressorsupportVectors_sparseSupportVectors:
@@ -48,6 +48,7 @@ enum MLSupportVectorClassifiersupportVectors: int {
     MLSupportVectorClassifiersupportVectors_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLSupportVectorClassifiersupportVectors_Name(MLSupportVectorClassifiersupportVectors x) {
     switch (x) {
         case MLSupportVectorClassifiersupportVectors_sparseSupportVectors:
@@ -65,6 +66,7 @@ enum MLSupportVectorClassifierClassLabels: int {
     MLSupportVectorClassifierClassLabels_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLSupportVectorClassifierClassLabels_Name(MLSupportVectorClassifierClassLabels x) {
     switch (x) {
         case MLSupportVectorClassifierClassLabels_stringClassLabels:
@@ -76,5 +78,4 @@ static const char * MLSupportVectorClassifierClassLabels_Name(MLSupportVectorCla
     }
 }
 
-#pragma clang diagnostic pop
 #endif

--- a/mlmodel/build/format/Scaler_enums.h
+++ b/mlmodel/build/format/Scaler_enums.h
@@ -1,6 +1,3 @@
 #ifndef __SCALER_ENUMS_H
 #define __SCALER_ENUMS_H
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
-#pragma clang diagnostic pop
 #endif

--- a/mlmodel/build/format/TextClassifier_enums.h
+++ b/mlmodel/build/format/TextClassifier_enums.h
@@ -1,12 +1,11 @@
 #ifndef __TEXTCLASSIFIER_ENUMS_H
 #define __TEXTCLASSIFIER_ENUMS_H
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
 enum MLTextClassifierClassLabels: int {
     MLTextClassifierClassLabels_stringClassLabels = 200,
     MLTextClassifierClassLabels_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLTextClassifierClassLabels_Name(MLTextClassifierClassLabels x) {
     switch (x) {
         case MLTextClassifierClassLabels_stringClassLabels:
@@ -16,5 +15,4 @@ static const char * MLTextClassifierClassLabels_Name(MLTextClassifierClassLabels
     }
 }
 
-#pragma clang diagnostic pop
 #endif

--- a/mlmodel/build/format/TreeEnsemble_enums.h
+++ b/mlmodel/build/format/TreeEnsemble_enums.h
@@ -1,7 +1,5 @@
 #ifndef __TREEENSEMBLE_ENUMS_H
 #define __TREEENSEMBLE_ENUMS_H
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
 enum MLTreeEnsemblePostEvaluationTransform: int {
     MLTreeEnsemblePostEvaluationTransformNoTransform = 0,
     MLTreeEnsemblePostEvaluationTransformClassification_SoftMax = 1,
@@ -25,6 +23,7 @@ enum MLTreeEnsembleClassifierClassLabels: int {
     MLTreeEnsembleClassifierClassLabels_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLTreeEnsembleClassifierClassLabels_Name(MLTreeEnsembleClassifierClassLabels x) {
     switch (x) {
         case MLTreeEnsembleClassifierClassLabels_stringClassLabels:
@@ -36,5 +35,4 @@ static const char * MLTreeEnsembleClassifierClassLabels_Name(MLTreeEnsembleClass
     }
 }
 
-#pragma clang diagnostic pop
 #endif

--- a/mlmodel/build/format/VisionFeaturePrint_enums.h
+++ b/mlmodel/build/format/VisionFeaturePrint_enums.h
@@ -1,12 +1,11 @@
 #ifndef __VISIONFEATUREPRINT_ENUMS_H
 #define __VISIONFEATUREPRINT_ENUMS_H
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
 enum MLVisionFeaturePrintVisionFeaturePrintType: int {
     MLVisionFeaturePrintVisionFeaturePrintType_scene = 20,
     MLVisionFeaturePrintVisionFeaturePrintType_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLVisionFeaturePrintVisionFeaturePrintType_Name(MLVisionFeaturePrintVisionFeaturePrintType x) {
     switch (x) {
         case MLVisionFeaturePrintVisionFeaturePrintType_scene:
@@ -21,5 +20,4 @@ enum MLSceneVersion: int {
     MLSceneVersionSCENE_VERSION_1 = 1,
 };
 
-#pragma clang diagnostic pop
 #endif

--- a/mlmodel/build/format/WordTagger_enums.h
+++ b/mlmodel/build/format/WordTagger_enums.h
@@ -1,12 +1,11 @@
 #ifndef __WORDTAGGER_ENUMS_H
 #define __WORDTAGGER_ENUMS_H
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
 enum MLWordTaggerTags: int {
     MLWordTaggerTags_stringTags = 200,
     MLWordTaggerTags_NOT_SET = 0,
 };
 
+__attribute__((__unused__))
 static const char * MLWordTaggerTags_Name(MLWordTaggerTags x) {
     switch (x) {
         case MLWordTaggerTags_stringTags:
@@ -16,5 +15,4 @@ static const char * MLWordTaggerTags_Name(MLWordTaggerTags x) {
     }
 }
 
-#pragma clang diagnostic pop
 #endif

--- a/mlmodel/tools/enumgen.cpp
+++ b/mlmodel/tools/enumgen.cpp
@@ -69,6 +69,7 @@ static void handleMessage(const Descriptor& message, std::ostream& ret) {
         ret << "};" << std::endl << std::endl;
 
         // generate a name function (reverse lookup)
+        ret << "__attribute__((__unused__))" << std::endl;
         ret << "static const char * " << enumName.str() << "_Name(" << enumName.str() << " x) {" << std::endl;
         ret << INDENT << "switch (x) {" << std::endl;
         for (size_t j=0; j<oneofType->field_count(); j++) {
@@ -97,8 +98,6 @@ static std::string makeContents(const FileDescriptor& in) {
   std::string guard = makeGuard(in.name());
   ret << "#ifndef " << guard << std::endl;
   ret << "#define " << guard << std::endl;
-  ret << "#pragma clang diagnostic push" << std::endl;
-  ret << "#pragma clang diagnostic ignored \"-Wunused-function\"" << std::endl;
 
   handleContainer(in, ret);
   for (size_t i=0; i<in.message_type_count(); i++) {
@@ -106,7 +105,6 @@ static std::string makeContents(const FileDescriptor& in) {
     handleMessage(*message, ret);
   }
 
-  ret << "#pragma clang diagnostic pop" << std::endl;
   ret << "#endif" << std::endl;
 
   return ret.str();


### PR DESCRIPTION
Instead of #pragma clang warning suppression. The attribute syntax works
across compiler toolchains (clang/gcc/etc.).