### PR TITLE
Update README concerning installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,20 @@ after which you can use make to build the project
 make
 ```
 
+Installing
+----------
+
+Once the project is built, it can be installed via the normal setup.py
+mechanisms, such as:
+
+```shell
+python /path/to/setup.py install
+```
+
+Make sure to activate any desired virtual environment first.
+
+Alternatively, a wheel can be created and installed via pip.
+
 Building Installable Wheel
 ---------------------------
 To make a wheel/egg that you can distribute, you can do the following


### PR DESCRIPTION
Allen and I were talking and I realized that, for those used to previous workflows, it was unclear that setup.py can still be invoked even though the build directory is different.  This adds some documentation to make that clear.