### PR TITLE
Docs: Fix doc formatting for linear and matmul (linear.py)

### DIFF
--- a/coremltools/converters/mil/mil/ops/defs/linear.py
+++ b/coremltools/converters/mil/mil/ops/defs/linear.py
@@ -10,29 +10,26 @@ from ._utils import broadcast_shapes
 @register_op(doc_str="")
 class linear(Operation):
     """
-    linear
-    ======
-    
     Perform  ``x * weight.T + bias`` where ``weight`` and ``bias`` are constant at
     compile time.
-
+    
     Parameters
     ----------
-    ``x: tensor<[*D,D_in], T>`` (required)
-    * ``1 <= rank <= 3``.
-    * ``0 <= rank(*D) <= 2``
+    x: tensor<[*D,D_in], T> (Required)
+        * ``1 <= rank <= 3``.
+        * ``0 <= rank(*D) <= 2``.
+    weight: const tensor<[D_out,D_in], T> (Required)
+    bias: const tensor<[D_out],T> (Optional)
+        * Default to ``0``.
     
-    ``weight: const tensor<[D_out,D_in], T>`` (required)
-    
-    ``bias: const tensor<[D_out],T>`` (optional, defaults to ``0``)
-
     Returns
     -------
-    ``tensor<[*D,D_out], T>``: Same rank as the input ``x``
-
+    tensor<[*D,D_out], T>
+        * Same rank as the input ``x``.
+    
     Attributes
     ----------
-    ``T: fp32``
+    T: fp32
     """
     input_spec = InputSpec(
         x=TensorInputType(),
@@ -64,17 +61,12 @@ class linear(Operation):
 @register_op(doc_str="")
 class matmul(Operation):
     """
-    matmul
-    ======
-    
-    Perform N-D batch matrix multiplication with Numpy-style broadcasting
+    Perform N-D batch matrix multiplication with NumPy-style broadcasting
     based on the following rules:
     
-    Rules
-    -----
-    1. If both ``x, y`` are 1-D, return the scalar from the dot product.
+    Rule 1. If both ``x, y`` are 1-D, return the scalar from the dot product.
     
-    2. If both ``x, y`` are 2-D or higher, perform a broadcast on the batch dimensions
+    Rule 2. If both ``x, y`` are 2-D or higher, perform a broadcast on the batch dimensions
     (all dimensions except the last ``2``).
     
     For example:
@@ -91,8 +83,8 @@ class matmul(Operation):
     * ``Matmul(x, y).shape == (4, 2)``
     
     If ``x`` is 1-D, and ``y`` is N-D where ``N >= 2``, ``x`` is first promoted to
-    matrix ``xm``by prepending a ``1`` to its dimension, and the resulting ``xm`` is
-    broadcast to ``y`` following Rule 2. Remove the inserted dimension afterwards.
+    matrix ``xm`` by prepending a ``1`` to its dimension, and the resulting ``xm`` is
+    broadcast to ``y`` following Rule 2 above. After this, remove the inserted dimension.
     For example:
     
     * ``x.shape == (4)``
@@ -100,12 +92,11 @@ class matmul(Operation):
     * ``xm.shape == (1, 4)``
     * ``Matmul(xm, y).shape == (10, 1, 3)``
     * Removing the inserted dimension results in ``Matmul(x, y).shape == (10, 3)``.
-    
-    Note: ``xm`` and ``Matmul(xm, y)`` are for illustration only.
+    * Note: ``xm`` and ``Matmul(xm, y)`` are for illustration only.
     
     If ``x`` is N-D where ``N >= 2``, and ``y`` is 1-D, ``y`` is first promoted to
     matrix ``ym`` by appending a ``1`` to its dimension, and the resulting ``ym`` is
-    broadcast to ``x`` following Rule 2. Remove the inserted dimension afterwards.
+    broadcast to ``x`` following Rule 2 above. After this, remove the inserted dimension.
     For example:
     
     * ``x.shape == (10, 3, 4)``
@@ -113,30 +104,31 @@ class matmul(Operation):
     * ``ym.shape == (4, 1)``
     * ``Matmul(x, ym).shape == (10, 3, 1)``
     * Removing the inserted dimension results in ``Matmul(x, y).shape == (10, 3)``.
+    * Note: ``xm`` and ``Matmul(xm, y)`` are for illustration only.
     
-    Note: ``xm`` and ``Matmul(xm, y)`` are for illustration only.
-
     Parameters
     ----------
-    ``x: tensor<[*,K1], T>`` (required): ``x`` must be 1-D or higher.
-    
-    ``y: tensor<[*,K2], T>`` (required): ``y`` must be 1-D or higher.
-    
-    ``transpose_x: const bool`` (optional, defaults to ``False``): Use ``True`` to
-    transpose the last two dimensions of ``x`` before multiplication. It has no effect
-    when ``x`` is 1-D.
-    
-    ``transpose_y: const bool`` (optional, defaults to ``False``): Use ```True`` to
-    transpose the last two dimensions of ``y`` before multiplication. It has no effect
-    when ``y`` is 1-D.
+    x: tensor<[*,K1], T> (Required)
+        * ``x`` must be 1-D or higher.
+    y: tensor<[*,K2], T> (Required)
+        * ``y`` must be 1-D or higher.
+    transpose_x: const bool (Optional)
+        * Default to ``False``.
+        * Use ``True`` to transpose the last two dimensions of ``x`` before multiplication.
+          It has no effect when ``x`` is 1-D.
+    transpose_y: const bool (Optional)
+        * Default to ``False``.
+        * Use ``True`` to transpose the last two dimensions of ``y`` before multiplication.
+          It has no effect when ``y`` is 1-D.
     
     Returns
     -------
-    ``tensor<*, T>``: Scalar or tensor output.
+    tensor<*, T>
+        * Scalar or tensor output.
     
     Attributes
     ----------
-    ``T: fp32``
+    T: fp32
     """
     input_spec = InputSpec(
         x=TensorInputType(),

--- a/coremltools/converters/mil/mil/ops/defs/linear.py
+++ b/coremltools/converters/mil/mil/ops/defs/linear.py
@@ -73,14 +73,14 @@ class matmul(Operation):
     
     * ``x.shape == (10, 4, 3)``
     * ``y.shape == (5, 10, 3, 2)``
-    * ``Matmul(x, y).shape == (5, 10, 4, 2)``
+    * ``matmul(x, y).shape == (5, 10, 4, 2)``
     
     Conventional matrix multiplication is a special case where both ``x, y`` are
     exactly 2-D. For example:
     
     * ``x.shape == (4, 3)``
     * ``y.shape == (3, 2)``
-    * ``Matmul(x, y).shape == (4, 2)``
+    * ``matmul(x, y).shape == (4, 2)``
     
     If ``x`` is 1-D, and ``y`` is N-D where ``N >= 2``, ``x`` is first promoted to
     matrix ``xm`` by prepending a ``1`` to its dimension, and the resulting ``xm`` is
@@ -90,9 +90,9 @@ class matmul(Operation):
     * ``x.shape == (4)``
     * ``y.shape == (10, 4, 3)``
     * ``xm.shape == (1, 4)``
-    * ``Matmul(xm, y).shape == (10, 1, 3)``
-    * Removing the inserted dimension results in ``Matmul(x, y).shape == (10, 3)``.
-    * Note: ``xm`` and ``Matmul(xm, y)`` are for illustration only.
+    * ``matmul(xm, y).shape == (10, 1, 3)``
+    * Removing the inserted dimension results in ``matmul(x, y).shape == (10, 3)``.
+    * Note: ``xm`` and ``matmul(xm, y)`` are for illustration only.
     
     If ``x`` is N-D where ``N >= 2``, and ``y`` is 1-D, ``y`` is first promoted to
     matrix ``ym`` by appending a ``1`` to its dimension, and the resulting ``ym`` is
@@ -102,9 +102,9 @@ class matmul(Operation):
     * ``x.shape == (10, 3, 4)``
     * ``y.shape == (4,)``
     * ``ym.shape == (4, 1)``
-    * ``Matmul(x, ym).shape == (10, 3, 1)``
-    * Removing the inserted dimension results in ``Matmul(x, y).shape == (10, 3)``.
-    * Note: ``xm`` and ``Matmul(xm, y)`` are for illustration only.
+    * ``matmul(x, ym).shape == (10, 3, 1)``
+    * Removing the inserted dimension results in ``matmul(x, y).shape == (10, 3)``.
+    * Note: ``xm`` and ``matmul(xm, y)`` are for illustration only.
     
     Parameters
     ----------


### PR DESCRIPTION
Fixed the doc formatting for the linear and matmul ops in converter.mil.ops page. 
Preview of this page is here: [converter.mil.ops preview](https://coremltools.readme.io/v1.0/reference/convertersmilops)
See "matmul" and "linear" ops.
