### PR TITLE
More fixes to make enumerated image inputs work correctly

### DIFF
--- a/coremltools/converters/mil/backend/nn/load.py
+++ b/coremltools/converters/mil/backend/nn/load.py
@@ -83,19 +83,29 @@ def _set_user_inputs(proto, inputs):
         shape = input_type.shape
         if isinstance(shape, EnumeratedShapes):
             if isinstance(input_type, ImageType):
+                default_height , default_width = 0, 0
+                for inp in proto.description.input:
+                    if inp.name == input_type.name:
+                        default_height = inp.type.imageType.height
+                        default_width = inp.type.imageType.width
+                        break
                 image_sizes = []
                 if input_type.channel_first:
                     for s in shape.shapes:
+                        if s.shape[-2] == default_height and s.shape[-1] == default_width:
+                            continue
                         image_sizes.append(
                             flexible_shape_utils.NeuralNetworkImageSize(
-                                s.shape[-2], s.shape[-1]
+                                height=s.shape[-2], width=s.shape[-1]
                             )
                         )
                 else:
                     for s in shape.shapes:
+                        if s.shape[-3] == default_height and s.shape[-2] == default_width:
+                            continue
                         image_sizes.append(
                             flexible_shape_utils.NeuralNetworkImageSize(
-                                s.shape[-3], s.shape[-2]
+                                height=s.shape[-3], width=s.shape[-2]
                             )
                         )
                 add_enumerated_image_sizes(

--- a/coremltools/converters/mil/mil/passes/image_input_preprocessing.py
+++ b/coremltools/converters/mil/mil/passes/image_input_preprocessing.py
@@ -44,7 +44,10 @@ def _image_input_preprocess(prog):
             elif isinstance(input_type.shape, EnumeratedShapes):
                 shape_list = []
                 for shape in input_type.shape.shapes:
-                    shape_list.append(_transform_to_channel_first(shape))
+                    if isinstance(shape, Shape):
+                        shape_list.append(_transform_to_channel_first(shape.shape))
+                    else:
+                        shape_list.append(_transform_to_channel_first(shape))
                 shape_type = EnumeratedShapes(shapes=shape_list,
                                               default=_transform_to_channel_first(input_type.shape.default))
             new_image_type = ImageType(name=name,

--- a/reqs/test.pip
+++ b/reqs/test.pip
@@ -2,7 +2,7 @@ boto3==1.14.8
 configparser
 Keras==2.1.6; python_version < "3.8"
 Pillow
-h5py
+h5py==2.10.0
 future
 numpy
 libsvm; python_version >= "3.6"


### PR DESCRIPTION
This has more fixes on top of the fixes made in #996 , to make sure that enumerated image inputs work with pre-processing parameters, and enumerated shapes are not repeated. 
Also updates the tests. 