### PR TITLE
CI: run tests based on files touched

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -94,6 +94,15 @@ test_macos11_py27_coremltools_test:
   variables:
     WHEEL_PATH: build/dist/*cp27*10_16*
     PYTHON: "2.7"
+  only:
+    changes:
+      - coremltools/test/**/*.{py}
+      - coremltools/models/**/*.{py}
+      - coremltools/converters/caffe/**/*.{py}
+      - coremltools/converters/keras/**/*.{py}
+      - coremltools/converters/libsvm/**/*.{py}
+      - coremltools/converters/sklearn/**/*.{py}
+      - coremltools/converters/xgboost/**/*.{py}
 
 test_macos11_py37_coremltools_test:
   <<: *test_macos_coremltools_test
@@ -104,6 +113,15 @@ test_macos11_py37_coremltools_test:
   variables:
     WHEEL_PATH: build/dist/*cp37*10_16*
     PYTHON: "3.7"
+  only:
+    changes:
+      - coremltools/test/**/*.{py}
+      - coremltools/models/**/*.{py}
+      - coremltools/converters/caffe/**/*.{py}
+      - coremltools/converters/keras/**/*.{py}
+      - coremltools/converters/libsvm/**/*.{py}
+      - coremltools/converters/sklearn/**/*.{py}
+      - coremltools/converters/xgboost/**/*.{py}
 
 test_macos11_py27_pytorch:
   <<: *test_macos_pkg
@@ -115,6 +133,9 @@ test_macos11_py27_pytorch:
     PYTHON: "2.7"
     TEST_PACKAGE: coremltools.converters.mil.frontend.torch
     WHEEL_PATH: build/dist/*cp27*10_16*
+  only:
+    changes:
+      - coremltools/converters/mil/frontend/torch/**/*.{py}
 
 test_macos11_py37_pytorch:
   <<: *test_macos_pkg
@@ -126,6 +147,9 @@ test_macos11_py37_pytorch:
     PYTHON: "3.7"
     TEST_PACKAGE: coremltools.converters.mil.frontend.torch
     WHEEL_PATH: build/dist/*cp37*10_16*
+  only:
+    changes:
+      - coremltools/converters/mil/frontend/torch/**/*.{py}
 
 test_macos11_py27_tensorflow1:
   <<: *test_macos_pkg
@@ -137,6 +161,9 @@ test_macos11_py27_tensorflow1:
     PYTHON: "2.7"
     TEST_PACKAGE: coremltools.converters.mil.frontend.tensorflow
     WHEEL_PATH: build/dist/*cp27*10_16*
+  only:
+    changes:
+      - coremltools/converters/mil/frontend/tensorflow/**/*.{py}
 
 test_macos11_py37_tensorflow1:
   <<: *test_macos_pkg
@@ -148,6 +175,9 @@ test_macos11_py37_tensorflow1:
     PYTHON: "3.7"
     TEST_PACKAGE: coremltools.converters.mil.frontend.tensorflow
     WHEEL_PATH: build/dist/*cp37*10_16*
+  only:
+    changes:
+      - coremltools/converters/mil/frontend/tensorflow/**/*.{py}
 
 test_macos11_py27_tensorflow2:
   <<: *test_macos_pkg_with_reqs
@@ -160,6 +190,9 @@ test_macos11_py27_tensorflow2:
     REQUIREMENTS: reqs/test_tf2.pip
     TEST_PACKAGE: coremltools.converters.mil.frontend.tensorflow2
     WHEEL_PATH: build/dist/*cp27*10_16*
+  only:
+    changes:
+      - coremltools/converters/mil/frontend/tensorflow2/**/*.{py}
 
 test_macos11_py37_tensorflow2:
   <<: *test_macos_pkg_with_reqs
@@ -172,6 +205,37 @@ test_macos11_py37_tensorflow2:
     REQUIREMENTS: reqs/test_tf2.pip
     TEST_PACKAGE: coremltools.converters.mil.frontend.tensorflow2
     WHEEL_PATH: build/dist/*cp37*10_16*
+  only:
+    changes:
+      - coremltools/converters/mil/frontend/tensorflow2/**/*.{py}
+
+test_macos11_py27_mil:
+  <<: *test_macos_pkg
+  tags:
+    - macos11
+  dependencies:
+    - build_wheel_macos_py27
+  variables:
+    PYTHON: "2.7"
+    TEST_PACKAGE: coremltools.converters.mil.mil
+    WHEEL_PATH: build/dist/*cp27*10_16*
+  only:
+    changes:
+      - coremltools/converters/mil/**/*.{py}
+
+test_macos11_py37_mil:
+  <<: *test_macos_pkg
+  tags:
+    - macos11
+  dependencies:
+    - build_wheel_macos_py37
+  variables:
+    PYTHON: "3.7"
+    TEST_PACKAGE: coremltools.converters.mil.mil
+    WHEEL_PATH: build/dist/*cp37*10_16*
+  only:
+    changes:
+      - coremltools/converters/mil/**/*.{py}
 
 #########################################################################
 ##

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,6 +21,31 @@ check_python_flake8:
     - flake8 ./coremltools --count --select=E9,F63,F7,F82 --show-source --statistics
 
 
+########################################################################
+#
+#                         linux - Build & Test
+#
+########################################################################
+
+.build_linux: &build_linux
+  tags:
+    - docker
+  stage: build
+  script:
+    - export PATH=$PATH:$HOME/miniconda3/condabin
+    - bash -e scripts/build.sh --num-procs=4 --python=$PYTHON --dist
+  artifacts:
+    expire_in: 2 weeks
+    paths:
+      - build/dist/
+
+build_wheel_linux_py27:
+  <<: *build_linux
+  image: registry.gitlab.com/zach_nation/coremltools/build-image-ubuntu-14.04:1.0.3
+  variables:
+    PYTHON: "2.7"
+
+
 #########################################################################
 ##
 ##                         macOS - Build & Test
@@ -96,6 +121,7 @@ test_macos11_py27_coremltools_test:
     PYTHON: "2.7"
   only:
     changes:
+      - mlmodel/**/*
       - coremltools/test/**/*.{py}
       - coremltools/models/**/*.{py}
       - coremltools/converters/caffe/**/*.{py}
@@ -236,6 +262,34 @@ test_macos11_py37_mil:
   only:
     changes:
       - coremltools/converters/mil/**/*.{py}
+
+
+#########################################################################
+##
+##                        Make docs
+##
+#########################################################################
+build_documentation:
+  tags:
+    - docker
+  stage: test
+  image: registry.gitlab.com/zach_nation/coremltools/build-image-ubuntu-14.04:1.0.3
+  script:
+    - bash -e scripts/build_docs.sh --wheel-path=${WHEEL_PATH} --python=${PYTHON}
+  dependencies:
+    - build_wheel_linux_py27
+  artifacts:
+    when: always
+    expire_in: 2 weeks
+    paths:
+      - _build/html/
+  variables:
+    WHEEL_PATH: build/dist/coremltools*cp27-none-manylinux1_x86_64.whl
+    PYTHON: "2.7"
+  only:
+    changes:
+      - docs/**/*
+
 
 #########################################################################
 ##


### PR DESCRIPTION
Run CI based on file touched.

In total, we have 5 test suites:
- MIL ops
- PyTorch ops
- TF1 ops
- TF2 ops
- coremltools/test

with `only:changes:`, we trigger the corresponding test based on files touched. @DawerG Can you help to double-check those conditions. Thanks!