### PR TITLE
Map object not subscriptable

### DIFF
--- a/coremltools/models/_infer_shapes_nn_mlmodel.py
+++ b/coremltools/models/_infer_shapes_nn_mlmodel.py
@@ -229,7 +229,7 @@ def _permute(layer, shape_dict):
     params = layer.permute
     Seq, Batch, Cin, Hin, Win = shape_dict[layer.input[0]]
     
-    axis = map(int, params.axis)
+    axis = list(map(int, params.axis))
     dims = (Seq, Cin, Hin, Win)
     Seq_out = dims[axis[0]]
     Cout = dims[axis[1]]


### PR DESCRIPTION
axis = list(map(int, params.axis))
In python3, for _permute(), 'map' object is not subscriptable.
Map object is passed to a list.