### PR TITLE
In GCC 4.8, -Wreturn fails on exhaustive switch

### DIFF
--- a/mlmodel/build/format/CategoricalMapping_enums.h
+++ b/mlmodel/build/format/CategoricalMapping_enums.h
@@ -16,6 +16,7 @@ static const char * MLCategoricalMappingMappingType_Name(MLCategoricalMappingMap
         case MLCategoricalMappingMappingType_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 enum MLCategoricalMappingValueOnUnknown: int {
@@ -34,6 +35,7 @@ static const char * MLCategoricalMappingValueOnUnknown_Name(MLCategoricalMapping
         case MLCategoricalMappingValueOnUnknown_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 #endif

--- a/mlmodel/build/format/CustomModel_enums.h
+++ b/mlmodel/build/format/CustomModel_enums.h
@@ -28,6 +28,7 @@ static const char * MLCustomModelParamValuevalue_Name(MLCustomModelParamValueval
         case MLCustomModelParamValuevalue_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 #endif

--- a/mlmodel/build/format/DictVectorizer_enums.h
+++ b/mlmodel/build/format/DictVectorizer_enums.h
@@ -16,6 +16,7 @@ static const char * MLDictVectorizerMap_Name(MLDictVectorizerMap x) {
         case MLDictVectorizerMap_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 #endif

--- a/mlmodel/build/format/FeatureTypes_enums.h
+++ b/mlmodel/build/format/FeatureTypes_enums.h
@@ -23,6 +23,7 @@ static const char * MLImageFeatureTypeSizeFlexibility_Name(MLImageFeatureTypeSiz
         case MLImageFeatureTypeSizeFlexibility_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 enum MLArrayDataType: int {
@@ -48,6 +49,7 @@ static const char * MLArrayFeatureTypeShapeFlexibility_Name(MLArrayFeatureTypeSh
         case MLArrayFeatureTypeShapeFlexibility_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 enum MLDictionaryFeatureTypeKeyType: int {
@@ -66,6 +68,7 @@ static const char * MLDictionaryFeatureTypeKeyType_Name(MLDictionaryFeatureTypeK
         case MLDictionaryFeatureTypeKeyType_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 enum MLSequenceFeatureTypeType: int {
@@ -84,6 +87,7 @@ static const char * MLSequenceFeatureTypeType_Name(MLSequenceFeatureTypeType x) 
         case MLSequenceFeatureTypeType_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 enum MLFeatureTypeType: int {
@@ -117,6 +121,7 @@ static const char * MLFeatureTypeType_Name(MLFeatureTypeType x) {
         case MLFeatureTypeType_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 #endif

--- a/mlmodel/build/format/GLMClassifier_enums.h
+++ b/mlmodel/build/format/GLMClassifier_enums.h
@@ -26,6 +26,7 @@ static const char * MLGLMClassifierClassLabels_Name(MLGLMClassifierClassLabels x
         case MLGLMClassifierClassLabels_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 #endif

--- a/mlmodel/build/format/Imputer_enums.h
+++ b/mlmodel/build/format/Imputer_enums.h
@@ -31,6 +31,7 @@ static const char * MLImputerImputedValue_Name(MLImputerImputedValue x) {
         case MLImputerImputedValue_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 enum MLImputerReplaceValue: int {
@@ -52,6 +53,7 @@ static const char * MLImputerReplaceValue_Name(MLImputerReplaceValue x) {
         case MLImputerReplaceValue_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 #endif

--- a/mlmodel/build/format/Model_enums.h
+++ b/mlmodel/build/format/Model_enums.h
@@ -91,6 +91,7 @@ static const char * MLModelType_Name(MLModelType x) {
         case MLModelType_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 #endif

--- a/mlmodel/build/format/NeuralNetwork_enums.h
+++ b/mlmodel/build/format/NeuralNetwork_enums.h
@@ -16,6 +16,7 @@ static const char * MLNeuralNetworkPreprocessingpreprocessor_Name(MLNeuralNetwor
         case MLNeuralNetworkPreprocessingpreprocessor_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 enum MLActivationParamsNonlinearityType: int {
@@ -67,6 +68,7 @@ static const char * MLActivationParamsNonlinearityType_Name(MLActivationParamsNo
         case MLActivationParamsNonlinearityType_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 enum MLNeuralNetworkLayerlayer: int {
@@ -196,6 +198,7 @@ static const char * MLNeuralNetworkLayerlayer_Name(MLNeuralNetworkLayerlayer x) 
         case MLNeuralNetworkLayerlayer_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 enum MLSamePaddingMode: int {
@@ -233,6 +236,7 @@ static const char * MLQuantizationParamsQuantizationType_Name(MLQuantizationPara
         case MLQuantizationParamsQuantizationType_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 enum MLConvolutionLayerParamsConvolutionPaddingType: int {
@@ -251,6 +255,7 @@ static const char * MLConvolutionLayerParamsConvolutionPaddingType_Name(MLConvol
         case MLConvolutionLayerParamsConvolutionPaddingType_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 enum MLPoolingType: int {
@@ -278,6 +283,7 @@ static const char * MLPoolingLayerParamsPoolingPaddingType_Name(MLPoolingLayerPa
         case MLPoolingLayerParamsPoolingPaddingType_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 enum MLPaddingLayerParamsPaddingType: int {
@@ -299,6 +305,7 @@ static const char * MLPaddingLayerParamsPaddingType_Name(MLPaddingLayerParamsPad
         case MLPaddingLayerParamsPaddingType_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 enum MLOperation: int {
@@ -384,6 +391,7 @@ static const char * MLCustomLayerParamValuevalue_Name(MLCustomLayerParamValueval
         case MLCustomLayerParamValuevalue_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 enum MLNeuralNetworkClassifierClassLabels: int {
@@ -402,6 +410,7 @@ static const char * MLNeuralNetworkClassifierClassLabels_Name(MLNeuralNetworkCla
         case MLNeuralNetworkClassifierClassLabels_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 #endif

--- a/mlmodel/build/format/NonMaximumSuppression_enums.h
+++ b/mlmodel/build/format/NonMaximumSuppression_enums.h
@@ -13,6 +13,7 @@ static const char * MLNonMaximumSuppressionSuppressionMethod_Name(MLNonMaximumSu
         case MLNonMaximumSuppressionSuppressionMethod_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 enum MLNonMaximumSuppressionClassLabels: int {
@@ -31,6 +32,7 @@ static const char * MLNonMaximumSuppressionClassLabels_Name(MLNonMaximumSuppress
         case MLNonMaximumSuppressionClassLabels_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 #endif

--- a/mlmodel/build/format/OneHotEncoder_enums.h
+++ b/mlmodel/build/format/OneHotEncoder_enums.h
@@ -21,6 +21,7 @@ static const char * MLOneHotEncoderCategoryType_Name(MLOneHotEncoderCategoryType
         case MLOneHotEncoderCategoryType_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 #endif

--- a/mlmodel/build/format/SVM_enums.h
+++ b/mlmodel/build/format/SVM_enums.h
@@ -22,6 +22,7 @@ static const char * MLKernelkernel_Name(MLKernelkernel x) {
         case MLKernelkernel_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 enum MLSupportVectorRegressorsupportVectors: int {
@@ -40,6 +41,7 @@ static const char * MLSupportVectorRegressorsupportVectors_Name(MLSupportVectorR
         case MLSupportVectorRegressorsupportVectors_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 enum MLSupportVectorClassifiersupportVectors: int {
@@ -58,6 +60,7 @@ static const char * MLSupportVectorClassifiersupportVectors_Name(MLSupportVector
         case MLSupportVectorClassifiersupportVectors_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 enum MLSupportVectorClassifierClassLabels: int {
@@ -76,6 +79,7 @@ static const char * MLSupportVectorClassifierClassLabels_Name(MLSupportVectorCla
         case MLSupportVectorClassifierClassLabels_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 #endif

--- a/mlmodel/build/format/TextClassifier_enums.h
+++ b/mlmodel/build/format/TextClassifier_enums.h
@@ -13,6 +13,7 @@ static const char * MLTextClassifierClassLabels_Name(MLTextClassifierClassLabels
         case MLTextClassifierClassLabels_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 #endif

--- a/mlmodel/build/format/TreeEnsemble_enums.h
+++ b/mlmodel/build/format/TreeEnsemble_enums.h
@@ -33,6 +33,7 @@ static const char * MLTreeEnsembleClassifierClassLabels_Name(MLTreeEnsembleClass
         case MLTreeEnsembleClassifierClassLabels_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 #endif

--- a/mlmodel/build/format/VisionFeaturePrint_enums.h
+++ b/mlmodel/build/format/VisionFeaturePrint_enums.h
@@ -13,6 +13,7 @@ static const char * MLVisionFeaturePrintVisionFeaturePrintType_Name(MLVisionFeat
         case MLVisionFeaturePrintVisionFeaturePrintType_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 enum MLSceneVersion: int {

--- a/mlmodel/build/format/WordTagger_enums.h
+++ b/mlmodel/build/format/WordTagger_enums.h
@@ -13,6 +13,7 @@ static const char * MLWordTaggerTags_Name(MLWordTaggerTags x) {
         case MLWordTaggerTags_NOT_SET:
             return "INVALID";
     }
+    return "INVALID";
 }
 
 #endif

--- a/mlmodel/tools/enumgen.cpp
+++ b/mlmodel/tools/enumgen.cpp
@@ -82,6 +82,7 @@ static void handleMessage(const Descriptor& message, std::ostream& ret) {
         ret << INDENT << INDENT << "case " << enumName.str() << "_NOT_SET:" << std::endl;
         ret << INDENT << INDENT << INDENT << "return \"INVALID\";" << std::endl;
         ret << INDENT << "}" << std::endl;
+        ret << INDENT << "return \"INVALID\";" << std::endl;
         ret << "}" << std::endl << std::endl;
   }
 


### PR DESCRIPTION
The generated code in enums gives warnings (including warning-as-error)
in GCC 4.8, which also can't be suppressed via pragma GCC diagnostic.

The workaround here is to add an explicit return statement past the
switch statement, so the compiler thinks we are always returning
something (even though we always were anyway).