### PR TITLE
Fix PyTorch transposed convolution

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -409,8 +409,10 @@ def _convolution(context, node):
 
         # PyTorch weight ordering [Cin, Cout, H, W]
         # MIL expects [Cout, Cin, H, W]
+        perm = _np.arange(len(weight.shape))
+        perm[[0, 1]] = perm[[1, 0]]
         weight_transpose = mb.transpose(
-            x=weight, perm=[1, 0, 2, 3], name=weight.name + "_transpose"
+            x=weight, perm=perm, name=weight.name + "_transpose"
         )
 
         # Handle output_padding using pre-pad or post-crop

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -101,6 +101,33 @@ class TestConv:
 
 class TestConvTranspose:
     @pytest.mark.parametrize(
+        "width, in_channels, out_channels, kernel_size, stride, padding, dilation, backend",
+        itertools.product(
+            [5, 7], [1, 3], [1, 3], [1, 3], [2, 3], [0, 1], [1, 3], backends
+        ),
+    )
+    def test_convolution_transpose1d(
+        self,
+        width,
+        in_channels,
+        out_channels,
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        backend,
+    ):
+        model = nn.ConvTranspose1d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+        )
+        run_compare_torch((1, in_channels, width), model, backend=backend)
+
+    @pytest.mark.parametrize(
         "height, width, in_channels, out_channels, kernel_size, stride, padding, dilation, backend",
         itertools.product(
             [5, 6], [5, 7], [1, 3], [1, 3], [1, 3], [2, 3], [0, 1], [1, 3], backends
@@ -128,6 +155,35 @@ class TestConvTranspose:
             dilation=dilation,
         )
         run_compare_torch((1, in_channels, height, width), model, backend=backend)
+
+    @pytest.mark.parametrize(
+        "depth, height, width, in_channels, out_channels, kernel_size, stride, padding, dilation, backend",
+        itertools.product(
+            [3, 4], [5, 6], [5, 7], [1, 3], [1, 3], [1, 3], [2, 3], [0, 1], [1, 3], backends
+        ),
+    )
+    def test_convolution_transpose3d(
+            self,
+            depth,
+            height,
+            width,
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            backend,
+    ):
+        model = nn.ConvTranspose3d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+        )
+        run_compare_torch((1, in_channels, depth, height, width), model, backend=backend)
 
     # TODO: rdar://65588783 ([PyTorch] Define and error out on unsupported configuration for output_padding)
     # TODO: rdar://65550420 (Add Image Resizing (crop, upsample, resize_bilinear) layers to the MIL backend)

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -162,6 +162,8 @@ class TestConvTranspose:
             [3, 4], [5, 6], [5, 7], [1, 3], [1, 3], [1, 3], [2, 3], [0, 1], [1, 3], backends
         ),
     )
+    @pytest.mark.skip(reason="old macOS version on the CI machine does not have fixes for convolution transposed 3D. "
+                             "Please, see details in https://github.com/apple/coremltools/pull/942")
     def test_convolution_transpose3d(
             self,
             depth,


### PR DESCRIPTION
Hi! Thanks for open-sourcing the framework! This fixes transposed convolution for 1D/3D cases in PyTorch (#904). 