### PR TITLE
Input shape bug in DepthwiseConv2D in NCHW format

### DIFF
--- a/coremltools/converters/mil/frontend/tensorflow/ops.py
+++ b/coremltools/converters/mil/frontend/tensorflow/ops.py
@@ -729,9 +729,16 @@ def DepthwiseConv2dNative(context, node):
 
     pad_type = pad_type.lower()
     x = context[node.inputs[0]]
-    C_in = x.shape[-1]
+
     if data_format == "NHWC":
         x = _transpose_NHWC_to_NCHW(x)
+        C_in = x.shape[-1]
+    elif data_format == "NCHW":
+        C_in = x.shape[1]
+
+    if not isinstance(C_in, int):
+        raise ValueError("Channel number of input node must be an integer, instead got: {}".format(C_in))
+
     # Only the last op should have the same name as node.name
     conv_name = node.name + "x" if data_format == "NHWC" else node.name
     x = mb.conv(


### PR DESCRIPTION
In the DepthwiseConv2dNative method, there appears to be a hard coded assumption of channel_last ordering when extracting the channel depth of the input node. This causes conversion to fail in channel_first mode. For instance, in channel_first mode x.shape can evaluate to (is0, 48, is5, is6), and C_in gets assigned is6, which causes a crash later.