### PR TITLE
support scikit-learn >= 0.21

### DIFF
--- a/coremltools/converters/sklearn/_imputer.py
+++ b/coremltools/converters/sklearn/_imputer.py
@@ -14,7 +14,13 @@ from ..._deps import HAS_SKLEARN as _HAS_SKLEARN
 
 if _HAS_SKLEARN:
     import sklearn
-    from sklearn.preprocessing import Imputer
+    try:
+        # scikit-learn >= 0.21
+        from sklearn.impute import SimpleImputer as Imputer
+    except ImportError:
+        # scikit-learn < 0.21
+        from sklearn.preprocessing import Imputer
+        
     model_type = 'transformer'
     sklearn_class = sklearn.preprocessing.Imputer
 


### PR DESCRIPTION
As of scikit-learn >= 0.21, the `Imputer` class no longer exists. I've addressed it in the same way as they've done [here](https://github.com/onnx/onnxmltools/pull/313/files), with a try-catch import. I'm really not a domain expert here, so I'm happy for other suggestions on how to resolve. 

Otherwise, with the current version of mltools running against scikit-learn >= 0.21, we'll get something like this when running `coreml_model = coremltools.converters.sklearn.convert(classifier)` : 

```
Traceback (most recent call last):
  File "my-script.py", line 68, in <module>
    main()
  File "my-script.py", line 61, in main
    coreml_model = coremltools.converters.sklearn.convert(classifier)
  File "/usr/local/lib/python3.7/site-packages/coremltools/converters/sklearn/_converter.py", line 145, in convert
    from ._converter_internal import _convert_sklearn_model
  File "/usr/local/lib/python3.7/site-packages/coremltools/converters/sklearn/_converter_internal.py", line 42, in <module>
    from . import _imputer
  File "/usr/local/lib/python3.7/site-packages/coremltools/converters/sklearn/_imputer.py", line 17, in <module>
    from sklearn.preprocessing import Imputer
ImportError: cannot import name 'Imputer' from 'sklearn.preprocessing' (/usr/local/lib/python3.7/site-packages/sklearn/preprocessing/__init__.py)
````