### PR TITLE
Fix alpha check to checking not None on ssa_converter.py

### DIFF
--- a/coremltools/converters/nnssa/coreml/ssa_converter.py
+++ b/coremltools/converters/nnssa/coreml/ssa_converter.py
@@ -2643,7 +2643,7 @@ class SSAConverter(object):
                     raise ValueError("Incorrect configuration!! Alpha not provided for Elementwise Div operator")
                 alpha = 1 / float(alpha)
             elif op == 'sub':
-                if alpha and inputs[0] == input_names[0]:
+                if alpha is not None and inputs[0] == input_names[0]:
                     alpha = -alpha
                 else:
                     neg_index = 1

--- a/coremltools/converters/tensorflow/test/test_convnets.py
+++ b/coremltools/converters/tensorflow/test/test_convnets.py
@@ -688,6 +688,16 @@ class TFSingleLayerTest(TFNetworkBatchTest):
         output_name = [output.op.name]
         self._test_tf_model_constant(graph, {y.op.name: input_shape}, output_name)
 
+    def test_sub_v3(self):
+        graph = tf.Graph()
+        input_shape = [1]
+        with graph.as_default():
+            x = tf.constant(0, shape=[])
+            y = tf.placeholder(tf.int32, shape=input_shape)
+            output = tf.math.subtract(y, x)
+        output_name = [output.op.name]
+        self._test_tf_model_constant(graph, {y.op.name: input_shape}, output_name)
+
     def test_mul(self):
         shape = [3, 4, 5]
         graph = tf.Graph()


### PR DESCRIPTION
When the conversion of `Sub` operation's second input value is zero, the following error occurred. I fix the error by replacing to `is not None` check.

![image](https://user-images.githubusercontent.com/37643248/76092652-1a432d80-6003-11ea-8dc4-087e5d8cd7a1.png)

<details>
<summary>log</summary>
<div markdown="1">

```
Traceback (most recent call last):
  File "/Users/doyounggwak/Project/ml-project/github/tf2-mobile-pose-estimation/tmp.py", line 80, in <module>
    outputs=[output_name]
  File "/Users/doyounggwak/anaconda3/envs/pose_tf2_env/lib/python3.6/site-packages/coremltools/converters/tensorflow/_tf_converter.py", line 193, in convert
    optional_inputs=optional_inputs)
  File "/Users/doyounggwak/anaconda3/envs/pose_tf2_env/lib/python3.6/site-packages/coremltools/converters/nnssa/coreml/ssa_converter.py", line 154, in ssa_convert
    converter.convert()
  File "/Users/doyounggwak/anaconda3/envs/pose_tf2_env/lib/python3.6/site-packages/coremltools/converters/nnssa/coreml/ssa_converter.py", line 581, in convert
    convert_func(node)
  File "/Users/doyounggwak/anaconda3/envs/pose_tf2_env/lib/python3.6/site-packages/coremltools/converters/nnssa/coreml/ssa_converter.py", line 2461, in _convert_binary
    if not _convert_binary_elementwise(node):
  File "/Users/doyounggwak/anaconda3/envs/pose_tf2_env/lib/python3.6/site-packages/coremltools/converters/nnssa/coreml/ssa_converter.py", line 2439, in _convert_binary_elementwise
    layer = builder.add_elementwise(name=node.name+'_'+inputs[neg_index]+'_neg',
IndexError: list index out of range
```

</div>
</details>
