### PR TITLE
add py.typed to setup to comply with pep 0561

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,8 @@ setup(
     url="https://github.com/apple/coremltools",
     packages=find_packages(),
     package_data={
-        "": ["LICENSE.txt", "README.md", "libcaffeconverter.so", "libcoremlpython.so"]
+        "": ["LICENSE.txt", "README.md", "libcaffeconverter.so", "libcoremlpython.so"],
+        "coremltools": ["py.typed"]
     },
     install_requires=[
         "numpy >= 1.14.5",


### PR DESCRIPTION
py.typed must be present to compy with https://www.python.org/dev/peps/pep-0561/