### PR TITLE
Added flag for bypassing TensorFlow log suppression

### DIFF
--- a/coremltools/converters/mil/frontend/tensorflow/__init__.py
+++ b/coremltools/converters/mil/frontend/tensorflow/__init__.py
@@ -9,8 +9,9 @@ from coremltools._deps import _HAS_TF_1
 import os
 import logging
 
-os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"  # FATAL
-logging.getLogger("tensorflow").setLevel(logging.FATAL)
+if os.getenv("TF_SUPPRESS_LOGS", "1") == "1":
+    os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"  # FATAL
+    logging.getLogger("tensorflow").setLevel(logging.FATAL)
 
 register_tf_op = None
 


### PR DESCRIPTION
Please consider this quick proposal of adding an environment variable (flag) in order to externally have the possibility of bypassing the TensorFlow log suppression. Otherwise, this log suppression would have to be reverted every time that this module is imported; so this flag would ease things up.

A conservative default value has been added in order to assure the backward compatibility of these minor changes.

Many thanks for your time.