### PR TITLE
Collect artifacts from the newly minted python 3.7 linux target

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -236,6 +236,7 @@ collect_artifacts:
     - build_wheel_linux_py27
     - build_wheel_linux_py35
     - build_wheel_linux_py36
+    - build_wheel_linux_py37
     - build_wheel_macos_py27
     - build_wheel_macos_py35
     - build_wheel_macos_py36


### PR DESCRIPTION
The artifact from the linux python 3.7 wasn't in the list.