### PR TITLE
Automate initial build and testing steps via CMake

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -24,22 +24,28 @@ cmake -H. -Bbuild
 make -C build -j3
 ```
 
-Then you can install it into your virtualenv:
+This build directory does not have to be identical to the `build` directory
+created by `./configure` as it is here.
 
-```shell
-pip install -e .
-```
+CMake `POST_BUILD` hooks on shared libraries targets will handle installing the
+dev tree into your virtualenv.
+
 ### Running Unit Tests
 
-You can run all the unite tests using the following command.
+You can run all the unit tests not marked as slow using the following command.
 
 ```shell
-pytest -rfs -m "not slow" coremltools/test
+make -j3 -C build pytest_no_slow
 ```
+
+To run all the tests instead, use the `pytest` target.
+
 See [pytest documentation](https://docs.pytest.org/en/latest/) to learn more
 about how to run a single unit test.
 
-If you would like a wheel to install outside of the virtualenv, 
+### Building wheels
+
+If you would like a wheel to install outside of the virtualenv (or in it), 
 use `make -C build dist` and find the resulting wheels in `build/dist/*.whl`.
 
 If you want to build a wheel for distribution or testing, there is a script

--- a/BUILD.md
+++ b/BUILD.md
@@ -35,10 +35,17 @@ dev tree into your virtualenv.
 You can run all the unit tests not marked as slow using the following command.
 
 ```shell
-make -j3 -C build pytest_no_slow
+pytest -rfs -m "no slow" <project_source_directory>/coremltools/test
 ```
 
-To run all the tests instead, use the `pytest` target.
+Shortcut targets to rebuild and run all the tests exist as well.
+This takes time, so the recommended workflow is to run only relevant tests until
+you're confident in a change.
+
+```shell
+make -j3 -C build pytest_no_slow
+make -j3 -C build pytest
+```
 
 See [pytest documentation](https://docs.pytest.org/en/latest/) to learn more
 about how to run a single unit test.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,19 +127,12 @@ foreach(cdir IN ITEMS ${copy_dirs})
   file(COPY ${CMAKE_SOURCE_DIR}/coremltools/${cdir}
        DESTINATION ${CMAKE_BINARY_DIR}/coremltools)
 endforeach()
-if(APPLE)
-  add_custom_command(
-    TARGET caffeconverter
-    POST_BUILD
-    COMMAND cp $<TARGET_FILE:caffeconverter> coremltools/libcaffeconverter.so
-  )
-else()
-  add_custom_command(
-    TARGET caffeconverter
-    POST_BUILD
-    COMMAND cp $<TARGET_FILE:caffeconverter> coremltools/libcaffeconverter.so
-  )
-endif()
+
+add_custom_command(
+  TARGET caffeconverter
+  POST_BUILD
+  COMMAND cp $<TARGET_FILE:caffeconverter> ${PROJECT_SOURCE_DIR}/coremltools/libcaffeconverter.so
+)
 
 find_library(CORE_VIDEO CoreVideo)
 find_library(CORE_ML CoreML)
@@ -187,7 +180,7 @@ if (APPLE AND CORE_VIDEO AND CORE_ML AND FOUNDATION)
   add_custom_command(
     TARGET coremlpython
     POST_BUILD
-    COMMAND cp $<TARGET_FILE:coremlpython> coremltools/libcoremlpython.so
+    COMMAND cp $<TARGET_FILE:coremlpython> ${PROJECT_SOURCE_DIR}/coremltools/libcoremlpython.so
   )
 
 else()
@@ -222,7 +215,17 @@ endforeach()
 # Add a 'dist' target that will build wheels for all possible platforms.
 add_custom_target(dist DEPENDS ${plat_targets})
 
+add_custom_target(pip_install_dev
+  COMMAND pip install -e ${PROJECT_SOURCE_DIR}
+  DEPENDS "caffeconverter;coremlpython"
+)
+
 add_custom_target(pytest
-  COMMAND pytest coremltools/test/
-  DEPENDS dist
+  COMMAND pytest -r fs ${PROJECT_SOURCE_DIR}/coremltools/test/
+  DEPENDS pip_install_dev
+)
+
+add_custom_target(pytest_no_slow
+  COMMAND pytest -r fs -m '"no slow"' ${PROJECT_SOURCE_DIR}/coremltools/test/
+  DEPENDS pip_install_dev
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,8 +207,9 @@ foreach(platform IN ITEMS ${PLAT_NAME})
       bdist_wheel
       --plat-name=${platform}
       --python-tag=${PYTHON_TAG}
+      --dist-dir=${PROJECT_BINARY_DIR}/dist
     DEPENDS "caffeconverter;coremlpython;${plat_targets}"
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   )
   set(plat_targets "${plat_targets};dist_${platform}")
 endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,9 +223,11 @@ add_custom_target(pip_install_dev
 add_custom_target(pytest
   COMMAND pytest -r fs ${PROJECT_SOURCE_DIR}/coremltools/test/
   DEPENDS pip_install_dev
+  USES_TERMINAL
 )
 
 add_custom_target(pytest_no_slow
   COMMAND pytest -r fs -m '"no slow"' ${PROJECT_SOURCE_DIR}/coremltools/test/
   DEPENDS pip_install_dev
+  USES_TERMINAL
 )

--- a/configure
+++ b/configure
@@ -7,6 +7,8 @@ set -e
 ## Main configuration processing
 COREMLTOOLS_HOME=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 BUILD_DIR="${COREMLTOOLS_HOME}/build"
+# TODO(Keith-Wyss): Allow configuring BUILD_DIR. This doesn't have to be the
+# same as CMAKE's build directory, but scripts/python_env.sh relies on it.
 COREMLTOOLS_ENV=coremltools-dev
 
 # command flag options


### PR DESCRIPTION
This adds support for out of tree builds.
Existing definitions were conflicted about expected and also not
allowing source and build directories to be identical, so POST_BUILD
hooks did not resolve.