### PR TITLE
Drop requests dependency

### DIFF
--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -12,7 +12,6 @@ numpydoc==0.7.0
 protobuf==3.5.1
 Pygments==2.2.0
 pytz==2017.3
-requests==2.18.4
 six==1.10.0
 snowballstemmer==1.2.1
 Sphinx==1.6.6

--- a/mlmodel/Requirements.txt
+++ b/mlmodel/Requirements.txt
@@ -7,7 +7,6 @@ Jinja2==2.9.6
 MarkupSafe==1.0
 Pygments==2.2.0
 pytz==2017.2
-requests==2.14.2
 six==1.10.0
 snowballstemmer==1.2.1
 Sphinx==1.6.1


### PR DESCRIPTION
It doesn't appear to be used anywhere, and the specific versions
requested are now unsupported and have reported vulnerabilities.