### PR TITLE
Bug fixes for image downsize, one-way split, slice, and depth-to-space

### DIFF
--- a/coremltools/converters/nnssa/coreml/graph_pass/__init__.py
+++ b/coremltools/converters/nnssa/coreml/graph_pass/__init__.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import as _
 from .op_removals import remove_no_ops_and_shift_control_dependencies
 from .op_removals import constant_weight_link_removal
 from .op_removals import remove_single_isolated_node
-from .op_removals import remove_identity
+from .op_removals import remove_identity, remove_oneway_split
 
 from .op_fusions import fuse_bias_add, transform_nhwc_to_nchw, \
     onehot_matmul_to_embedding, fuse_layer_norm, fuse_gelu, \

--- a/coremltools/converters/nnssa/coreml/graph_pass/op_fusions.py
+++ b/coremltools/converters/nnssa/coreml/graph_pass/op_fusions.py
@@ -35,7 +35,7 @@ ELEMENTWISE_OPS = {
 # Native SSA nodes with data_format attributes of NHWC / NCHW
 NATIVE_NHWC_OPS = {
     'Conv2D', 'Conv2DBackpropInput', 'DepthwiseConv2dNative',
-    'Pooling', 'MaxPool', 'AvgPool'
+    'Pooling', 'MaxPool', 'AvgPool', 'DepthToSpace', 'SpaceToDepth',
 }
 
 REDUCTION_OPS = {

--- a/coremltools/converters/nnssa/coreml/graph_pass/op_removals.py
+++ b/coremltools/converters/nnssa/coreml/graph_pass/op_removals.py
@@ -138,7 +138,8 @@ def remove_identity(nnssa):
 
 
 def remove_oneway_split(nnssa):
-
+    """ Remove split op with 1 output that splits the input into itself.
+    """
     for fn_key in list(nnssa.functions.keys()):
         f = nnssa.functions[fn_key]
         keys = list(f.graph.keys())

--- a/coremltools/converters/nnssa/coreml/graph_pass/op_removals.py
+++ b/coremltools/converters/nnssa/coreml/graph_pass/op_removals.py
@@ -135,3 +135,42 @@ def remove_identity(nnssa):
     delete_count = _remove_internal_identity_nodes(nnssa)
     delete_count += _remove_output_identity_nodes(nnssa)
     print('%d identity nodes deleted' % delete_count)
+
+
+def remove_oneway_split(nnssa):
+
+    for fn_key in list(nnssa.functions.keys()):
+        f = nnssa.functions[fn_key]
+        keys = list(f.graph.keys())
+        for k in keys:
+            if k not in f.graph:
+                continue
+            node = f.graph[k]
+            if not (node.op == 'Split' and node.attr['num_split'] == 1 and
+                len(node.datatype.T) == 1 and len(node.inputs) == 2):
+                continue
+
+            if f.graph[node.inputs[0]].op == 'Const':
+                axis_name, parent_name = node.inputs
+            elif f.graph[node.inputs[1]].op == 'Const':
+                parent_name, axis_name = node.inputs
+            else:
+                continue
+
+            if len(node.outputs) == 1 and f.graph[node.outputs[0]].op == 'get_tuple':
+                get_tuple_name = node.outputs[0]
+            else:
+                continue
+
+            parent_node = f.graph[parent_name]
+            get_tuple_node = f.graph[get_tuple_name]
+            for out_name in get_tuple_node.outputs:
+                out_node = f.graph[out_name]
+                out_node.inputs = [parent_name if x == get_tuple_name else x \
+                    for x in out_node.inputs]
+                out_node.control_inputs = [parent_name if x == get_tuple_name \
+                    else x for x in out_node.control_inputs]
+            parent_node.outputs = get_tuple_node.outputs[:]
+            parent_node.control_outputs = get_tuple_node.control_outputs[:]
+
+            del f.graph[axis_name], f.graph[k], f.graph[get_tuple_name]

--- a/coremltools/converters/nnssa/coreml/shapes.py
+++ b/coremltools/converters/nnssa/coreml/shapes.py
@@ -26,16 +26,20 @@ def _slice_static(layer_spec, input_shapes):
     output_shape = [-1] * rank
     begin_indices = params.beginIds
     end_indices = params.endIds
+    begin_masks = params.beginMasks
+    end_masks = params.endMasks
+
     for i in range(rank):
         begin_indices[i] = begin_indices[i] if begin_indices[i] >= 0 else input_shape[i] + begin_indices[i]
         end_indices[i] = end_indices[i] if end_indices[i] >= 0 else input_shape[i] + end_indices[i]
     for idx, dim in enumerate(input_shape):
         if dim > 0:  # known
-            begin = 0 if params.beginMasks[idx] else begin_indices[idx]
-            end = dim if params.endMasks[idx] else end_indices[idx]
-            output_shape[idx] = (end - begin) // params.strides[idx]
-            if (end - begin) % params.strides[idx] != 0:
-                output_shape[idx] += 1
+            begin = None if params.beginMasks[idx] else begin_indices[idx]
+            end = None if params.endMasks[idx] else end_indices[idx]
+            thisslice = slice(begin, end, params.strides[idx])
+            thisslicelen = len(list(range(input_shape[idx]))[thisslice])
+            output_shape[idx] = thisslicelen
+
     return [output_shape]
 
 

--- a/coremltools/converters/nnssa/coreml/ssa_converter.py
+++ b/coremltools/converters/nnssa/coreml/ssa_converter.py
@@ -112,6 +112,7 @@ def ssa_convert(ssa,
         fuse_conv_mul_add_into_batchnorm,
         spatial_reduce_to_global_pool,
         fuse_pad_into_conv,
+        remove_oneway_split,
     ]
 
     for p in passes:
@@ -1898,7 +1899,10 @@ class SSAConverter(object):
         top, bottom = paddings[1][0], paddings[1][1]
 
         if node.attr.get('mode', '').lower() == 'symmetric':
-            raise NotImplementedError('symmetric mode is not supported.')
+            print('[SSAConverter]Warning: Symmetric MirrorPad is not supported'
+                  'but can be approximated with non-symmetric padding in some'
+                  'cases. Conversion will continue, but expect some loss'
+                  'of model accuracy.')
         builder = self._get_builder()
 
         layer = builder.add_padding(
@@ -2138,33 +2142,39 @@ class SSAConverter(object):
             raise ValueError('[SSAConverter] ResizeNearestNeighbor has invalid'
                              'input shape {}'.format(input_shape))
 
-        if (target_size[0] % input_shape[2] > 0 or
-                target_size[1] % input_shape[3] > 0):
-            raise ValueError('[SSAConverter] Unsupported fractional'
-                             'nearest-neighbor upsampling')
+        if target_size[0] < input_shape[2] and target_size[1] < input_shape[3]:
+            self._convert_resize_bilinear(node)
 
-        scaling_factor_h = int(target_size[0] / input_shape[2])
-        scaling_factor_w = int(target_size[1] / input_shape[3])
+        elif target_size[0] > input_shape[2] and target_size[1] > input_shape[3]:
+            if (target_size[0] % input_shape[2] > 0 or
+                    target_size[1] % input_shape[3] > 0):
+                raise ValueError('[SSAConverter] Unsupported fractional'
+                                 'nearest-neighbor upsampling')
 
-        if scaling_factor_h <= 0 or scaling_factor_w <= 0:
-            raise ValueError('[SSAConverter] Invalid scaling factor.')
+            scaling_factor_h = int(target_size[0] / input_shape[2])
+            scaling_factor_w = int(target_size[1] / input_shape[3])
 
-        if node.attr.get('align_corners', False) is True:
-            raise ValueError('[SSAConverter] CoreML does not support '
-                             'ResizeNearestNeighbor with align_core.')
+            if scaling_factor_h <= 0 or scaling_factor_w <= 0:
+                raise ValueError('[SSAConverter] Invalid scaling factor.')
 
-        builder = self._get_builder()
-        layer = builder.add_upsample(
-            name=node.name,
-            scaling_factor_h=scaling_factor_h,
-            scaling_factor_w=scaling_factor_w,
-            input_name=input_names[0],
-            output_name=node.name,
-            mode='NN')
+            if node.attr.get('align_corners', False) is True:
+                raise ValueError('[SSAConverter] CoreML does not support '
+                                 'ResizeNearestNeighbor with align_core.')
 
-        output_shape = self._get_tensor_shape_from_type(node.datatype)
-        shapes.propagate_single_layer(layer, self.tensor_shapes,
-                                      output_shapes=[output_shape])
+            builder = self._get_builder()
+            layer = builder.add_upsample(
+                name=node.name,
+                scaling_factor_h=scaling_factor_h,
+                scaling_factor_w=scaling_factor_w,
+                input_name=input_names[0],
+                output_name=node.name,
+                mode='NN')
+
+            output_shape = self._get_tensor_shape_from_type(node.datatype)
+            shapes.propagate_single_layer(layer, self.tensor_shapes,
+                                          output_shapes=[output_shape])
+        else:
+            raise NotImplementedError("[SSAConverter] Unsupported resizing option.")
 
     def _convert_layer_normalization(self, node):
         assert len(node.inputs) == 1
@@ -2323,28 +2333,12 @@ class SSAConverter(object):
 
         builder = self._get_builder()
 
-        layer = builder.add_transpose(
-            name=node.name + '_transpose1',
-            input_name=input_names[0],
-            output_name=node.name + '_transpose1',
-            axes=[0, 3, 1, 2]
-        )
-        shapes.propagate_single_layer(layer, self.tensor_shapes)
-
         layer = builder.add_reorganize_data(
-            name=node.name + '_reorganize',
-            input_name=node.name + '_transpose1',
-            output_name=node.name + '_reorganize',
+            name=node.name,
+            input_name=input_names[0],
+            output_name=node.name,
             mode=mode,
             block_size=block_size
-        )
-        shapes.propagate_single_layer(layer, self.tensor_shapes)
-
-        layer = builder.add_transpose(
-            name=node.name,
-            input_name=node.name + '_reorganize',
-            output_name=node.name,
-            axes=[0, 2, 3, 1]
         )
         shapes.propagate_single_layer(layer, self.tensor_shapes)
 

--- a/coremltools/converters/nnssa/frontend/graph_pass/type_inference.py
+++ b/coremltools/converters/nnssa/frontend/graph_pass/type_inference.py
@@ -1567,7 +1567,7 @@ class TypeInferenceVisitor(object):
                     except:
                         pass
                 for i in begin_mask:
-                    begin[i] = 0
+                    begin[i] = None
                 for i in end_mask:
                     end[i] = None
                 for i in shrink_axes:
@@ -1596,13 +1596,13 @@ class TypeInferenceVisitor(object):
                         else:
                             retshape.append(make_symbol(node.name + '_' + str(i)))
                     else:
-                        if begin[i] < 0:
+                        if begin[i] is not None and begin[i] < 0:
                             try:
                                 begin[i] += input_shape[i]
                             except:
                                 pass
                         if end[i] is None:
-                            end[i] = input_shape[i]
+                            end[i] = None # used to be input_shape[i]
                         elif end[i] < 0:
                             try:
                                 end[i] += input_shape[i]


### PR DESCRIPTION
This PR:
(1) Add a graph pass to remove dummy split layer
(2) Fix bug in nnssa type inference in strided-slice
(3) Add conversion function to ResizeNearestNeighbor when target size is smaller than input size
(4) Remove transposes around DepthToSpace/SpaceToDepth conversion
(5) Allow conversion to proceed with unsupported symmetric mirror pad and give a warning