### PR TITLE
Update build status badge to point to Gitlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/apple/coremltools.svg?branch=master)](#)
+[![Build Status](https://img.shields.io/gitlab/pipeline/zach_nation/coremltools/master)](#)
 [![PyPI Release](https://img.shields.io/pypi/v/coremltools.svg)](#)
 [![Python Versions](https://img.shields.io/pypi/pyversions/coremltools.svg)](#)
 


### PR DESCRIPTION
Now that we're using Gitlab builds for PRs and master, the status badge should reflect that build.