### PR TITLE
Fix two trivial bugs when `target_ios='13'`

### DIFF
--- a/coremltools/converters/nnssa/coreml/ssa_converter.py
+++ b/coremltools/converters/nnssa/coreml/ssa_converter.py
@@ -156,27 +156,28 @@ def ssa_convert(ssa,
 
     # Add classifier classes (if applicable)
     if is_classifier:
+        classes = []
         classes_in = class_labels
-        if isinstance(classes_in, _string_types):
+        if isinstance(classes_in, _string_types): # string
             import os
             if not os.path.isfile(classes_in):
                 raise ValueError("Path to class labels (%s) does not exist." % \
                                  classes_in)
-                with open(classes_in, 'r') as f:
-                    classes = f.read()
-                classes = classes.splitlines()
-            elif type(classes_in) is list:  # list[int or str]
-                classes = classes_in
-            else:
-                raise ValueError('Class labels must be a list of integers / strings,' \
-                                 ' or a file path')
+            with open(classes_in, 'r') as f:
+                classes = f.read()
+            classes = classes.splitlines()
+        elif type(classes_in) is list:  # list[int or str]
+            classes = classes_in
+        else:
+            raise ValueError('Class labels must be a list of integers / strings,' \
+                             ' or a file path')
 
-            if predicted_feature_name is not None:
-                builder.set_class_labels(
-                    classes, predicted_feature_name=predicted_feature_name,
-                    prediction_blob=predicted_probabilities_output)
-            else:
-                builder.set_class_labels(classes)
+        if predicted_feature_name is not None:
+            builder.set_class_labels(
+                classes, predicted_feature_name=predicted_feature_name,
+                prediction_blob=predicted_probabilities_output)
+        else:
+            builder.set_class_labels(classes)
 
     image_format = ssa.get_image_format()
     # Set pre-processing parameters

--- a/coremltools/models/neural_network/builder.py
+++ b/coremltools/models/neural_network/builder.py
@@ -3318,7 +3318,7 @@ class NeuralNetworkBuilder(object):
                             input_name=input_.name,
                             output_name=input_transpose
                         )
-                        layers = spec.neuralNetwork.layers
+                        layers = self.nn_spec.layers
                         layers.insert(0, layers.pop())
                         for layer_ in layers:
                             for i in range(len(layer_.input)):

--- a/coremltools/test/neural_network/test_neural_networks.py
+++ b/coremltools/test/neural_network/test_neural_networks.py
@@ -156,7 +156,11 @@ class TFBasicConversionTest(unittest.TestCase):
             conv_layer_out = my_conv
         return conv_layer_out
 
-    def test_prepare(self):
+    def test_1(self):
+        with open('/tmp/labels.txt', 'w+') as labels_file:
+            for a in range(10):
+                labels_file.write(str(a + 1)+"\n")
+
         image_size = 224
 
         with tf.Graph().as_default():


### PR DESCRIPTION
I cannot convert simple network with `image_input_names = ...` (i.e., classifier) and `class_labels = FILENAME` without these two one-line patches.

what I used to convert TensorFlow frozen pb is something like:
```python
model = tf_converter.convert(tf_model_path = 'mobilenet_v2_1.0_224.pb',
                     mlmodel_path = 'MobileNetV2.mlmodel',
                     image_input_names = ['input'],
                     input_name_shape_dict = {'input' : [1, 224, 224, 3]},
                     output_feature_names = ['MobilenetV2/Predictions/Softmax'],
                     class_labels = 'labels.txt',
                     predicted_feature_name = 'classLabel',
                     predicted_probabilities_output = 'classLabelProbs',
                     red_bias = -1,
                     green_bias = -1,
                     blue_bias = -1,
                     image_scale = 2.0/255.0,
                     target_ios='13')
```