### PR TITLE
Make sure torch.tensor returns a cpu tensor

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -1886,7 +1886,7 @@ def to(context, node):
         _input = _input.val
         # numpy -> torch -> torch cast -> numpy
         # This path is needed to use the mapping of passed in dtypes to torch dtypes.
-        casted_input = torch.tensor(_input).type(torch_dtype).numpy()
+        casted_input = torch.tensor(_input).type(torch_dtype).cpu().numpy()
         res = mb.const(mode="immediate_value", val=casted_input, name=node.name)
     else:
         res = mb.cast(x=_input, dtype=NUM_TO_DTYPE_STRING[dtype], name=node.name)
@@ -2047,7 +2047,7 @@ def meshgrid(context, node):
         view_shape = [1] * size
         view_shape[i] = -1
         view_shape = tuple(view_shape)
-        tensor = torch.tensor(inputs[i].val)
+        tensor = torch.tensor(inputs[i].val).cpu()
         # (a.) in docstring
         view = mb.reshape(
             x=inputs[i], shape=view_shape, name=node.name + "_view_" + str(i)


### PR DESCRIPTION
Hi, 

This is less of a bugfix and more of a "better safe than sorry" change. In PyTorch you can set the default tensor type to be `torch.cuda.FloatTensor`, which resides on gpu. In this case when you call `torch.tensor` you get a gpu tensor back, and the `.numpy()` call fails. So if you have something like this the following snippet conversion would fail

`import torch`
`torch.set_default_tensor_type('torch.cuda.FloatTensor')`
`print(torch.tensor(1).device)`
`... do the actual coreml conversion...`

There's a few other locations (tests) that use `torch.tensor`, however I don't think any final user touches these, so left them as they are.