### PR TITLE
Fixing error message in _get_translator_function

### DIFF
--- a/coremltools/models/_infer_shapes_nn_mlmodel.py
+++ b/coremltools/models/_infer_shapes_nn_mlmodel.py
@@ -10,7 +10,7 @@ def _get_translator_function(layer_type):
     if layer_type in _LAYER_REGISTERY:
         return _LAYER_REGISTERY[layer_type]
     else:
-        raise TypeError("Shape computation function missing for layer of type %s." % type(layer_type))
+        raise TypeError("Shape computation function missing for layer of type %s." % layer_type)
 
 
 def _identity(layer, shape_dict):


### PR DESCRIPTION
It seems that type(layer_type) will always be 'str'. And the error message should include the name of the layer (the content of layer_type), rather than 'str'.