### PR TITLE
Adds conversion functions to support MobileNetV1/V2

### DIFF
--- a/coremltools/converters/nnssa/coreml/graph_pass/op_fusions.py
+++ b/coremltools/converters/nnssa/coreml/graph_pass/op_fusions.py
@@ -9,7 +9,7 @@ from ...commons.basic_graph_ops import disconnect_edge, connect_edge, \
     delete_node, replace_node, connect_dests, topsort
 from ...nnssa import ParsedNode
 
-ELEMENTWISE_OPS = [
+ELEMENTWISE_OPS = {
     'Maximum',
     'Minimum',
     'Add',
@@ -17,14 +17,22 @@ ELEMENTWISE_OPS = [
     'BiasAdd',
     'Mul',
     'Sigmoid',
-    'Relu',
+    'Relu', 'Relu6',
     'LeakyRelu',
     'Tanh',
     'Identity',
     'Sqrt',
     'Rsqrt',
     'Pow',
-]
+    'Pad',
+
+}
+
+# Native SSA nodes with data_format attributes of NHWC / NCHW
+NATIVE_NHWC_OPS = {
+    'Conv2D', 'Conv2DBackpropInput', 'DepthwiseConv2dNative',
+    'Pooling', 'MaxPool', 'AvgPool'
+}
 
 
 def _check_number_inputs(node, n):
@@ -36,29 +44,26 @@ def _check_number_outputs(node, n):
 
 
 def _check_single_out_vector_constant_node(node):
-    return (node.op == 'Const' and len(node.outputs) == 1 and \
-            node.value is not None and len(np.squeeze(node.value.val).shape) == 1)
+    return node.op == 'Const' and len(node.outputs) == 1 and \
+           node.value is not None and len(np.squeeze(node.value.val).shape) == 1
 
 
 def _is_NHWC(graph, node):
     if node.op == 'ResizeBilinear' or node.op == 'ResizeNearestNeighbor':
         return True
-    if (node.op == 'Conv2D' or node.op == 'Conv2DBackpropInput' or node.op == 'Pooling' or node.op == 'MaxPool' or
-        node.op == 'AvgPool') and node.attr.get('data_format') == 'NHWC':
+    if node.op in NATIVE_NHWC_OPS and node.attr.get('data_format') == 'NHWC':
         return True
     if node.op == 'ConcatV2':
         # ConcatV2's last input is axis
-        return all(graph[inp].attr.get('data_format') == 'NHWC_format_inserted' for inp in
-            node.inputs[:-1])
+        return all(graph[inp].attr.get('data_format') == 'NHWC_format_inserted'
+            for inp in node.inputs[:-1])
     if node.op in ELEMENTWISE_OPS:
-        # if its an elementwise op
-        # and if all of its parent(s) are "NHWC_format_inserted" or
-        # given that at least one of the parents is "NHWC_format_inserted" and rest are
-        # vector constants, then the node is also
-        # declared to be "NHWC_format_inserted"
-
-        NHWC_parent = any(
-            [graph[inp].attr.get('data_format', None) == 'NHWC_format_inserted' for inp in node.inputs])
+        # if its an elementwise op and if all of its parent(s) are
+        # "NHWC_format_inserted" or given that at least one of the parents
+        # is "NHWC_format_inserted" and rest are vector constants, then the
+        # node is also declared to be "NHWC_format_inserted"
+        NHWC_parent = any([graph[inp].attr.get('data_format',
+            None) == 'NHWC_format_inserted' for inp in node.inputs])
 
         if NHWC_parent:
             for inp in node.inputs:
@@ -66,9 +71,10 @@ def _is_NHWC(graph, node):
                 if parent_node.attr.get('data_format', None) == 'NHWC_format_inserted':
                     continue
                 elif parent_node.value is not None:
-                    # check that the input is a constant and a vector (rank 1)
+                    # check that the input is a constant or a rank-1 tensor
                     val = np.array(parent_node.value.val)
-                    if len(val.shape) == 1 and builtins.is_tensor(parent_node.datatype) and len(parent_node.outputs) == 1:
+                    if len(val.shape) == 1 and builtins.is_tensor(
+                        parent_node.datatype) and len(parent_node.outputs) == 1:
                         continue
                     else:
                         return False
@@ -79,11 +85,14 @@ def _is_NHWC(graph, node):
     return False
 
 
-def _insert_transpose_to_or_from_nchw(graph, src, dst, transpose_node_name, transpose_params=[0, 3, 1, 2]):
-    '''
-    Insert a node called "transpose_node_name" between src and dst
-    This node should be a transpose node with params "transpose_params"
-    '''
+def _insert_transpose_to_or_from_nchw(graph, src, dst, transpose_node_name, transpose_params=None):
+    """
+    Insert a node called 'transpose_node_name' between src and dst
+    This node should be a transpose node with params 'transpose_params'
+    """
+
+    if not transpose_params:
+        transpose_params = [0, 3, 1, 2]
 
     # First check whether the node already exists in the graph or not.
 
@@ -181,6 +190,11 @@ def transform_nhwc_to_nchw(nnssa):
                     node.attr['_output_shapes'] = [[s[0], s[3], s[1], s[2]]]
 
             if node.op in ELEMENTWISE_OPS:
+                if node.op == 'Relu':
+                    print('relu')
+                if node.op == 'Pad':
+                    print('pad')
+
                 for inp in node.inputs:
                     parent_node = graph[inp]
                     if parent_node.value is not None:
@@ -190,7 +204,7 @@ def transform_nhwc_to_nchw(nnssa):
                                                                    (1, val.shape[0], 1, 1))
                             parent_node.value.val = np.reshape(parent_node.value.val, (1, val.shape[0], 1, 1))
 
-            # Insert NHWC->NCHW transpose
+            # Insert NHWC -> NCHW transpose
             for i, inp_node_name in enumerate(node.inputs):
                 inp_node_format = graph[inp_node_name].attr.get('data_format')
                 if graph[inp_node_name].op == 'Const':
@@ -199,7 +213,7 @@ def transform_nhwc_to_nchw(nnssa):
                 if inp_node_format != 'NHWC_format_inserted':
                     _insert_transpose_to_nchw(graph, graph[inp_node_name], node)
 
-            # Insert NCHW->NHWC transpose
+            # Insert NCHW -> NHWC transpose
             for i, out_node_name in enumerate(node.outputs):
                 out_node_format = graph[out_node_name].attr.get('data_format')
                 if out_node_format != 'NHWC_format_inserted':
@@ -465,6 +479,7 @@ def _match_gelu_pattern(gf, entry_node):
     except:
         return None
 
+
 def _fuse_gelu(graph):
     keys = list(graph.keys())
     count = 0
@@ -508,14 +523,21 @@ def fuse_gelu(nnssa):
 
 
 def fuse_conv_mul_add_into_batchnorm(nnssa):
-    '''
-            Const vector  Const vector
-                  |          |
-                  |          |
-                  |          |
-                  V          V
-    Conv2D ----> Mul -----> Add ---->     =========>    Conv2D ---> BN --->
-    '''
+    """
+    A graph pass that match and fuses following op patterns into one BatchNorm op.
+
+    Pattern 1:
+                [Const]   [Const]
+                   |         |
+                   V         V
+    [Conv2D] --> [Mul] --> [Add] --> [...] to [Conv2D] --> [BatchNorm] --> [...]
+
+    Pattern 2:
+                [Const]   [Const]   [Const]
+                   |         |         |
+                   V         V         V
+    [Conv2D] --> [Sub] --> [Mul] --> [Add] --> [...] to [Conv2D] --> [BatchNorm] --> [...]
+    """
 
     def _match_mul_add_bn_pattern(gd, conv2d_node):
         try:
@@ -539,6 +561,34 @@ def fuse_conv_mul_add_into_batchnorm(nnssa):
         except Exception as e:
             return None
 
+    def _match_sub_mul_add_batchnorm_pattern(graph, conv2d_node):
+        try:
+            if not _check_number_outputs(conv2d_node, 1):
+                return None
+            sub_node = graph[conv2d_node.outputs[0]]
+            if not (sub_node.op == 'Sub' and _check_number_outputs(sub_node, 1) and _check_number_inputs(sub_node, 2)):
+                return None
+            sub_const_node = graph[sub_node.inputs[0]] if sub_node.inputs[1] == conv2d_node.name else graph[sub_node.inputs[1]]
+            if not _check_single_out_vector_constant_node(sub_const_node):
+                return None
+            mul_node = graph[sub_node.outputs[0]]
+            if not (mul_node.op == 'Mul' and _check_number_outputs(mul_node, 1) and _check_number_inputs(mul_node, 2)):
+                return None
+            mul_const_node = graph[mul_node.inputs[0]] if mul_node.inputs[1] == conv2d_node.name else graph[mul_node.inputs[1]]
+            if not _check_single_out_vector_constant_node(mul_const_node):
+                return None
+            add_node = graph[mul_node.outputs[0]]
+            if not (add_node.op == 'Add' and _check_number_inputs(add_node, 2)):
+                return None
+            add_const_node = graph[add_node.inputs[0]] if add_node.inputs[1] == mul_node.name else graph[add_node.inputs[1]]
+            if not _check_single_out_vector_constant_node(add_const_node):
+                return None
+
+            return [sub_const_node, sub_node, mul_const_node, mul_node, add_const_node, add_node]
+
+        except Exception:
+            return None
+
     def _fuse_conv_mul_add_into_batchnorm(graph):
         keys = list(graph.keys())
         count = 0
@@ -546,14 +596,17 @@ def fuse_conv_mul_add_into_batchnorm(nnssa):
             if k not in graph:
                 continue
             current_node = graph[k]
-            if current_node.op != 'Conv2D':
+            if current_node.op not in ['Conv2D', 'DepthwiseConv2dNative']:
                 continue
 
-            # BN_nodes order : [Const, Mul, Const, Add]
-            BN_nodes = _match_mul_add_bn_pattern(graph, current_node)
-            if BN_nodes is not None:
-                assert len(BN_nodes) == 4
-                out_node = BN_nodes[-1]
+            # BN_nodes1 order: [Const, Mul, Const, Add]
+            bn_nodes1 = _match_mul_add_bn_pattern(graph, current_node)
+            # bn_nodes2 order: [Const, Sub, Const, Mul, Const, Add]
+            bn_nodes2 = _match_sub_mul_add_batchnorm_pattern(graph, current_node)
+
+            if bn_nodes1:
+                assert len(bn_nodes1) == 4
+                out_node = bn_nodes1[-1]
                 bn_outputs = out_node.outputs[:]
 
                 # Instantiate a new fused node in the graph
@@ -561,15 +614,15 @@ def fuse_conv_mul_add_into_batchnorm(nnssa):
                 fused_bn_node.op = 'BatchNorm'
                 fused_bn_node.name = out_node.name + '_batch_norm'
                 fused_bn_node.attr = {
-                    'gamma': np.squeeze(BN_nodes[0].value.val),
-                    'beta': np.squeeze(BN_nodes[2].value.val)
+                    'gamma': np.squeeze(bn_nodes1[0].value.val),
+                    'beta': np.squeeze(bn_nodes1[2].value.val),
                 }
                 fused_bn_node.datatype = current_node.datatype
                 graph[fused_bn_node.name] = fused_bn_node
 
                 # Delete nodes
-                BN_node_names = [x.name for x in BN_nodes]
-                for name in BN_node_names:
+                bn_node_names = [x.name for x in bn_nodes1]
+                for name in bn_node_names:
                     delete_node(graph, name)
 
                 # Connect fused node to entry and output nodes
@@ -577,11 +630,38 @@ def fuse_conv_mul_add_into_batchnorm(nnssa):
                 connect_dests(graph, fused_bn_node.name, bn_outputs)
 
                 count += 1
+
+            if bn_nodes2:
+                assert len(bn_nodes2) == 6
+                out_node = bn_nodes2[-1]
+                bn_outputs = out_node.outputs[:]
+
+                # Instantiate a new fused node in the graph
+                fused_bn_node = ParsedNode()
+                fused_bn_node.op = 'BatchNorm'
+                fused_bn_node.name = out_node.name + '_batch_norm'
+                fused_bn_node.attr = {
+                    'mean': np.squeeze(bn_nodes2[0].value.val),
+                    'gamma': np.squeeze(bn_nodes2[2].value.val),
+                    'beta': np.squeeze(bn_nodes2[4].value.val),
+                }
+                fused_bn_node.datatype = current_node.datatype
+                graph[fused_bn_node.name] = fused_bn_node
+
+                # Delete nodes
+                bn_node_names = [x.name for x in bn_nodes2]
+                for name in bn_node_names:
+                    delete_node(graph, name)
+
+                # Connect fused node to entry and output nodes
+                connect_edge(graph, current_node.name, fused_bn_node.name)
+                connect_dests(graph, fused_bn_node.name, bn_outputs)
+
+                count += 1
+
         if count > 0:
             print('[Op Fusion] Fused {} BatchNorms.'.format(count))
 
     for fn_key in list(nnssa.functions.keys()):
         f = nnssa.functions[fn_key]
         _fuse_conv_mul_add_into_batchnorm(f.graph)
-
-

--- a/coremltools/converters/nnssa/coreml/shapes.py
+++ b/coremltools/converters/nnssa/coreml/shapes.py
@@ -576,10 +576,10 @@ def _propagate_shapes(nn_spec, blob_names, shapes, srcs, dsts, layer_specs):
     Traverse the neural network spec. The spec may not be top level.
     This should be used as the internal recursive call. Use traverse() to do the top level traversal.
     blob_names - a list of blob names
-    shapes - a dictionary of \{blob_name : shape\}
-    srcs - a dictionary of \{ blob_name : layers_writing_to_it \}
-    dsts - a dictionary of \{ blob_name : layers_reading_from_it \}
-    layer_specs - a dictionary of \{layer_name : layer_spec\} for easy access to parameters.
+    shapes - a dictionary of {blob_name: shape}
+    srcs - a dictionary of {blob_name: layers_writing_to_it}
+    dsts - a dictionary of {blob_name: layers_reading_from_it}
+    layer_specs - a dictionary of {layer_name: layer_spec} for easy access to parameters.
 
     srcs, dsts, and layer_specs are byproducts that are not necessary for propagating the shapes.
     I made these for debugging purposes.
@@ -638,7 +638,7 @@ def _finalize_spec(nn_spec, shapes, overwrite=True):
     """
     This is the internal recursive call. Use propagate_shapes() to do the top level traversal.
     nn_spec: spec for the neural network
-    shapes: a \{str : shape\} dictionary tracking the name -> coreml_shape pair
+    shapes: a {str : shape} dictionary tracking the name -> coreml_shape pair
     overwrite: If True, will discard existing tensor shapes in the spec.
                If False, will check for tensor shape existence, write it if spec does not have tensor field,
                otherwise will check for consistency.

--- a/coremltools/converters/nnssa/frontend/graph_pass/type_inference.py
+++ b/coremltools/converters/nnssa/frontend/graph_pass/type_inference.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import as _
 import traceback
 import numpy as np
 import sympy as sm
-import sys
+import sys, math
 
 PY3 = False
 if sys.version_info >= (3, 0):
@@ -15,6 +15,15 @@ from ...commons import builtins
 from ...commons.symbolic import *
 
 short_var_name_cache = {}
+
+def get_conv_outdim(in_dim, ks, stride, dl, padding_type):
+    if padding_type == 'VALID':
+        ks_dilated = (ks - 1) * dl + 1
+        return (in_dim - ks_dilated) / stride + 1
+    elif padding_type == 'SAME':
+        return math.ceil(in_dim * 1.0 / stride)
+    else:
+        raise ValueError('[Type Inference] Unrecognized padding type.')
 
 
 def get_short_var_name(name):
@@ -292,7 +301,7 @@ class TypeInferenceVisitor(object):
 
     # The main visitors
 
-    def visit_get_tuple(self, node): # DO NOT PROPAGATE TYPE INFERENCE ACROSS FUNCTIONS
+    def visit_get_tuple(self, node):  # DO NOT PROPAGATE TYPE INFERENCE ACROSS FUNCTIONS
         assert (len(node.inputs) == 1)
         parent_type = self.visit(node.inputs[0])
         self.propagate_tensor_array(node)
@@ -442,66 +451,53 @@ class TypeInferenceVisitor(object):
         return self._get_type_from_attr(node)
 
     def visit_Conv2D(self, node):
+
+        output_shapes = node.attr.get('_output_shapes')
+        if output_shapes is None or len(output_shapes) == 0:
+            return self._get_type_from_attr(node)
+
         input_type = self.visit(node.inputs[0])
         filter_type = self.visit(node.inputs[1])
-        if input_type is not None and filter_type is not None:
-            # we implement shape inference for a simple case
-            if node.attr['data_format'] == 'NHWC' and \
-                    all(d == 1 for d in node.attr['dilations']) and \
-                    all(d == 1 for d in node.attr['strides']):
-                inshape = input_type.get_shape()
-                filtshape = filter_type.get_shape()
-                if node.attr['padding'] == 'VALID':
-                    # filtshape is [H, W, in_channels, out_channels]
-                    assert (len(inshape) == 4)
-                    assert (len(filtshape) == 4)
-                    retshape = [
-                        inshape[0],  # N copies
-                        inshape[1] - filtshape[0] + 1,
-                        inshape[2] - filtshape[1] + 1,
-                        filtshape[3]
-                    ]
-                    return builtins.tensor(input_type.get_primitive(), tuple(retshape))
 
-                elif node.attr['padding'] == 'SAME':
-                    retshape = [
-                        inshape[0],  # N copies
-                        inshape[1],
-                        inshape[2],
-                        filtshape[3]
-                    ]
-                    return builtins.tensor(input_type.get_primitive(), tuple(retshape))
+        if all([dim > 0 for dim in output_shapes[0]]):
+            return builtins.tensor(input_type.get_primitive(), tuple(output_shapes[0]))
+
+        if input_type is not None and filter_type is not None:
+            inshape = input_type.get_shape()
+            filtshape = filter_type.get_shape()
+            assert len(inshape) == 4
+            assert len(filtshape) == 4
+            strides = node.attr['strides']
+            padding = node.attr['padding']
+            dilations = node.attr['dilations']
+            retshape = output_shapes[0]
+            if node.attr['data_format'] == 'NHWC':
+
+                retshape[1] = get_conv_outdim(inshape[1], filtshape[0],
+                    strides[1], dilations[1], padding)
+                retshape[2] = get_conv_outdim(inshape[2], filtshape[1],
+                    strides[2], dilations[2], padding)
+            else:
+                retshape[2] = get_conv_outdim(inshape[2], filtshape[0],
+                    strides[2], dilations[2], padding)
+                retshape[3] = get_conv_outdim(inshape[3], filtshape[1],
+                    strides[3], dilations[3], padding)
+
+            return builtins.tensor(input_type.get_primitive(), tuple(retshape))
+
         return self._get_type_from_attr(node)
+
+    def visit_DepthwiseConv2dNative(self, node):
+        return self.visit_Conv2D(node)
 
     def visit_Conv2DBackpropInput(self, node):
-        filter_type = self.visit(node.inputs[1])
-        input_type = self.visit(node.inputs[2])
-        if input_type and filter_type:
-            # we implement shape inference for a simple case
-            if node.attr['data_format'] == 'NHWC' and \
-                    all(d == 1 for d in node.attr['dilations']) and \
-                    all(d == 1 for d in node.attr['strides']):
-                input_shape = input_type.get_shape()
-                filter_shape = filter_type.get_shape()
-                if node.attr['padding'].lower() == 'valid':
-                    assert len(input_shape) == 4
-                    assert len(filter_shape) == 4
-                    ret_shape = [
-                        input_shape[0],
-                        input_shape[1] - filter_shape[0] + 1,
-                        input_shape[2] - filter_shape[1] + 1,
-                        filter_shape[2]
-                    ]
-                    return builtins.tensor(input_type.get_primitive(), tuple(ret_shape))
-                elif node.attr['padding'].lower() == 'same':
-                    ret_shape = [
-                        input_shape[0],
-                        input_shape[1],
-                        input_shape[2],
-                        filter_shape[2]
-                    ]
-                    return builtins.tensor(input_type.get_primitive(), tuple(ret_shape))
-        return self._get_type_from_attr(node)
+        attr_output_type = self._get_type_from_attr(node)
+
+        if attr_output_type is not None:
+            return attr_output_type
+        else:
+            raise ValueError("[Type Inference] Conv2DBackpropInput type "
+                "inference case not handled")
 
     def visit_ResizeBilinear(self, node):
         return self._get_type_from_attr(node)
@@ -2021,20 +2017,16 @@ class TypeInferenceVisitor(object):
         return self.visit(node.inputs[0])
 
     def visit_SpaceToDepth(self, node):
-        primitive = self.visit_unary(node).get_primitive()
-        return builtins.tensor(primitive, node.attr['_output_shapes'][0])
+        return self._get_type_from_attr(node)
 
     def visit_DepthToSpace(self, node):
-        primitive = self.visit_unary(node).get_primitive()
-        return builtins.tensor(primitive, node.attr['_output_shapes'][0])
+        return self._get_type_from_attr(node)
 
     def visit_SpaceToBatchND(self, node):
-        primitive = self.visit_unary(node).get_primitive()
-        return builtins.tensor(primitive, node.attr['_output_shapes'][0])
+        return self._get_type_from_attr(node)
 
     def visit_BatchToSpaceND(self, node):
-        primitive = self.visit_unary(node).get_primitive()
-        return builtins.tensor(primitive, node.attr['_output_shapes'][0])
+        return self._get_type_from_attr(node)
 
 
 def type_is_unknown(t):

--- a/coremltools/converters/nnssa/frontend/tensorflow/load.py
+++ b/coremltools/converters/nnssa/frontend/tensorflow/load.py
@@ -51,8 +51,12 @@ def load(tfgraph, resume_on_errors=False, **kwargs):
             graph[name].attr['_output_shapes'] = [placeholder_shape[name]]
 
     passes = [
-        delete_asserts, functionalize_loops, constant_propagation,
-        cond_to_where, remove_variable_nodes, fusedbatchnorm_rewrite,
+        delete_asserts,
+        functionalize_loops,
+        constant_propagation,
+        cond_to_where,
+        remove_variable_nodes,
+        fusedbatchnorm_rewrite,
         lstmblockcell_rewrite
     ]
 


### PR DESCRIPTION
(1) adds depthwise convolution conversion
(2) make sure mobile net conversion passes for V1 and V2
(3) re-implement type-inference for Conv2D and DepthwiseCovn2dNative
(4) fix NHWC-NCHW transforms for ReLU6 and DepthwiseConv2dNative
(5) fix numerical instability cause by ignored epsilon in fusing FusedBatchNorm
(6) adds unit test for conv->batchnorm