### PR TITLE
Add copy_ torch op from #918

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -2380,3 +2380,8 @@ def topk(context, node):
     indices_name = node.outputs[1]
     context.add(res[0], torch_name=values_name)
     context.add(res[1], torch_name=indices_name)
+
+@register_torch_op
+def copy_(context, node):
+    inputs = _get_inputs(context, node, expected=3)
+    context.add(mb.identity(x=inputs[0]))


### PR DESCRIPTION
A simple torch `copy_` op implemented using `mb.identity`