### PR TITLE
Add a script to sync PRs to Gitlab for CI

### DIFF
--- a/scripts/sync_gitlab_with_github.py
+++ b/scripts/sync_gitlab_with_github.py
@@ -1,0 +1,41 @@
+import os
+import pathlib
+import tempfile
+
+import git
+from github import Github
+
+# get a reference to the current dir's repo (coremltools clone dir)
+temp_dir = tempfile.mkdtemp()
+existing_local_repo = git.Repo(pathlib.Path(__file__).parent.parent.absolute())
+local_repo = existing_local_repo.clone(temp_dir)
+
+# since this is cloned from a local repo, its origin points to the local fs.
+# add a 'gitlab_build' remote we can push to.
+git.remote.Remote.add(local_repo, 'gitlab_build', 'git@gitlab.com:zach_nation/coremltools.git')
+current_remotes = set([remote.name for remote in local_repo.remotes])
+
+g = Github(os.getenv('COREMLTOOLS_GITHUB_API_TOKEN'))
+remote_repo = g.get_repo('apple/coremltools')
+pulls = remote_repo.get_pulls(state='open', sort='created', base='master')
+for pr in pulls:
+    remote_name = pr.head.repo.owner.login
+    remote_url = pr.head.repo.clone_url
+    if not(remote_name in current_remotes):
+        print('Adding remote {} with url {}'.format(remote_name, remote_url))
+        git.remote.Remote.add(local_repo, remote_name, remote_url)
+    remote = git.remote.Remote(local_repo, remote_name)
+    remote.fetch()
+
+    # check out the PR branch
+    print('Checking out branch {} from remote {}'.format(pr.head.ref, remote_name))
+    branch_ref = git.refs.remote.RemoteReference(local_repo, 'refs/remotes/{}/{}'.format(remote_name, pr.head.ref))
+    branch_ref.checkout()
+
+    new_branch_name = 'PR-{}'.format(pr.number)
+    print('Checking out new branch {}'.format(new_branch_name))
+    local_repo.git.checkout('HEAD', b=new_branch_name)
+
+    print('Pushing PR branch to gitlab_build remote')
+    gitlab_build = git.remote.Remote(local_repo, 'gitlab_build')
+    gitlab_build.push('{}:{}'.format(new_branch_name, new_branch_name))

--- a/scripts/sync_gitlab_with_github.sh
+++ b/scripts/sync_gitlab_with_github.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+
+##=============================================================================
+## Main configuration processing
+COREMLTOOLS_HOME=$( cd "$( dirname "$0" )/.." && pwd )
+COREMLTOOLS_NAME=$(basename $COREMLTOOLS_HOME)
+
+# Make sure we have an API token
+if [[ -z "$COREMLTOOLS_GITHUB_API_TOKEN" ]]; then
+    echo "Expected COREMLTOOLS_GITHUB_API_TOKEN environment variable to be defined. Exiting."
+    exit 1
+fi
+
+# Create and set up Python env
+# Copied from test.sh
+cd ${COREMLTOOLS_HOME}
+zsh -i -e scripts/env_create.sh --python=3.7
+source scripts/env_activate.sh --python=3.7
+echo
+echo "Using python from $(which python)"
+echo
+
+# Install PyGithub and gitpython
+$PIP_EXECUTABLE install PyGithub gitpython
+
+# Now run sync_gitlab_with_github.py, which contains the real logic
+$PYTHON_EXECUTABLE scripts/sync_gitlab_with_github.py


### PR DESCRIPTION
The current CI setup only seems to kick off builds for commits that have
been pushed to either a branch on apple/coremltools on GitHub, or a
branch on zach_nation/coremltools on Gitlab. This script will enumerate
all of the open PRs on GitHub apple/coremltools, and push their commits
to a corresponding branch on zach_nation/coremltools.

Requires a valid GitHub access token to be set as an environment
variable. This is to use the GitHub API, but it doesn't need any access
beyond PRs on public repos.

Requires push access to zach_nation/coremltools. Only zach_nation can
give you this.