### PR TITLE
Handling default strides for max_pool2d and avg_pool2d 

### DIFF
--- a/coremltools/converters/mil/frontend/tensorflow/test/test_graphs.py
+++ b/coremltools/converters/mil/frontend/tensorflow/test/test_graphs.py
@@ -1,0 +1,48 @@
+#  Copyright (c) 2020, Apple Inc. All rights reserved.
+#
+#  Use of this source code is governed by a BSD-3-clause license that can be
+#  found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+
+from coremltools.converters.mil import testing_reqs
+from coremltools.converters.mil.testing_reqs import *
+from coremltools.converters.mil.frontend.tensorflow.test.testing_utils import (
+    make_tf_graph,
+    run_compare_tf,
+    layer_counts,
+)
+import math
+
+backends = testing_reqs.backends
+
+tf = pytest.importorskip("tensorflow")
+
+
+class TestTF1Graphs:
+
+    @pytest.mark.parametrize(
+        "use_cpu_only, backend", itertools.product([True, False], backends)
+    )
+    def test_masked_input(self, use_cpu_only, backend):
+
+        input_shape = [4, 10, 8]
+        val = np.random.rand(*input_shape).astype(np.float32)
+
+        @make_tf_graph([input_shape])
+        def build_model(input):
+            sliced_input = input[..., 4]
+            mask = tf.where_v2(sliced_input > 0)
+            masked_input = tf.gather_nd(input, mask)
+            return masked_input
+
+        model, inputs, outputs = build_model
+
+        input_values = [val]
+        input_dict = dict(zip(inputs, input_values))
+        run_compare_tf(
+            model,
+            input_dict,
+            outputs,
+            use_cpu_only=use_cpu_only,
+            frontend_only=False,
+            backend=backend,
+        )

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -1419,6 +1419,9 @@ def _avg_pool(context, node, inputs):
     x = inputs[0]
     kernel_sizes = inputs[1]
     strides = inputs[2]
+    if strides.op.op_type == "const"  and (not strides.val):
+        strides = mb.const(val=kernel_sizes.val, name=strides.name)
+
     pad_type = "custom"
     # Need to explicity state L-R, T-B pad
     pad = inputs[3]

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -496,6 +496,9 @@ def max_pool2d(context, node):
     x = inputs[0]
     kernel_sizes = inputs[1]
     strides = inputs[2]
+    if strides.op.op_type == "const"  and (not list(strides.val)):
+        strides = mb.const(val=kernel_sizes.val, name=strides.name)
+
     pad_type = "custom"
 
     # Need to explicity state L-R, T-B pad
@@ -1419,7 +1422,7 @@ def _avg_pool(context, node, inputs):
     x = inputs[0]
     kernel_sizes = inputs[1]
     strides = inputs[2]
-    if strides.op.op_type == "const"  and (not strides.val):
+    if strides.op.op_type == "const"  and (not list(strides.val)):
         strides = mb.const(val=kernel_sizes.val, name=strides.name)
 
     pad_type = "custom"

--- a/coremltools/converters/mil/frontend/torch/test/test_numerical.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_numerical.py
@@ -263,8 +263,8 @@ class TestTorchNumerical:
         "input_shape, kernel_size, stride, pad, include_pad",
         itertools.product(
             [(1, 3, 15, 15), (1, 1, 7, 7), (1, 3, 10, 10)],
-            [1, 2, 3],
-            [1, 2],
+            [4, 5, 6],
+            [1, 2, None],
             [0, 1],
             [True, False],
         ),
@@ -272,7 +272,10 @@ class TestTorchNumerical:
     def test_avg_pool2d(self, input_shape, kernel_size, stride, pad, include_pad):
         if pad > kernel_size / 2:
             return
-        model = nn.AvgPool2d(kernel_size, stride, pad, False, include_pad)
+        if stride:
+            model = nn.AvgPool2d(kernel_size, stride, pad, False, include_pad)
+        else:
+            model = nn.AvgPool2d(kernel_size, padding=pad, ceil_mode=False, count_include_pad=include_pad)
         run_numerical_test(input_shape, model)
 
     @pytest.mark.parametrize(
@@ -316,13 +319,16 @@ class TestTorchNumerical:
     @pytest.mark.parametrize(
         "input_shape, kernel_size, stride, pad",
         itertools.product(
-            [(1, 3, 15, 15), (1, 1, 7, 7), (1, 3, 10, 10)], [1, 2, 3], [1, 2], [0, 1],
+            [(1, 3, 15, 15), (1, 1, 7, 7), (1, 3, 10, 10)], [4, 5, 6], [1, 2, None], [0, 1],
         ),
     )
     def test_max_pool2d(self, input_shape, kernel_size, stride, pad):
         if pad > kernel_size / 2:
             return
-        model = nn.MaxPool2d(kernel_size, stride, pad, ceil_mode=False)
+        if stride:
+            model = nn.MaxPool2d(kernel_size, stride, pad, ceil_mode=False)
+        else:
+            model = nn.MaxPool2d(kernel_size, padding=pad, ceil_mode=False)
         run_numerical_test(input_shape, model)
 
     @pytest.mark.parametrize(

--- a/coremltools/converters/mil/mil/ops/defs/tensor_operation.py
+++ b/coremltools/converters/mil/mil/ops/defs/tensor_operation.py
@@ -16,8 +16,11 @@ from coremltools.converters.mil.mil import (
     VALUE,
     NONE,
 )
+
+from coremltools.converters.mil.mil import types
 from ._op_reqs import *
 from ._utils import promoted_primitive_type
+
 
 
 @register_op(doc_str="")
@@ -271,7 +274,7 @@ class non_zero(Operation):
 
     def type_inference(self):
         shape = tuple([get_new_symbol(), self.x.rank])
-        return types.tensor(self.x.dtype, shape)
+        return types.tensor(types.int, shape)
 
     @precondition(allow=VALUE)
     def value_inference(self):


### PR DESCRIPTION
This PR: 

1. Handles default/optional strides cases for max_pool2d and `avg_pool2d`
2. Fixes bug in the type inference for non-zero op