### PR TITLE
Fix typo in jupyter notebook example

### DIFF
--- a/examples/neural_network_inference/Neural_network_control_flow_power_iteration.ipynb
+++ b/examples/neural_network_inference/Neural_network_control_flow_power_iteration.ipynb
@@ -170,7 +170,7 @@
     "# output shape: (n,1)\n",
     "loop_body_builder.add_batched_mat_mul('bmm.1', input_names=['matrix','x'], output_name='y')\n",
     "# normalize the vector\n",
-    "loop_body_builder.add_reduce_l2('reduce', input_name='y', output_name='norm', axes = 0)\n",
+    "loop_body_builder.add_reduce_l2('reduce', input_name='y', output_name='norm', axes = [0])\n",
     "loop_body_builder.add_divide_broadcastable('divide', ['y','norm'], 'y_normalized')\n",
     "\n",
     "# find difference with previous, which is computed as (1 - abs(cosine diff))\n",
@@ -436,21 +436,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fix invocation of the builder API for the reduce layer which now expects `axes` attribute to be a list