### PR TITLE
Fix CI test build issues

### DIFF
--- a/reqs/test.pip
+++ b/reqs/test.pip
@@ -4,7 +4,7 @@ Keras==2.1.6; python_version < "3.8"
 Pillow
 h5py==2.10.0
 future
-numpy
+numpy > 1.18.5
 libsvm; python_version >= "3.6"
 olefile==0.44
 onnx==1.6.0; python_version <= "3.7"
@@ -16,16 +16,14 @@ pytest-cov
 pytest-sugar
 scikit-learn==0.19.2; python_version <= '3.7'
 scikit-learn; python_version > '3.7'
-scipy
-sympy
+scipy > 1.4
+sympy > 1.6
 tensorflow==1.14.0; python_version < '3.8'
-torch==1.4.0; python_version == '2.7'
-torch==1.6.0; python_version > '2.7'
-torchvision; python_version == '2.7'
-torchvision==0.6.0; python_version > '2.7'
+torch==1.7.1
+torchvision==0.8.2
 xgboost
 mock
 wrapt
-pyyaml
+pyyaml > 5.3
 tqdm
 pytest-timeout

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -65,7 +65,7 @@ cd ${COREMLTOOLS_HOME}
 if [[ $PYTHON != "None" ]]; then
   # Setup the right python
   if [[ $CHECK_ENV == 1 ]]; then
-    zsh -i scripts/env_create.sh --python=$PYTHON --include-docs-deps
+    zsh -i scripts/env_create.sh --python=$PYTHON --include-docs-deps --exclude-test-deps
   fi
   source scripts/env_activate.sh --python=$PYTHON
 fi


### PR DESCRIPTION
The installation step of test.pip fails due to strict checking by pip 20.3
This PR fixes those issues by updating the torch and torchvision packages and putting minimum versions for a few other packages to avoid pypi backtracking. 
Pytorch 1.7 will be supported after the fixes proposed in #1020 and #1027. This PR unblocks the CI testing of those PRs. 