### PR TITLE
Fixed the initialization list of the layer types in _optimize_nn()

### DIFF
--- a/coremltools/models/neural_network/optimization_utils.py
+++ b/coremltools/models/neural_network/optimization_utils.py
@@ -172,7 +172,11 @@ def _get_nn_mappings(layers):
 
 def _optimize_nn(layers):
     type_map, output_map, input_map = _get_nn_mappings(layers)
-    bn_layers = conv_layers = ip_layers = bias_layers = scale_layers = []
+    bn_layers = []
+    conv_layers = []
+    ip_layers = []
+    bias_layers = []
+    scale_layers = []
 
     # Only fuse with non-instance batchnorm layers
     if 'batchnorm' in type_map.keys():


### PR DESCRIPTION
When I tried to quantize a model which has the batch normalization layers, in spite of not having scale layers, `_fuse_layer_with_scale_layer()` is called, and this process failed in the process of the model optimization.

if `bn_layers.append(bn_layer_idx)` is processed, it appends `bn_layer_idx` to `conv_layers`, `ip_layers`, `bias_layers` and `scale_layers`.
So I changed the line 175 in `optimization_utils.py`, the model quantization was succeeded.