### PR TITLE
Added quantization utils to allow extending FP16 CoreML models to FP32

### DIFF
--- a/coremltools/models/neural_network/quantization_utils.py
+++ b/coremltools/models/neural_network/quantization_utils.py
@@ -10,7 +10,6 @@ Only available in coremltools 2.0b1 and onwards
 from __future__ import print_function as _
 from __future__ import division as _
 from __future__ import absolute_import as _
-
 import numpy as _np
 import sys, os
 from .optimization_utils import _optimize_nn
@@ -26,7 +25,7 @@ from coremltools.models import (
     _LUT_BASED_QUANTIZATION
 )
 
-from ..utils import _get_nn_layers, _wp_to_fp16wp, _get_model, macos_version
+from ..utils import _get_nn_layers, _wp_to_fp16wp, _fp16wp_to_fp32wp, _get_model, macos_version
 from ..._deps import HAS_SKLEARN as _HAS_SKLEARN
 from ... import (_MINIMUM_QUANTIZED_MODEL_SPEC_VERSION,
                  _MINIMUM_FP16_SPEC_VERSION)
@@ -392,8 +391,10 @@ def _quantize_wp(wp, nbits, qm, axis=0, **kwargs):
     else:
         raise NotImplementedError(
             'Quantization method "{}" not supported'.format(qm))
-
-    quantized_wp = _np.uint8(qw)
+    if nbits <= 8:
+        quantized_wp = _np.uint8(qw)
+    elif nbits == 32:
+        quantized_wp = _np.float32(qw)
     return scale, bias, lut, quantized_wp
 
 
@@ -415,21 +416,29 @@ def _quantize_wp_field(wp, nbits, qm, shape, axis=0, **kwargs):
     lut_function: (``callable function``)
         Python callable representing a LUT table function
     """
-
     # De-quantization
     if qm == _QUANTIZATION_MODE_DEQUANTIZE:
         return _dequantize_wp(wp, shape, axis)
 
+    # Half precision to full precision extension
+    if nbits == 32:
+        # If the weights are stored in a float16 byte array as a string, we can read it and convert
+        # to a float32 numpy array before populating the field for the weightparam since we cannot
+        # directly assign to this field.
+        if len(wp.float16Value) > 0:
+            wp.floatValue.extend(_np.float32(_np.fromstring(wp.float16Value, dtype='float16')))
+            wp.float16Value = ''
+            return
+        if len(wp.floatValue) > 0:
+            return
+    
     # If the float32 field is empty do nothing and return
     if len(wp.floatValue) == 0:
         return
-
+    
     # Half precision (16-bit) quantization
     if nbits == 16:
         return _wp_to_fp16wp(wp)
-
-    if nbits > 8:
-        raise Exception('Only 8-bit and lower quantization is supported')
 
     if qm not in _SUPPORTED_QUANTIZATION_MODES:
         raise Exception('Quantization mode {} not supported'.format(qm))
@@ -467,7 +476,9 @@ def _quantize_wp_field(wp, nbits, qm, shape, axis=0, **kwargs):
     else:
         wp.rawValue += _convert_array_to_nbit_quantized_bytes(uint8_weights,
             nbits).tobytes()
-    del wp.floatValue[:]
+    # Delete the field for 32bit float if not converting to 32bit
+    if nbits != 32:
+        del wp.floatValue[:]
 
 
 def unpack_to_bytes(byte_arr, num_weights, nbits):
@@ -560,7 +571,7 @@ def _quantize_nn_spec(nn_spec, nbits, qm, **kwargs):
     if qm != _QUANTIZATION_MODE_DEQUANTIZE:
         if nbits is None:
             raise Exception('Missing argument "nbits"')
-        if not (nbits > 0 and nbits <= 8 or nbits == 16):
+        if not (nbits > 0 and nbits <= 8 or nbits == 16 or nbits==32):
             raise Exception('Only half precision (16-bit), 1 to 8-bit '
                     'quantization is supported')
 

--- a/coremltools/models/utils.py
+++ b/coremltools/models/utils.py
@@ -181,6 +181,29 @@ def _fp32_to_fp16_byte_array(fp32_arr):
         return _fp32_to_reversed_fp16_byte_array(fp32_arr)
 
 
+def _fp16_to_reversed_fp32_byte_array(fp16_arr):
+    raw_fp32 = _np.float32(fp16_arr)
+    x = ''
+    for fp32 in raw_fp32:
+        all_bytes = _np.fromstring(fp32.tobytes(), dtype='int8')
+        x += all_bytes[3].tobytes()
+        x += all_bytes[2].tobytes()
+        x += all_bytes[1].tobytes()
+        x += all_bytes[0].tobytes()
+    return x
+
+
+def _fp16_to_fp32_byte_array(fp16_arr):
+    import sys
+    if sys.byteorder == 'little':
+        if type(fp16_arr) == str:
+            return _np.float32(_np.fromstring(fp16_arr, dtype='float16')).tobytes()
+        else:
+            return _np.float32(fp16_arr).tobytes()
+    else:
+        return _fp32_to_reversed_fp16_byte_array(fp32_arr)
+
+
 def _wp_to_fp16wp(wp):
     assert wp
     # If the float32 field is empty do nothing.
@@ -188,6 +211,14 @@ def _wp_to_fp16wp(wp):
         return
     wp.float16Value = _fp32_to_fp16_byte_array(wp.floatValue)
     del wp.floatValue[:]
+
+def _fp16wp_to_fp32wp(wp):
+    assert wp
+    # If the float16 field is empty do nothing.
+    if len(wp.float16Value) == 0:
+        return
+    wp.floatValue = _fp16_to_fp32_byte_array(wp.float16Value)
+    del wp.float16Value[:]
 
 
 def convert_neural_network_spec_weights_to_fp16(fp_spec):
@@ -229,6 +260,37 @@ def convert_neural_network_weights_to_fp16(full_precision_model):
     spec = full_precision_model.get_spec()
     return _get_model(convert_neural_network_spec_weights_to_fp16(spec))
 
+
+def convert_neural_network_spec_weights_to_fp32(fp16_spec):
+    nn_model_types = ['neuralNetwork', 'neuralNetworkClassifier',
+                      'neuralNetworkRegressor']
+
+    from .neural_network.quantization_utils import quantize_spec_weights
+    from .neural_network.quantization_utils import _QUANTIZATION_MODE_LINEAR_QUANTIZATION
+
+    qspec = quantize_spec_weights(fp16_spec, 32, _QUANTIZATION_MODE_LINEAR_QUANTIZATION)
+
+    return qspec
+
+
+def convert_neural_network_weights_to_fp32(fp16_model):
+    """ 
+    Utility function to convert a 16 bit FP model in MLModel to full precision
+    by extending the weights to be float (32 bit)
+    Parameters
+    ----------
+    half_precision_model: MLModel
+        Model which will be converted to full precision. Currently conversion
+        for only neural network models is supported. If a pipeline model is
+        passed in then all embedded neural network models embedded within
+        will be converted.
+
+    Returns -------
+    model: MLModel
+        Thehalf converted full precision MLModel
+    """
+    spec = fp16_model.get_spec()
+    return _get_model(convert_neural_network_spec_weights_to_fp32(spec))
 
 def _get_model(spec):
     """


### PR DESCRIPTION
Extend the parameters of a FP16 MLModel to FP32 by typecasting in numpy and converting definitions in the model's graph definition protobuf.