### PR TITLE
Support for bilinear interpolation for upsampling Keras layer

### DIFF
--- a/coremltools/converters/keras/_layers2.py
+++ b/coremltools/converters/keras/_layers2.py
@@ -865,8 +865,9 @@ def convert_upsample(builder, layer, input_names, output_names, keras_layer):
             raise ValueError("Unrecognized upsample factor format %s" % (str(keras_layer.size)))
 
     kerasmode2coreml = {'nearest': 'NN', 'bilinear': 'BILINEAR'}
+    interpolation = getattr(keras_layer, 'interpolation', 'nearest') # Defaults to 'nearest' for Keras < 2.2.3
 
-    if keras_layer.interpolation not in kerasmode2coreml:
+    if interpolation not in kerasmode2coreml:
         raise ValueError('Only supported "nearest" or "bilinear" interpolation for upsampling layers.')
 
     mode = kerasmode2coreml[keras_layer.interpolation]

--- a/coremltools/converters/keras/_layers2.py
+++ b/coremltools/converters/keras/_layers2.py
@@ -864,11 +864,19 @@ def convert_upsample(builder, layer, input_names, output_names, keras_layer):
         else:
             raise ValueError("Unrecognized upsample factor format %s" % (str(keras_layer.size)))
 
+    kerasmode2coreml = {'nearest': 'NN', 'bilinear': 'BILINEAR'}
+
+    if keras_layer.interpolation not in kerasmode2coreml:
+        raise ValueError('Only supported "nearest" or "bilinear" interpolation for upsampling layers.')
+
+    mode = kerasmode2coreml[keras_layer.interpolation]
+
     builder.add_upsample(name = layer,
              scaling_factor_h = fh,
              scaling_factor_w = fw,
              input_name = input_name,
-             output_name = output_name)
+             output_name = output_name,
+             mode = mode)
 
 def convert_permute(builder, layer, input_names, output_names, keras_layer):
     """

--- a/coremltools/test/test_keras2.py
+++ b/coremltools/test/test_keras2.py
@@ -278,7 +278,7 @@ class KerasSingleLayerTest(unittest.TestCase):
         model = Sequential()
         model.add(Conv2D(input_shape=(64, 64, 3), filters=32,
             kernel_size=(5,5)))
-        model.add(UpSampling2D(size = (2, 2), interpolation = 'nearest'))
+        model.add(UpSampling2D(size = (2, 2)))
         input_names = ['input']
         output_names = ['output']
         spec = keras.convert(model, input_names, output_names).get_spec()
@@ -308,7 +308,10 @@ class KerasSingleLayerTest(unittest.TestCase):
         model = Sequential()
         model.add(Conv2D(input_shape=(64, 64, 3), filters=32,
             kernel_size=(5,5)))
-        model.add(UpSampling2D(size = (2, 2), interpolation = 'bilinear'))
+        try:
+            model.add(UpSampling2D(size = (2, 2), interpolation = 'bilinear'))
+        except TypeError: # Early version of Keras, no support for 'interpolation'
+            return
         spec = keras.convert(model, input_names, output_names).get_spec()
         self.assertIsNotNone(spec)
         layer_1 = layers[1]

--- a/coremltools/test/test_keras2.py
+++ b/coremltools/test/test_keras2.py
@@ -278,7 +278,7 @@ class KerasSingleLayerTest(unittest.TestCase):
         model = Sequential()
         model.add(Conv2D(input_shape=(64, 64, 3), filters=32,
             kernel_size=(5,5)))
-        model.add(UpSampling2D(size = (2, 2)))
+        model.add(UpSampling2D(size = (2, 2), interpolation = 'nearest'))
         input_names = ['input']
         output_names = ['output']
         spec = keras.convert(model, input_names, output_names).get_spec()
@@ -302,6 +302,18 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertIsNotNone(layer_0.convolution)
         layer_1 = layers[1]
         self.assertIsNotNone(layer_1.upsample)
+        self.assertEquals(layer_1.upsample.mode, NeuralNetwork_pb2.UpsampleLayerParams.InterpolationMode.Value('NN'))
+
+        # Test if BILINEAR mode works as well
+        model = Sequential()
+        model.add(Conv2D(input_shape=(64, 64, 3), filters=32,
+            kernel_size=(5,5)))
+        model.add(UpSampling2D(size = (2, 2), interpolation = 'bilinear'))
+        spec = keras.convert(model, input_names, output_names).get_spec()
+        self.assertIsNotNone(spec)
+        layer_1 = layers[1]
+        self.assertIsNotNone(layer_1.upsample)
+        self.assertEquals(layer_1.upsample.mode, NeuralNetwork_pb2.UpsampleLayerParams.InterpolationMode.Value('BILINEAR'))
 
     def test_pooling(self):
         """


### PR DESCRIPTION
In newer Keras there is a support for bilinear interpolation.
This PR adds a logic to handle it properly.