### PR TITLE
__repr__,__str__ for RangeDim

### DIFF
--- a/coremltools/converters/mil/input_types.py
+++ b/coremltools/converters/mil/input_types.py
@@ -269,6 +269,11 @@ class RangeDim(object):
                 )
             self.default = default
 
+    def __repr__(self):
+        return f'RangeDim({self.lower_bound}, {self.upper_bound}, {self.default}, "{self.symbol}")'
+
+    __str__ = __repr__
+
 
 class Shape(object):
     def __init__(self, shape, default=None):

--- a/coremltools/converters/mil/input_types.py
+++ b/coremltools/converters/mil/input_types.py
@@ -270,9 +270,11 @@ class RangeDim(object):
             self.default = default
 
     def __repr__(self):
-        return f'RangeDim({self.lower_bound}, {self.upper_bound}, {self.default}, "{self.symbol}")'
+        return self.__str__()
 
-    __str__ = __repr__
+    def __str__(self):
+        return 'RangeDim(lower_bound={}, upper_bound={}, default={}, symbol="{}")'.format(
+            self.lower_bound, self.upper_bound, self.default, self.symbol)
 
 
 class Shape(object):


### PR DESCRIPTION
Make me happy and accept this `__repr__` for RangeDim (with `__str__ = __repr__`). Something so basic surely deserves either this implementation or something you'd think fits.

Thanks!

Example `__repr__`:

```
>>> from coremltools.converters.mil.input_types import RangeDim
>>> RangeDim(1,2)
RangeDim(1, 2, 1, "is0")
```