### PR TITLE
Add support for torch layer adaptive_max_pool2d

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -835,11 +835,8 @@ def adaptive_max_pool2d(context, node):
     if output_size == (1, 1):
         # Represent (1,1) output size via @reduce_max
         # Assume channel first ordering, reduce the last two (HW) dims.
-        axes = mb.const(val=[-2, -1], name=node.name + "_axes")
-        keep_dims = mb.const(val=True, name=node.name + "_keep_dims")
-
         max_pool = mb.reduce_max(
-            x=_input, axes=axes, keep_dims=keep_dims, name=node.name
+            x=_input, axes=[-2,-1], keep_dims=True, name=node.name
         )
     elif _input.shape is not None:
         # TODO: The calculations to convert adaptive_pool to standard pool,

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -823,6 +823,58 @@ def adaptive_avg_pool2d(context, node):
 
     context.add(avg_pool)
 
+@register_torch_op
+def adaptive_max_pool2d(context, node):
+    inputs = _get_inputs(context, node, expected=2)
+
+    _input = inputs[0]
+    output_size = inputs[1].val
+    assert isinstance(output_size, _np.ndarray)
+    output_size = tuple(output_size)
+
+    if output_size == (1, 1):
+        # Represent (1,1) output size via @reduce_max
+        # Assume channel first ordering, reduce the last two (HW) dims.
+        axes = mb.const(val=[-2, -1], name=node.name + "_axes")
+        keep_dims = mb.const(val=True, name=node.name + "_keep_dims")
+
+        max_pool = mb.reduce_max(
+            x=_input, axes=axes, keep_dims=keep_dims, name=node.name
+        )
+    elif _input.shape is not None:
+        # TODO: The calculations to convert adaptive_pool to standard pool,
+        # given a known input size, come from
+        # https://stackoverflow.com/questions/53841509/how-does-adaptive-pooling-in-pytorch-work
+        # However, as indicated in that SO, this isn't quite how PyTorch
+        # computes adaptive pooling, leading to inaccuracies in model outputs.
+        # rdar://60900834
+        strides = [ind // outd for ind, outd in zip(_input.shape[-2:], output_size)]
+        pad_type = "valid"
+        # Need to explicity state L-R, T-B pad
+        pad = [0, 0, 0, 0]
+        dilation = [1, 1]
+        kernel_sizes = [
+            ind - s * (outd - 1)
+            for ind, outd, s in zip(_input.shape[-2:], output_size, strides)
+        ]
+        max_pool = mb.max_pool(
+            x=_input,
+            kernel_sizes=kernel_sizes,
+            strides=strides,
+            pad_type=pad_type,
+            pad=pad,
+            name=node.name,
+        )
+    else:
+        raise ValueError(
+            "adaptive_max_pool2d only supported when input tensor size is known or output size == (1,1). Recived: input size == {}, output size == {}".format(
+                _input.shape_str(), output_size,
+            )
+        )
+
+    context.add(max_pool)
+
+
 
 @register_torch_op
 def batch_norm(context, node):

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -442,24 +442,31 @@ class TestAvgPool:
 
 class TestAdaptiveMaxPool:
     @pytest.mark.parametrize(
-        "output_size, magnification, backend",
+        "output_size, magnification, delta, depth, backend",
         itertools.product(
-            [(1,1), (3,3),(6,6),(32,32)],
+            [(1,1), (3,2),(3,6),(32,32)],
             [1,2,4,5,6,7],
+            [0,11],
+            [1,2,3],
             backends,
         ),
     )
     def test_adaptive_max_pool2d(
-            self, output_size, magnification, backend
+            self, output_size, magnification, delta, depth, backend
     ):
-        # we maginify output_size to get input_size
-        # we only test adaptive pooling where input_size is a multiple of output_size
-        input_size = (magnification * output_size[0], magnification * output_size[1])
+        # input_size = output_size * magnification + delta
+        input_size = (delta + magnification * output_size[0], delta + magnification * output_size[1])
+        # since coremltools reproduces PyTorch's kernel sizes and
+        # offsets for adaptive pooling layers only when input_size is
+        # a multiple of output_size, we expect failures otherwise
+        if not (input_size[0] % output_size[0]  == 0 and input_size[1] % output_size[1] == 0):
+            pytest.xfail("Test should fail because input_size is not a multiple of output_size")
+        n = 1
+        in_shape = (n,depth) + input_size
         model = nn.AdaptiveMaxPool2d(
             output_size
         )
-        print("running compare torch")
-        run_compare_torch(input_size, model, backend=backend)
+        run_compare_torch(in_shape, model, backend=backend)
 
 class TestMaxPool:
     # rdar://66066001 (PyTorch converter: enable ceil_mode=True tests for pooling ops)

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -440,6 +440,26 @@ class TestAvgPool:
         )
         run_compare_torch(input_shape, model, backend=backend)
 
+class TestAdaptiveMaxPool:
+    @pytest.mark.parametrize(
+        "output_size, magnification, backend",
+        itertools.product(
+            [(1,1), (3,3),(6,6),(32,32)],
+            [1,2,4,5,6,7],
+            backends,
+        ),
+    )
+    def test_adaptive_max_pool2d(
+            self, output_size, magnification, backend
+    ):
+        # we maginify output_size to get input_size
+        # we only test adaptive pooling where input_size is a multiple of output_size
+        input_size = (magnification * output_size[0], magnification * output_size[1])
+        model = nn.AdaptiveMaxPool2d(
+            output_size
+        )
+        print("running compare torch")
+        run_compare_torch(input_size, model, backend=backend)
 
 class TestMaxPool:
     # rdar://66066001 (PyTorch converter: enable ceil_mode=True tests for pooling ops)


### PR DESCRIPTION
This PR adds support for converting PyTorch 2-D adaptive max pooling layers.

`coremltools` already has support for 2-D adaptive average pooling layers. This commit is strictly based off of that existing implementation, except that it builds with the operations `reduce_max` and `max_pool` instead of `reduce_mean` and `avg_pool`.

Why do max pooling layers matter? Besides the fact that they are part of PyTorch, they are frequently used in models produced by the [FastAI library](https://github.com/fastai/fastai), so `coremltools` will be better able to convert those models if it adds support for this layer type.

I am not sure what is official process for contributing a PR, so I would be glad to receive any guidance on what other steps might be necessary in order to improve this change as needed and shepherd it into the upstream.

I have also prepared a gist which demonstrates using this PR's code to successfully convert a max pooling layer: https://gist.github.com/algal/818229cc168483ed237ba5cdf7634f72
