### PR TITLE
Try to get SSH keypair for sync from env variable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -363,7 +363,10 @@ collect_artifacts:
 #########################################################################
 sync_gitlab_with_github:
   image: "registry.gitlab.com/zach_nation/coremltools/sync-gitlab-with-github:1.0"
-  script: "bash scripts/sync_gitlab_with_github.sh"
+  script:
+    - echo "$COREMLTOOLS_SSH_PUBLIC_KEY" > ~/.ssh/id_rsa.pub
+    - echo "$COREMLTOOLS_SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
+    - bash scripts/sync_gitlab_with_github.sh
   only:
     refs:
       - schedules


### PR DESCRIPTION
Instead of relying on the Gitlab CI credentials (which don't have push
permission), see if we can get the credentials from environment
variables and insert them into the current SSH config.