### PR TITLE
Add image_format parameter to TensorFlow converter

### DIFF
--- a/coremltools/converters/nnssa/coreml/ssa_converter.py
+++ b/coremltools/converters/nnssa/coreml/ssa_converter.py
@@ -93,7 +93,8 @@ def ssa_convert(ssa,
         This is required for new converter path, which maintains and propagates shapes while converting operators.
     image_format: str
       Optional and valid if image_input_names is also set. Specify either 'NCHW' or 'NHWC' to set or
-      override the image format. Defaults to None, in which case the image format may be determined from the input model.
+      override the image format. If not set, tries to use hints from the graph which may be present in convolution or
+      other image-specific layers. Ultimately defaults to NHWC.
     """
     if not custom_conversion_functions:
         custom_conversion_functions = dict()

--- a/coremltools/converters/nnssa/coreml/ssa_converter.py
+++ b/coremltools/converters/nnssa/coreml/ssa_converter.py
@@ -36,6 +36,7 @@ def ssa_convert(ssa,
                 inputs=None,
                 outputs=None,
                 image_input_names=None,
+                image_format=None,
                 is_bgr=False,
                 red_bias=0.0,
                 green_bias=0.0,
@@ -88,6 +89,9 @@ def ssa_convert(ssa,
     custom_shape_functions : dict of str -> functions or empty dict
         Specify custom function to compute `output` shape given `input` shape for given custom operator
         This is required for new converter path, which maintains and propagates shapes while converting operators.
+    image_format: str
+      Optional and valid if image_input_names is also set. Specify either 'NCHW' or 'NHWC'  to set or
+      override the image format. Without this field set, the image format may be determined from the input model.
     """
     if not custom_conversion_functions:
         custom_conversion_functions = dict()
@@ -184,7 +188,7 @@ def ssa_convert(ssa,
         else:
             builder.set_class_labels(classes)
 
-    image_format = ssa.get_image_format()
+    image_format = image_format or ssa.get_image_format()
     # Set pre-processing parameters
     builder.set_pre_processing_parameters(image_input_names=image_input_names,
                                           is_bgr=is_bgr,

--- a/coremltools/converters/nnssa/coreml/ssa_converter.py
+++ b/coremltools/converters/nnssa/coreml/ssa_converter.py
@@ -194,7 +194,7 @@ def ssa_convert(ssa,
     if image_format and detected_image_format and image_format != detected_image_format:
         warn('[SSAConverter] Detected image format different from input.'
               'Detected: {} Input: {}'.format(detected_image_format, image_format))
-    image_format = image_format or detected_image_format
+    image_format = image_format or detected_image_format or 'NHWC'
 
     # Set pre-processing parameters
     builder.set_pre_processing_parameters(image_input_names=image_input_names,

--- a/coremltools/converters/tensorflow/_tf_converter.py
+++ b/coremltools/converters/tensorflow/_tf_converter.py
@@ -12,7 +12,7 @@ def convert(filename,
             inputs=None,
             outputs=None,
             image_input_names=None,
-            image_format=None,
+            tf_image_format=None,
             is_bgr=False,
             red_bias=0.0,
             green_bias=0.0,
@@ -46,12 +46,13 @@ def convert(filename,
         Model output names.
 
     image_input_names: [str] | str
-      Input names (a subset of the keys of input_name_shape_dict)
+      Input names (a subset of the keys of inputs)
       that can be treated as images by Core ML. All other inputs
       are treated as MultiArrays.
-    image_format: str
-      Optional. Specify either 'NCHW' or 'NHWC' to set or override the image format. Without this
-      field set, the image format may be determined from the input model.
+    tf_image_format: str
+      Optional and valid if image_input_names is also set. Specify either 'NCHW' or 'NHWC' to set or
+      override the image format. If not set, tries to use hints from the graph which may be present in convolution or
+      other image-specific layers. Ultimately defaults to NHWC.
     is_bgr: bool | dict():
       Applicable only if image_input_names is specified.
       To specify different values for each image input provide a dictionary with input names as keys and booleans as values.
@@ -127,8 +128,8 @@ def convert(filename,
 
         model = coremltools.converters.tensorflow.convert(
             './model.h5',
-             input_name_shape_dict={'input_1': (1, 224, 224, 3)},
-             output_feature_names=['Identity']
+             inputs={'input_1': (1, 224, 224, 3)},
+             outputs=['Identity']
         )
 
     For more examples, see: https://github.com/apple/coremltools/blob/master/docs/NeuralNetworkGuide.md
@@ -182,7 +183,7 @@ def convert(filename,
                              inputs=inputs,
                              outputs=outputs,
                              image_input_names=image_input_names,
-                             image_format=image_format,
+                             image_format=tf_image_format,
                              is_bgr=is_bgr,
                              red_bias=red_bias,
                              green_bias=green_bias,

--- a/coremltools/converters/tensorflow/_tf_converter.py
+++ b/coremltools/converters/tensorflow/_tf_converter.py
@@ -12,6 +12,7 @@ def convert(filename,
             inputs=None,
             outputs=None,
             image_input_names=None,
+            image_format=None,
             is_bgr=False,
             red_bias=0.0,
             green_bias=0.0,
@@ -48,6 +49,9 @@ def convert(filename,
       Input names (a subset of the keys of input_name_shape_dict)
       that can be treated as images by Core ML. All other inputs
       are treated as MultiArrays.
+    image_format: str
+      Optional. Specify either 'NCHW' or 'NHWC' to set or override the image format. Without this
+      field set, the image format may be determined from the input model.
     is_bgr: bool | dict():
       Applicable only if image_input_names is specified.
       To specify different values for each image input provide a dictionary with input names as keys and booleans as values.
@@ -178,6 +182,7 @@ def convert(filename,
                              inputs=inputs,
                              outputs=outputs,
                              image_input_names=image_input_names,
+                             image_format=image_format,
                              is_bgr=is_bgr,
                              red_bias=red_bias,
                              green_bias=green_bias,

--- a/coremltools/test/neural_network/test_neural_networks.py
+++ b/coremltools/test/neural_network/test_neural_networks.py
@@ -262,12 +262,6 @@ class TFBasicConversionTest(unittest.TestCase):
             output_feature_names=['Softmax'],
             image_format='NHWC')
         spec = mlmodel.get_spec()
-        # Layers are not in a deterministic order - checking all layers to see that
-        # the expected one is present.
-        for layer in spec.neuralNetwork.layers:
-            if layer.name == "input_to_nhwc":
-                return
-        self.fail("Could not find input_to_nhwc layer")
 
     def test_classifier_nchw(self):
         # Expect failure - input dimensions are incompatible with NCHW

--- a/coremltools/test/neural_network/test_neural_networks.py
+++ b/coremltools/test/neural_network/test_neural_networks.py
@@ -254,13 +254,15 @@ class TFBasicConversionTest(unittest.TestCase):
     def test_classifier_nhwc(self):
         # Test manually specifying the image format. The converter would have
         # detected NHWC.
-        coremltools.converters.tensorflow.convert(
+        mlmodel = coremltools.converters.tensorflow.convert(
             self.frozen_graph_file,
             mlmodel_path=self.converted_coreml_file,
             input_name_shape_dict={'input': [1, 224, 224, 3]},
             image_input_names=['input'],
             output_feature_names=['Softmax'],
             image_format='NHWC')
+        spec = mlmodel.get_spec()
+        self.assertEqual(spec.neuralNetwork.layers[0].name, "input_to_nhwc",)
 
     def test_classifier_nchw(self):
         # Expect failure - input dimensions are incompatible with NCHW

--- a/coremltools/test/neural_network/test_neural_networks.py
+++ b/coremltools/test/neural_network/test_neural_networks.py
@@ -262,7 +262,12 @@ class TFBasicConversionTest(unittest.TestCase):
             output_feature_names=['Softmax'],
             image_format='NHWC')
         spec = mlmodel.get_spec()
-        self.assertEqual(spec.neuralNetwork.layers[0].name, "input_to_nhwc",)
+        # Layers are not in a deterministic order - checking all layers to see that
+        # the expected one is present.
+        for layer in spec.neuralNetwork.layers:
+            if layer.name == "input_to_nhwc":
+                return
+        self.fail("Could not find input_to_nhwc layer")
 
     def test_classifier_nchw(self):
         # Expect failure - input dimensions are incompatible with NCHW

--- a/coremltools/test/neural_network/test_neural_networks.py
+++ b/coremltools/test/neural_network/test_neural_networks.py
@@ -243,6 +243,35 @@ class TFBasicConversionTest(unittest.TestCase):
             predicted_feature_name='classLabel',
             class_labels=['1', '2', '3', '4', '5', '6', '7', '8', '9', '10'])
 
+    def test_classifier_without_class_labels(self):
+        coremltools.converters.tensorflow.convert(
+            self.frozen_graph_file,
+            mlmodel_path=self.converted_coreml_file,
+            input_name_shape_dict={'input': [1, 224, 224, 3]},
+            image_input_names=['input'],
+            output_feature_names=['Softmax'])
+
+    def test_classifier_nhwc(self):
+        # Test manually specifying the image format. The converter would have
+        # detected NHWC.
+        coremltools.converters.tensorflow.convert(
+            self.frozen_graph_file,
+            mlmodel_path=self.converted_coreml_file,
+            input_name_shape_dict={'input': [1, 224, 224, 3]},
+            image_input_names=['input'],
+            output_feature_names=['Softmax'],
+            image_format='NHWC')
+
+    def test_classifier_nchw(self):
+        # Expect failure - input dimensions are incompatible with NCHW
+        with self.assertRaises(ValueError) as e:
+            coremltools.converters.tensorflow.convert(
+                self.frozen_graph_file,
+                mlmodel_path=self.converted_coreml_file,
+                input_name_shape_dict={'input': [1, 224, 224, 3]},
+                image_input_names=['input'],
+                output_feature_names=['Softmax'],
+                image_format='NCHW')
 
 class CustomLayerUtilsTest(unittest.TestCase):
 


### PR DESCRIPTION
 Add image_format parameter to TensorFlow converter to allow callers to manually specify NCHW or NHWC format, if needed.