### PR TITLE
DOCS: Update mil ops in  normalization.py for converter.mil.op

### DIFF
--- a/coremltools/converters/mil/mil/ops/defs/normalization.py
+++ b/coremltools/converters/mil/mil/ops/defs/normalization.py
@@ -9,8 +9,8 @@ from ._op_reqs import *
 class batch_norm(Operation):
     """
     Normalize input tensor ``x`` by ``mean`` and ``variance``, and optionally apply a
-    scale ``gamma`` and offset ``beta``. ``mean``, ``variance``, ``gamma``, and ``beta``
-    must be 1-D tensors whose length is equal to the second axis ("depth" or "channel"
+    scale ``gamma`` and an offset ``beta``. ``mean``, ``variance``, ``gamma``, and ``beta``
+    must be 1-D tensors whose lengths are equal to the second axis ("depth" or "channel"
     dimension) of ``x``.
 
     Parameters
@@ -23,10 +23,10 @@ class batch_norm(Operation):
     variance: const tensor<[C], T> (Required)
     gamma: const tensor<[C], T> (Optional)
         * Optional scale applied to normalized tensor.
-        * Default to all ``1``s.
+        * Default to all ones.
     beta: const tensor<[C], T> (Optional)
         * Optional offset applied to normalized tensor.
-        * Default to all ``0``s.
+        * Default to all zeros.
     epsilon: const f32 (Optional)
         * Default to ``1e-5``.
 
@@ -68,10 +68,10 @@ class instance_norm(Operation):
         * ``n`` is the batch dimension.
     gamma: const tensor<[C], T> (Optional)
         * Optional scale applied to normalized tensor.
-        * Default to all ``1``s.
+        * Default to all ones.
     beta: const tensor<[C], T> (Optional)
         * Optional offset applied to normalized tensor.
-        * Default to all ``0``s.
+        * Default to all zeros.
     epsilon: const f32 (Optional)
         * Default to ``1e-5``.
 
@@ -149,10 +149,10 @@ class layer_norm(Operation):
         * Defaults to ``None`` (all dimensions).
     gamma: const tensor<[K], T> (Optional)
         * Same shape as normalized_shape.
-        * Defaults to all ``1``s.
+        * Defaults to all ones.
     beta: const tensor<[K], T> (Optional)
         * Same shape as normalized_shape.
-        * Defaults to all ``0``s.
+        * Defaults to all zeros.
     epsilon: const fp32 (Optional)
         * Small constant to avoid division by ``0``.
         * Defaults to ``1e-5``.

--- a/coremltools/converters/mil/mil/ops/defs/normalization.py
+++ b/coremltools/converters/mil/mil/ops/defs/normalization.py
@@ -8,30 +8,32 @@ from ._op_reqs import *
 @register_op(doc_str="")
 class batch_norm(Operation):
     """
-    Normalizes input tensor ``x`` by ``mean`` and ``variance``, and optionally applies a scale ``gamma`` and offset ``beta``.
-    ``mean``, ``variance``, ``gamma``, ``beta`` must be 1D tensors with length equal to the second axis ("depth" or "channel" dimension) of ``x``.
+    Normalize input tensor ``x`` by ``mean`` and ``variance``, and optionally apply a
+    scale ``gamma`` and offset ``beta``. ``mean``, ``variance``, ``gamma``, and ``beta``
+    must be 1-D tensors whose length is equal to the second axis ("depth" or "channel"
+    dimension) of ``x``.
 
     Parameters
     ----------
     x: tensor<[n,C,*D], T> (Required)
         * ``3 <= rank <= 4``.
         * ``*D`` refers to the spatial dimensions, ``1 <= rank(*D) <= 2``.
-        * ``n`` is the batch dimension
+        * ``n`` is the batch dimension.
     mean: const tensor<[C], T> (Required)
     variance: const tensor<[C], T> (Required)
     gamma: const tensor<[C], T> (Optional)
-        * Default to all ``1s``.
         * Optional scale applied to normalized tensor.
+        * Default to all ``1``s.
     beta: const tensor<[C], T> (Optional)
-        * Default to all ``0s``.
         * Optional offset applied to normalized tensor.
+        * Default to all ``0``s.
     epsilon: const f32 (Optional)
         * Default to ``1e-5``.
 
     Returns
     -------
     tensor<[n,C,*D], T>
-        * output tensor has the same shape and type as the input ``x``.
+        * Output tensor has the same shape and type as the input ``x``.
 
     Attributes
     ----------
@@ -56,7 +58,7 @@ class batch_norm(Operation):
 @register_op(doc_str="")
 class instance_norm(Operation):
     """
-    Applies instance normalization to the n-dimensional input tensor.
+    Apply instance normalization to the n-dimensional input tensor.
 
     Parameters
     ----------
@@ -65,18 +67,18 @@ class instance_norm(Operation):
         * ``*D`` refers to the spatial dimensions, ``1 <= rank(*D) <= 2``.
         * ``n`` is the batch dimension.
     gamma: const tensor<[C], T> (Optional)
-        * Default to all ``1s``.
         * Optional scale applied to normalized tensor.
+        * Default to all ``1``s.
     beta: const tensor<[C], T> (Optional)
-        * Default to all ``0s``.
         * Optional offset applied to normalized tensor.
+        * Default to all ``0``s.
     epsilon: const f32 (Optional)
         * Default to ``1e-5``.
 
     Returns
     -------
     tensor<[n,C,*D], T>
-        * output tensor has the same shape and type as the input ``x``.
+        * Output tensor has the same shape and type as the input ``x``.
     """
     input_spec = InputSpec(
         x=TensorInputType(),
@@ -95,14 +97,14 @@ class instance_norm(Operation):
 @register_op(doc_str="")
 class l2_norm(Operation):
     """
-    Applies L2 normalization to the n-dimensional input tensor on given ``axes``.
+    Apply L2 normalization to the n-dimensional input tensor on given ``axes``.
 
     Parameters
     ----------
     x: tensor<[n,C,*D], T> (Required)
         * Input tensor, ``3 <= rank(x) <= 4``.
         * ``*D`` refers to the spatial dimensions, ``1 <= rank(*D) <= 2``.
-        * ``n`` is the batch dimension
+        * ``n`` is the batch dimension.
     axes: const tensor<[K], i32> (Required)
         * Dimensions to perform normalizations.
     epsilon: const fp32 (Optional)
@@ -135,30 +137,30 @@ class l2_norm(Operation):
 @register_op(doc_str="")
 class layer_norm(Operation):
     """
-    Applies layer normalization to the n-dimensional input tensor:\n
+    Apply layer normalization to the n-dimensional input tensor:\n
     ``out = gamma * (input - mean) / sqrt(variance + epsilon) + beta``.
 
     Parameters
     ----------
     x: tensor<*?, T> (Required)
-        * Input tensor
+        * Input tensor.
     axes: const<[K], i32> (Optional)
-        * defaults to ``None`` (all dimensions)
         * Dimensions to perform layer normalization.
+        * Defaults to ``None`` (all dimensions).
     gamma: const tensor<[K], T> (Optional)
-        * defaults to all ``1s``.
-        * same shape as normalized_shape.
+        * Same shape as normalized_shape.
+        * Defaults to all ``1``s.
     beta: const tensor<[K], T> (Optional)
-        * defaults to all ``0s``.
-        * same shape as normalized_shape.
+        * Same shape as normalized_shape.
+        * Defaults to all ``0``s.
     epsilon: const fp32 (Optional)
-        * defaults to ``1e-5``.
         * Small constant to avoid division by ``0``.
+        * Defaults to ``1e-5``.
 
     Returns
     -------
     tensor<*?, T>:
-    * tensor with same shape and type as the input tensor ``x``.
+        * Tensor with same shape and type as the input tensor ``x``.
     """
     input_spec = InputSpec(
         x=TensorInputType(),
@@ -197,29 +199,30 @@ class layer_norm(Operation):
 @register_op(doc_str="")
 class local_response_norm(Operation):
     """
-    Applies local response normalization to the n-dimensional input tensor.
+    Apply local response normalization to the n-dimensional input tensor.
 
     Parameters
     ----------
     x: tensor<[n,C,*D], T> (Required)
         * Input tensor, ``3 <= rank(x) <= 4``.
         * ``*D`` refers to the spatial dimensions, ``1 <= rank(*D) <= 2``.
-        * ``n`` is the batch dimension
+        * ``n`` is the batch dimension.
     size: const i32 (Required)
         * Amount of neighboring channels to normalize.
     alpha: const fp32 (Optional)
-        * defaults to ``1.0``.
         * Scale factor.
+        * Defaults to ``1.0``.
     beta: const fp32 (Optional)
-        * defaults to ``0.5``.
         * An exponent.
+        * Defaults to ``0.5``.
     k: const fp32 (Optional)
-        * defaults to ``1.0``.
         * Additive factor.
+        * Defaults to ``1.0``.
+    
     Returns
     -------
     tensor<[n,C,*D], T>
-        * same type ans shape as the input tensor ``x``.
+        * Same type and shape as the input tensor ``x``.
 
     Attributes
     ----------


### PR DESCRIPTION
Fix formatting for MIL ops in normalization.py for [converter.mil.ops](https://coremltools.readme.io/reference/convertersmilops). Ops are:
batch_norm, instance_norm, l2_norm, layer_norm, and local_response_norm. 

See [preview](https://coremltools.readme.io/v1.0/reference/convertersmilops).

