### PR TITLE
Update version check

### DIFF
--- a/coremltools/converters/mil/frontend/tensorflow/load.py
+++ b/coremltools/converters/mil/frontend/tensorflow/load.py
@@ -26,6 +26,7 @@ from .parsed_tf_node import ParsedTFNode
 from coremltools.converters._profile_utils import _profile
 from tqdm import tqdm as _tqdm
 from distutils.version import StrictVersion as _StrictVersion
+from coremltools._deps import __get_version as _get_version
 
 
 class TFLoader:
@@ -105,7 +106,7 @@ class TFLoader:
         logging.debug(msg.format(outputs))
         outputs = outputs if isinstance(outputs, list) else [outputs]
         outputs = [i.split(":")[0] for i in outputs]
-        if tf.__version__ < _StrictVersion("1.13.1"):
+        if _get_version(tf.__version__) < _StrictVersion("1.13.1"):
             return tf.graph_util.extract_sub_graph(graph_def, outputs)
         else:
             return tf.compat.v1.graph_util.extract_sub_graph(graph_def, outputs)
@@ -146,7 +147,7 @@ class TF1Loader(TFLoader):
             if not os.path.exists(str(self.model)):
                 raise ValueError('Input model "{}" does not exist'.format(self.model))
             elif os.path.isfile(str(self.model)) and self.model.endswith(".pb"):
-                if tf.__version__ < _StrictVersion("1.13.1"):
+                if _get_version(tf.__version__) < _StrictVersion("1.13.1"):
                     with open(self.model, "rb") as f:
                         gd = tf.GraphDef()
                         gd.ParseFromString(f.read())
@@ -242,7 +243,7 @@ class TF1Loader(TFLoader):
 
         # get model outputs
         output_node_names = []
-        if tf.__version__ < _StrictVersion("1.13.1"):
+        if _get_version(tf.__version__) < _StrictVersion("1.13.1"):
             sess = tf.Session()
         else:
             sess = tf.compat.v1.Session()
@@ -256,7 +257,7 @@ class TF1Loader(TFLoader):
 
         # get frozen graph
         output_graph = mktemp()
-        tf.compat.v1.reset_default_graph() if tf.__version__ >= _StrictVersion("1.13.1") else tf.reset_default_graph()
+        tf.compat.v1.reset_default_graph() if _get_version(tf.__version__) >= _StrictVersion("1.13.1") else tf.reset_default_graph()
         freeze_graph.freeze_graph(
             input_graph=None,
             input_saver=None,
@@ -275,7 +276,7 @@ class TF1Loader(TFLoader):
             saved_model_tags=",".join(saved_model_tags),
         )
 
-        if tf.__version__ < _StrictVersion("1.13.1"):
+        if _get_version(tf.__version__) < _StrictVersion("1.13.1"):
             graph_def = tf.GraphDef()
             with open(output_graph, "rb") as f:
                 graph_def.ParseFromString(f.read())

--- a/coremltools/converters/mil/frontend/tensorflow/tf_graph_pass/constant_propagation.py
+++ b/coremltools/converters/mil/frontend/tensorflow/tf_graph_pass/constant_propagation.py
@@ -17,6 +17,7 @@ from coremltools.converters.mil.mil import types
 from coremltools.converters.mil.mil.types.type_mapping import numpy_val_to_builtin_val
 from coremltools.converters._profile_utils import _profile
 from distutils.version import StrictVersion as _StrictVersion
+from coremltools._deps import __get_version as _get_version
 
 
 def _get_const_nodes(fn):
@@ -76,7 +77,7 @@ def _constant_propagation(fn, new_graph, constant_nodes, constant_node_num_outpu
                 # We're only making one call to `sess.run()` in order to compute constant values.
                 # In this context, the default optimization settings make everything dramatically
                 # slower and more memory-intensive.
-                if tf.__version__ < _StrictVersion("1.13.1"):
+                if _get_version(tf.__version__) < _StrictVersion("1.13.1"):
                     session_config = tf.ConfigProto()
                     session_config.graph_options.optimizer_options.opt_level = (
                         tf.OptimizerOptions.L0


### PR DESCRIPTION
The check `tf.__version__ < _StrictVersion("1.13.1")` fails, when TF is an `rc` version, e.g.: `2.4.0rc2`, since `distutils.version.StrictVersion` does not work properly with release candidate versions (a known issue with StrictVersion). 
This PR updates this check to first clean up the version using the method `coremltools._deps.__version` after which comparison with StrictVersion can be safely done. 

Fixes #1001