### PR TITLE
fix the mode checking for SpaceToDepth and DepthToSpace (#676)

### DIFF
--- a/coremltools/converters/nnssa/coreml/shapes.py
+++ b/coremltools/converters/nnssa/coreml/shapes.py
@@ -2,6 +2,8 @@
 Shape inference functions.
 """
 
+from ....proto import NeuralNetwork_pb2 as _NeuralNetwork_pb2
+
 
 def _transpose(layer_spec, input_shapes):
     axes = list(layer_spec.transpose.axes)
@@ -446,11 +448,14 @@ def _unidirectional_lstm(layer_spec, input_shapes):
 def _reorganize_data(layer_spec, input_shapes):
     block_size = layer_spec.reorganizeData.blockSize
     output_shape = input_shapes[0][:]
-    if 'SpaceToDepth' in layer_spec.name or 'SpaceToBatchND' in layer_spec.name:
+    mode = layer_spec.reorganizeData.mode
+    space_to_depth_mode = _NeuralNetwork_pb2.ReorganizeDataLayerParams.ReorganizationType.Value('SPACE_TO_DEPTH')
+    depth_to_space_mode = _NeuralNetwork_pb2.ReorganizeDataLayerParams.ReorganizationType.Value('DEPTH_TO_SPACE')
+    if mode == space_to_depth_mode:
         output_shape[2] //= block_size
         output_shape[3] //= block_size
         output_shape[1] = output_shape[1] * block_size * block_size
-    elif 'DepthToSpace' in layer_spec.name or 'BatchToSpaceND' in layer_spec.name:
+    elif mode == depth_to_space_mode:
         output_shape[2] *= block_size
         output_shape[3] *= block_size
         output_shape[1] = output_shape[1] // (block_size * block_size)


### PR DESCRIPTION
Fixes #676 

Fix the mode checking for `SpaceToDepth` and `DepthToSpace` in function [`_reorganize_data()`](https://github.com/apple/coremltools/blob/master/coremltools/converters/nnssa/coreml/shapes.py#L446), since one should check the layer mode instead of layer name to get the accurate mode.

However, I'm not sure how to keep support for `SpaceToBatchND` nor `BatchToSpaceND`. It seems neither `SpaceToBatchND` nor `BatchToSpaceND` is supported In [ReorganizeDataLayerParams](https://apple.github.io/coremltools/coremlspecification/sections/NeuralNetwork.html#reorganizedatalayerparams).

According to `CONVERT_FUNCTION_MAP` in [`coremltools/converters/nnssa/coreml/ssa_converter.py`](https://github.com/apple/coremltools/blob/master/coremltools/converters/nnssa/coreml/ssa_converter.py#L355), the converter functions for `SpaceToBatchND` and `BatchToSpaceND` are [`_convert_space_to_batch_nd()`](https://github.com/apple/coremltools/blob/master/coremltools/converters/nnssa/coreml/ssa_converter.py#L447) and [`_convert_batch_to_space_nd()`](https://github.com/apple/coremltools/blob/master/coremltools/converters/nnssa/coreml/ssa_converter.py#L367) respectively. So I suspect that `_reorganize_data()` isn't responsible for op `SpaceToBatchND` and `BatchToSpaceND`.