### PR TITLE
Added root logger isolation

### DIFF
--- a/coremltools/__init__.py
+++ b/coremltools/__init__.py
@@ -25,7 +25,7 @@ For more information: http://developer.apple.com/documentation/coreml
 # Backup root logger handlers
 from logging import getLogger
 root_logger = getLogger()
-root_logger_handlers = root_logger.handlers.copy()
+root_logger_handlers_backup = root_logger.handlers.copy()
 
 from .version import __version__
 
@@ -89,4 +89,4 @@ if _ENABLE_PROFILING:
 root_logger = getLogger()
 coreml_logger = getLogger(__name__)
 coreml_logger.handlers = root_logger.handlers.copy()
-root_logger.handlers = root_logger_handlers
+root_logger.handlers = root_logger_handlers_backup

--- a/coremltools/__init__.py
+++ b/coremltools/__init__.py
@@ -22,6 +22,11 @@ format. In particular, it can be used to:
 For more information: http://developer.apple.com/documentation/coreml
 """
 
+# Backup root logger handlers
+from logging import getLogger
+root_logger = getLogger()
+root_logger_handlers = root_logger.handlers.copy()
+
 from .version import __version__
 
 # This is the basic Core ML specification format understood by iOS 11.0
@@ -79,3 +84,9 @@ _ENABLE_PROFILING = _os.environ.get("ENABLE_PROFILING", False)
 
 if _ENABLE_PROFILING:
     _sys.setprofile(_profiler)
+
+# Restore root logger handlers
+root_logger = getLogger()
+coreml_logger = getLogger(__name__)
+coreml_logger.handlers = root_logger.handlers.copy()
+root_logger.handlers = root_logger_handlers


### PR DESCRIPTION
Pull request proposal for solving a _minor_ issue of logging outputting.

The following code can be used in order to reproduce the mentioned issue:

```
import coremltools
import logging


FORMAT = '%(asctime)-15s - %(levelname)s - %(message)s'
logging.basicConfig(format=FORMAT, level=logging.INFO)
logger = logging.getLogger()
logger.info("This message does not show up unless the coremltools import above is removed.")
```

I suspect that the issue might be related to one of the dependencies used by coremltools, not sure which one. But the thing is that the root logger is being modified whenever coremltools is imported and normally that's not a good practice as far as I know.

Anyway, it is a minor issue because it can be avoided disabling logging propagation, removing the root logger handlers, or just using a different handler.

The solution proposed might be not the cleanest, but it works as expected. The ideal solution would be just finding out which of the dependencies is involved and then fixing it there.