### PR TITLE
Remove unused six code for Python 2 compatibility

### DIFF
--- a/coremltools/_deps/__init__.py
+++ b/coremltools/_deps/__init__.py
@@ -150,17 +150,11 @@ MSG_KERAS2_NOT_FOUND = "Keras 2 not found."
 
 try:
     # Prevent keras from printing things that are not errors to standard error.
-    import six
     import sys
 
-    if six.PY2:
-        import StringIO
+    import io
 
-        temp = StringIO.StringIO()
-    else:
-        import io
-
-        temp = io.StringIO()
+    temp = io.StringIO()
     stderr = sys.stderr
     try:
         sys.stderr = temp

--- a/coremltools/_scripts/converter.py
+++ b/coremltools/_scripts/converter.py
@@ -4,7 +4,6 @@
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
 import logging as _logging
-from six import string_types as _string_types
 
 # expose files as imports
 from ..models import utils
@@ -112,56 +111,56 @@ def _main():
     )
     parser.add_argument(
         "--srcModelFormat",
-        type=_string_types,
+        type=str,
         choices=["auto", "caffe", "keras"],
         default="auto",
         help="Format of model at srcModelPath (default is to auto-detect).",
     )
     parser.add_argument(
         "--srcModelPath",
-        type=_string_types,
+        type=str,
         required=True,
         help="Path to the model file of the external tool (e.g caffe weights proto binary, keras h5 binary",
     )
     parser.add_argument(
         "--dstModelPath",
-        type=_string_types,
+        type=str,
         required=True,
         help="Path to save the model in format .mlmodel",
     )
     parser.add_argument(
         "--caffeProtoTxtPath",
-        type=_string_types,
+        type=str,
         default="",
         help="Path to the .prototxt file if network differs from the source file (optional)",
     )
     parser.add_argument(
         "--meanImageProtoPath",
-        type=_string_types,
+        type=str,
         default="",
         help="Path to the .binaryproto file containing the mean image if required by the network (optional). This requires a prototxt file to be specified.",
     )
     parser.add_argument(
         "--kerasJsonPath",
-        type=_string_types,
+        type=str,
         default=None,
         help="Path to the .json file for keras if the network differs from the weights file (optional)",
     )
     parser.add_argument(
         "--inputNames",
-        type=_string_types,
+        type=str,
         nargs="*",
         help="Names of the feature (input) columns, in order (required for keras models).",
     )
     parser.add_argument(
         "--outputNames",
-        type=_string_types,
+        type=str,
         nargs="*",
         help="Names of the target (output) columns, in order (required for keras models).",
     )
     parser.add_argument(
         "--imageInputNames",
-        type=_string_types,
+        type=str,
         default=[],
         action="append",
         help="Label the named input as an image. Can be specified more than once for multiple image inputs.",
@@ -204,13 +203,13 @@ def _main():
     )
     parser.add_argument(
         "--classInputPath",
-        type=_string_types,
+        type=str,
         default="",
         help="Path to class labels (ordered new line separated) for treating the neural network as a classifier",
     )
     parser.add_argument(
         "--predictedFeatureName",
-        type=_string_types,
+        type=str,
         default="class_output",
         help="Name of the output feature that captures the class name (for classifiers models).",
     )

--- a/coremltools/converters/_converters_entry.py
+++ b/coremltools/converters/_converters_entry.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import as _
 
 import gc
 import coremltools
-from six import string_types as _string_types
 import collections
 
 from coremltools.converters.mil.input_types import InputType, ClassifierConfig

--- a/coremltools/converters/caffe/_caffe_converter.py
+++ b/coremltools/converters/caffe/_caffe_converter.py
@@ -4,7 +4,6 @@
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
 import os
-import six as _six
 from ...models import (
     _MLMODEL_FULL_PRECISION,
     _MLMODEL_HALF_PRECISION,
@@ -239,7 +238,7 @@ def _export(
 ):
     from ... import libcaffeconverter
 
-    if isinstance(model, _six.string_types):
+    if isinstance(model, str):
         src_model_path = model
         prototxt_path = u""
         binaryproto_path = dict()
@@ -250,7 +249,7 @@ def _export(
             src_model_path, prototxt_path = model
             binaryproto_path = dict()
 
-    if isinstance(image_input_names, _six.string_types):
+    if isinstance(image_input_names, str):
         image_input_names = [image_input_names]
     if predicted_feature_name is None:
         predicted_feature_name = u"classLabel"
@@ -263,7 +262,7 @@ def _export(
                 "'image_input_names' must be provided when a mean image binaryproto path is specified. "
             )
 
-    if isinstance(binaryproto_path, _six.string_types):
+    if isinstance(binaryproto_path, str):
         binaryproto_paths = dict()
         binaryproto_paths[image_input_names[0]] = binaryproto_path
     elif isinstance(binaryproto_path, dict):

--- a/coremltools/converters/keras/_keras2_converter.py
+++ b/coremltools/converters/keras/_keras2_converter.py
@@ -3,7 +3,6 @@
 # Use of this source code is governed by a BSD-3-clause license that can be
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 import logging
-from six import string_types as _string_types
 
 from ...models.neural_network import NeuralNetworkBuilder as _NeuralNetworkBuilder
 from ...models.neural_network.update_optimizer_utils import AdamParams
@@ -349,7 +348,7 @@ def _convert(
     # Check custom conversion functions / custom objects
     add_custom_layers = custom_conversion_functions is not None
 
-    if isinstance(model, _string_types):
+    if isinstance(model, str):
         model = _keras.models.load_model(model, custom_objects=custom_objects)
     elif isinstance(model, tuple):
         model = _load_keras_model(model[0], model[1])
@@ -370,18 +369,18 @@ def _convert(
 
     # check input / output names validity
     if input_names is not None:
-        if isinstance(input_names, _string_types):
+        if isinstance(input_names, str):
             input_names = [input_names]
     else:
         input_names = ["input" + str(i + 1) for i in range(len(inputs))]
 
     if output_names is not None:
-        if isinstance(output_names, _string_types):
+        if isinstance(output_names, str):
             output_names = [output_names]
     else:
         output_names = ["output" + str(i + 1) for i in range(len(outputs))]
 
-    if image_input_names is not None and isinstance(image_input_names, _string_types):
+    if image_input_names is not None and isinstance(image_input_names, str):
         image_input_names = [image_input_names]
 
     graph.reset_model_input_names(input_names)
@@ -552,12 +551,7 @@ def _convert(
             )
         else:
             if _is_activation_layer(keras_layer):
-                import six
-
-                if six.PY2:
-                    layer_name = keras_layer.activation.func_name
-                else:
-                    layer_name = keras_layer.activation.__name__
+                layer_name = keras_layer.activation.__name__
             else:
                 layer_name = type(keras_layer).__name__
             if layer_name in custom_conversion_functions:
@@ -574,7 +568,7 @@ def _convert(
     # Add classifier classes (if applicable)
     if is_classifier:
         classes_in = class_labels
-        if isinstance(classes_in, _string_types):
+        if isinstance(classes_in, str):
             import os
 
             if not os.path.isfile(classes_in):

--- a/coremltools/converters/keras/_keras_converter.py
+++ b/coremltools/converters/keras/_keras_converter.py
@@ -3,8 +3,6 @@
 # Use of this source code is governed by a BSD-3-clause license that can be
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
-from six import string_types as _string_types
-
 from ...models.neural_network import NeuralNetworkBuilder as _NeuralNetworkBuilder
 from ...proto import FeatureTypes_pb2 as _FeatureTypes_pb2
 from collections import OrderedDict as _OrderedDict
@@ -176,7 +174,7 @@ def _convert(
             "keras not found or unsupported version or backend "
             "found. keras conversion API is disabled."
         )
-    if isinstance(model, _string_types):
+    if isinstance(model, str):
         model = _keras.models.load_model(model, custom_objects=custom_objects)
     elif isinstance(model, tuple):
         model = _load_keras_model(model[0], model[1], custom_objects=custom_objects)
@@ -203,17 +201,17 @@ def _convert(
 
     # check input / output names validity
     if input_names is not None:
-        if isinstance(input_names, _string_types):
+        if isinstance(input_names, str):
             input_names = [input_names]
     else:
         input_names = ["input" + str(i + 1) for i in range(len(inputs))]
     if output_names is not None:
-        if isinstance(output_names, _string_types):
+        if isinstance(output_names, str):
             output_names = [output_names]
     else:
         output_names = ["output" + str(i + 1) for i in range(len(outputs))]
 
-    if image_input_names is not None and isinstance(image_input_names, _string_types):
+    if image_input_names is not None and isinstance(image_input_names, str):
         image_input_names = [image_input_names]
 
     graph.reset_model_input_names(input_names)
@@ -316,7 +314,7 @@ def _convert(
     # Add classifier classes (if applicable)
     if is_classifier:
         classes_in = class_labels
-        if isinstance(classes_in, _string_types):
+        if isinstance(classes_in, str):
             import os
 
             if not os.path.isfile(classes_in):

--- a/coremltools/converters/keras/_layers.py
+++ b/coremltools/converters/keras/_layers.py
@@ -39,12 +39,7 @@ def _get_activation_name_from_keras_layer(keras_layer):
     elif isinstance(keras_layer, keras.layers.advanced_activations.ThresholdedReLU):
         non_linearity = "THRESHOLDEDRELU"
     else:
-        import six
-
-        if six.PY2:
-            act_name = keras_layer.activation.func_name
-        else:
-            act_name = keras_layer.activation.__name__
+        act_name = keras_layer.activation.__name__
 
         if act_name == "softmax":
             non_linearity = "SOFTMAX"

--- a/coremltools/converters/keras/_layers2.py
+++ b/coremltools/converters/keras/_layers2.py
@@ -50,12 +50,7 @@ def _get_activation_name_from_keras_layer(keras_layer):
     elif isinstance(keras_layer, _keras.layers.advanced_activations.Softmax):
         non_linearity = "SOFTMAX"
     else:
-        import six
-
-        if six.PY2:
-            act_name = keras_layer.activation.func_name
-        else:
-            act_name = keras_layer.activation.__name__
+        act_name = keras_layer.activation.__name__
 
         if act_name == "softmax":
             non_linearity = "SOFTMAX"

--- a/coremltools/converters/keras/_topology.py
+++ b/coremltools/converters/keras/_topology.py
@@ -428,12 +428,7 @@ class NetGraph(object):
                 or isinstance(k_layer, _keras.layers.core.Dense)
             ):
 
-                import six
-
-                if six.PY2:
-                    func_name = k_layer.activation.func_name
-                else:
-                    func_name = k_layer.activation.__name__
+                func_name = k_layer.activation.__name__
 
                 if func_name != "linear":
                     # Create new layer

--- a/coremltools/converters/keras/_topology2.py
+++ b/coremltools/converters/keras/_topology2.py
@@ -1,6 +1,5 @@
 import keras as _keras
 import numpy as _np
-import six
 
 _KERAS_LAYERS_1D = [
     _keras.layers.Conv1D,
@@ -538,9 +537,7 @@ class NetGraph(object):
             ):
 
                 func_name = (
-                    k_layer.activation.func_name
-                    if six.PY2
-                    else k_layer.activation.__name__
+                    k_layer.activation.__name__
                 )
 
                 if func_name != "linear":

--- a/coremltools/converters/libsvm/__init__.py
+++ b/coremltools/converters/libsvm/__init__.py
@@ -3,7 +3,6 @@
 # Use of this source code is governed by a BSD-3-clause license that can be
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
-from six import string_types as _string_types
 
 from . import _libsvm_converter
 from . import _libsvm_util
@@ -76,7 +75,7 @@ def convert(
     if not (_HAS_LIBSVM):
         raise RuntimeError("libsvm not found. libsvm conversion API is disabled.")
 
-    if isinstance(model, _string_types):
+    if isinstance(model, str):
         libsvm_model = _libsvm_util.load_model(model)
     else:
         libsvm_model = model
@@ -86,7 +85,7 @@ def convert(
             % (_svmutil.svm_model, type(libsvm_model))
         )
 
-    if not isinstance(target_name, _string_types):
+    if not isinstance(target_name, str):
         raise TypeError(
             "Expected 'target_name' of type str (got %s)" % type(libsvm_model)
         )
@@ -96,12 +95,12 @@ def convert(
             "Expected 'input_length' of type int, got %s" % type(input_length)
         )
 
-    if input_length != "auto" and not isinstance(input_names, _string_types):
+    if input_length != "auto" and not isinstance(input_names, str):
         raise ValueError(
             "'input_length' should not be used unless the input will be only one array."
         )
 
-    if not isinstance(probability, _string_types):
+    if not isinstance(probability, str):
         raise TypeError(
             "Expected 'probability' of type str (got %s)" % type(probability)
         )

--- a/coremltools/converters/libsvm/_libsvm_converter.py
+++ b/coremltools/converters/libsvm/_libsvm_converter.py
@@ -7,7 +7,6 @@ from ... import SPECIFICATION_VERSION
 from ..._deps import _HAS_LIBSVM
 from coremltools import __version__ as ct_version
 from coremltools.models import _METADATA_VERSION, _METADATA_SOURCE
-from six import string_types as _string_types
 
 
 def _infer_min_num_features(model):
@@ -73,7 +72,7 @@ def convert(libsvm_model, feature_names, target, input_length, probability):
 
     # Set the features names
     inferred_length = _infer_min_num_features(libsvm_model)
-    if isinstance(feature_names, _string_types):
+    if isinstance(feature_names, str):
         # input will be a single array
         if input_length == "auto":
             print(

--- a/coremltools/converters/mil/backend/nn/op_mapping.py
+++ b/coremltools/converters/mil/backend/nn/op_mapping.py
@@ -5,7 +5,6 @@
 
 import numpy as _np
 import logging as _logging
-from six import string_types as _string_types
 from coremltools.models import neural_network as neural_network
 from coremltools.proto import NeuralNetwork_pb2
 from coremltools.converters.mil.mil.types.symbolic import (
@@ -64,7 +63,7 @@ def make_input(const_context, builder, variables):
     """
     if isinstance(variables, (list, tuple)):
         return [make_input(const_context, builder, v) for v in variables]
-    if isinstance(variables, _string_types):
+    if isinstance(variables, str):
         return variables
 
     v = variables  # variables is Var

--- a/coremltools/converters/mil/frontend/tensorflow/basic_graph_ops.py
+++ b/coremltools/converters/mil/frontend/tensorflow/basic_graph_ops.py
@@ -9,33 +9,31 @@ from __future__ import print_function as _
 from __future__ import division as _
 from __future__ import absolute_import as _
 
-import six
-
 
 def connect_edge(g, source, dest):
-    if isinstance(source, six.string_types):
+    if isinstance(source, str):
         source = g[source]
-    if isinstance(dest, six.string_types):
+    if isinstance(dest, str):
         dest = g[dest]
     source.outputs.append(dest.name)
     dest.inputs.append(source.name)
 
 
 def connect_edge_at_index(g, source, dest, idx):
-    if isinstance(source, six.string_types):
+    if isinstance(source, str):
         source = g[source]
-    if isinstance(dest, six.string_types):
+    if isinstance(dest, str):
         dest = g[dest]
     source.outputs.insert(idx, dest.name)
     dest.inputs.insert(idx, source.name)
 
 
 def replace_source(g, source, dest, new_source):
-    if isinstance(source, six.string_types):
+    if isinstance(source, str):
         source = g[source]
-    if isinstance(dest, six.string_types):
+    if isinstance(dest, str):
         dest = g[dest]
-    if isinstance(new_source, six.string_types):
+    if isinstance(new_source, str):
         new_source = g[new_source]
     dest_inputs = []
     for inp in dest.inputs:
@@ -49,11 +47,11 @@ def replace_source(g, source, dest, new_source):
 
 
 def replace_control_source(g, source, dest, new_source):
-    if isinstance(source, six.string_types):
+    if isinstance(source, str):
         source = g[source]
-    if isinstance(dest, six.string_types):
+    if isinstance(dest, str):
         dest = g[dest]
-    if isinstance(new_source, six.string_types):
+    if isinstance(new_source, str):
         new_source = g[new_source]
     dest_inputs = []
     for inp in dest.control_inputs:
@@ -67,11 +65,11 @@ def replace_control_source(g, source, dest, new_source):
 
 
 def replace_dest(g, source, dest, new_dest):
-    if isinstance(source, six.string_types):
+    if isinstance(source, str):
         source = g[source]
-    if isinstance(dest, six.string_types):
+    if isinstance(dest, str):
         dest = g[dest]
-    if isinstance(new_dest, six.string_types):
+    if isinstance(new_dest, str):
         new_dest = g[new_dest]
     for idx, d in enumerate(source.outputs):
         if d == dest.name:
@@ -82,11 +80,11 @@ def replace_dest(g, source, dest, new_dest):
 
 
 def replace_control_dest(g, source, dest, new_dest):
-    if isinstance(source, six.string_types):
+    if isinstance(source, str):
         source = g[source]
-    if isinstance(dest, six.string_types):
+    if isinstance(dest, str):
         dest = g[dest]
-    if isinstance(new_dest, six.string_types):
+    if isinstance(new_dest, str):
         new_dest = g[new_dest]
     for idx, d in enumerate(source.control_outputs):
         if d == dest.name:
@@ -107,9 +105,9 @@ def connect_sources(g, sources, dest):
 
 
 def disconnect_edge(g, source, dest):
-    if isinstance(source, six.string_types):
+    if isinstance(source, str):
         source = g[source]
-    if isinstance(dest, six.string_types):
+    if isinstance(dest, str):
         dest = g[dest]
     source.outputs = [i for i in source.outputs if i != dest.name]
 
@@ -117,9 +115,9 @@ def disconnect_edge(g, source, dest):
 
 
 def disconnect_control_edge(g, source, dest):
-    if isinstance(source, six.string_types):
+    if isinstance(source, str):
         source = g[source]
-    if isinstance(dest, six.string_types):
+    if isinstance(dest, str):
         dest = g[dest]
     source.control_outputs = [i for i in source.control_outputs if i != dest.name]
 
@@ -127,7 +125,7 @@ def disconnect_control_edge(g, source, dest):
 
 
 def disconnect_vertex_outs(g, source):
-    if isinstance(source, six.string_types):
+    if isinstance(source, str):
         source = g[source]
     for out in source.outputs:
         g[out].inputs = [i for i in g[out].inputs if i != source.name]
@@ -135,10 +133,10 @@ def disconnect_vertex_outs(g, source):
 
 
 def disconnect_vertex_ins(g, dest):
-    if isinstance(dest, six.string_types):
+    if isinstance(dest, str):
         dest = g[dest]
     for inp in dest.inputs:
-        if isinstance(inp, six.string_types):
+        if isinstance(inp, str):
             innode = g[inp]
         else:
             innode = inp
@@ -147,10 +145,10 @@ def disconnect_vertex_ins(g, dest):
 
 
 def disconnect_vertex_control_ins(g, dest):
-    if isinstance(dest, six.string_types):
+    if isinstance(dest, str):
         dest = g[dest]
     for inp in dest.control_inputs:
-        if isinstance(inp, six.string_types):
+        if isinstance(inp, str):
             innode = g[inp]
         else:
             innode = inp
@@ -159,7 +157,7 @@ def disconnect_vertex_control_ins(g, dest):
 
 
 def disconnect_vertex_control_outs(g, source):
-    if isinstance(source, six.string_types):
+    if isinstance(source, str):
         source = g[source]
     for out in source.control_outputs:
         g[out].control_inputs = [i for i in g[out].control_inputs if i != source.name]
@@ -167,7 +165,7 @@ def disconnect_vertex_control_outs(g, source):
 
 
 def delete_node(g, node):
-    if not isinstance(node, six.string_types):
+    if not isinstance(node, str):
         node = node.name
     disconnect_vertex_ins(g, node)
     disconnect_vertex_outs(g, node)
@@ -177,9 +175,9 @@ def delete_node(g, node):
 
 
 def replace_node(g, original_node, new_node):
-    if isinstance(new_node, six.string_types):
+    if isinstance(new_node, str):
         new_node = g[new_node]
-    if not isinstance(original_node, six.string_types):
+    if not isinstance(original_node, str):
         original_node = original_node.name
 
     for o in list(g[original_node].control_outputs):
@@ -227,24 +225,24 @@ def check_connections(gd):
     # check that inputs and outputs line up
     for k, v in gd.items():
         for i in v.inputs:
-            if isinstance(i, six.string_types):
+            if isinstance(i, str):
                 assert k in gd[i].outputs
             else:
                 assert k in gd[i.name].outputs
         for i in v.outputs:
             inputs = [
-                inp if isinstance(inp, six.string_types) else inp.name
+                inp if isinstance(inp, str) else inp.name
                 for inp in gd[i].inputs
             ]
             assert k in inputs
         for i in v.control_inputs:
-            if isinstance(i, six.string_types):
+            if isinstance(i, str):
                 assert k in gd[i].control_outputs
             else:
                 assert k in gd[i.name].control_outputs
         for i in v.control_outputs:
             control_inputs = [
-                inp if isinstance(inp, six.string_types) else inp.name
+                inp if isinstance(inp, str) else inp.name
                 for inp in gd[i].control_inputs
             ]
             assert k in control_inputs
@@ -262,7 +260,7 @@ def const_determined_nodes(gd, assume_variable_nodes=None):
 
     def visit(node):
         # make sure node is a ParsedNode
-        if isinstance(node, six.string_types):
+        if isinstance(node, str):
             node = gd[node]
         if node.name in vis:
             return
@@ -288,7 +286,7 @@ def const_determined_nodes(gd, assume_variable_nodes=None):
             ret = True
             vis[node.name] = False
             for innode in node.inputs:
-                if isinstance(innode, six.string_types):
+                if isinstance(innode, str):
                     inname = innode
                 else:
                     inname = innode.name

--- a/coremltools/converters/mil/frontend/tensorflow/converter.py
+++ b/coremltools/converters/mil/frontend/tensorflow/converter.py
@@ -3,7 +3,6 @@
 #  Use of this source code is governed by a BSD-3-clause license that can be
 #  found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
-import six
 import logging
 from coremltools.converters.mil.input_types import (
     InputType,
@@ -228,7 +227,7 @@ class TFConverter:
         self._validate_outputs(tfssa, outputs)
         outputs = main_func.outputs if outputs is None else outputs
         outputs = outputs if isinstance(outputs, (tuple, list)) else [outputs]
-        outputs = [x if isinstance(x, six.string_types) else x.name for x in outputs]
+        outputs = [x if isinstance(x, str) else x.name for x in outputs]
         self.outputs = outputs
 
         # We would like a stack so that we run conversion sequentially.
@@ -279,7 +278,7 @@ class TFConverter:
     @staticmethod
     def _get_tensor_name(tensor):
         ret = None
-        if isinstance(tensor, six.string_types):
+        if isinstance(tensor, str):
             ret = tensor
         else:
             ret = tensor.name

--- a/coremltools/converters/mil/frontend/tensorflow/load.py
+++ b/coremltools/converters/mil/frontend/tensorflow/load.py
@@ -13,8 +13,6 @@ import logging
 import os
 import gc
 
-import six
-
 import tensorflow as tf
 
 from tempfile import mktemp
@@ -143,7 +141,7 @@ class TF1Loader(TFLoader):
         elif isinstance(self.model, tf.keras.Model):
             graph_def = self._from_tf_keras_model(self.model)
             return self.extract_sub_graph(graph_def, outputs)
-        elif isinstance(self.model, six.string_types):
+        elif isinstance(self.model, str):
             if not os.path.exists(str(self.model)):
                 raise ValueError('Input model "{}" does not exist'.format(self.model))
             elif os.path.isfile(str(self.model)) and self.model.endswith(".pb"):

--- a/coremltools/converters/mil/frontend/tensorflow/naming_utils.py
+++ b/coremltools/converters/mil/frontend/tensorflow/naming_utils.py
@@ -9,7 +9,6 @@ from __future__ import print_function as _
 from __future__ import division as _
 from __future__ import absolute_import as _
 
-import six
 
 _varname_charset = set(
     [chr(i) for i in range(ord("A"), ord("Z") + 1)]
@@ -37,6 +36,6 @@ def escape_fn_name(name):
 
 
 def normalize_names(names):
-    if isinstance(names, six.string_types):
+    if isinstance(names, str):
         return names.replace(":", "__").replace("/", "__")
     return [i.replace(":", "__").replace("/", "__") for i in names]

--- a/coremltools/converters/mil/frontend/tensorflow/ops.py
+++ b/coremltools/converters/mil/frontend/tensorflow/ops.py
@@ -4,7 +4,6 @@
 #  found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
 import logging as _logging
-from six import string_types as _string_types
 import numpy as _np
 
 from coremltools.converters.mil.mil.ops import get_const_mode
@@ -883,7 +882,7 @@ def Conv3D(context, node):
     )
 
     pad_type = node.attr.get("padding")
-    if not isinstance(pad_type, _string_types):
+    if not isinstance(pad_type, str):
         pad_type = "custom"
         raise NotImplementedError("Custom padding not implemented for TF")
     pad_type = pad_type.lower()
@@ -929,7 +928,7 @@ def Conv3DBackpropInputV2(context, node):
     if pad_type is None:
         raise ValueError("Padding type not specified for op: {}".format(node.name))
 
-    if not isinstance(pad_type, _string_types):
+    if not isinstance(pad_type, str):
         pad_type = "custom"
         raise NotImplementedError("Custom padding not implemented for TF")
     pad_type = pad_type.lower()
@@ -1980,7 +1979,7 @@ def Conv2DBackpropInput(context, node):
     )
     pad_type = node.attr.get("padding")
 
-    if not isinstance(pad_type, _string_types):
+    if not isinstance(pad_type, str):
         pad_type = "custom"
         raise NotImplementedError("Custom padding not implemented for TF")
 

--- a/coremltools/converters/mil/frontend/tensorflow/test/test_load.py
+++ b/coremltools/converters/mil/frontend/tensorflow/test/test_load.py
@@ -5,7 +5,6 @@
 
 import numpy as np
 import os
-import six
 import pytest
 import shutil
 import tempfile
@@ -52,7 +51,7 @@ class TestTf1ModelInputsOutputs:
             outputs = [outputs]
 
         output_names = [
-            j if isinstance(j, six.string_types) else j.op.name for j in outputs
+            j if isinstance(j, str) else j.op.name for j in outputs
         ]
         mlmodel = converter.convert(model, outputs=output_names)
         assert mlmodel is not None
@@ -70,7 +69,7 @@ class TestTf1ModelInputsOutputs:
 
         model, inputs, outputs = build_model
         input_name = (
-            inputs[0] if isinstance(inputs[0], six.string_types) else inputs[0].op.name
+            inputs[0] if isinstance(inputs[0], str) else inputs[0].op.name
         )
         mlmodel = converter.convert(model, inputs=[TensorType(input_name, (3, 4, 5))])
         assert mlmodel is not None
@@ -103,7 +102,7 @@ class TestTf1ModelInputsOutputs:
             return tf.nn.relu(x), tf.math.add(x, y)
 
         model, inputs, outputs = build_model
-        if isinstance(outputs[0], six.string_types):
+        if isinstance(outputs[0], str):
             first_output_name = outputs[0]
         else:
             first_output_name = outputs[0].name.split(":")[0]

--- a/coremltools/converters/mil/frontend/tensorflow/test/testing_utils.py
+++ b/coremltools/converters/mil/frontend/tensorflow/test/testing_utils.py
@@ -3,7 +3,6 @@
 #  Use of this source code is governed by a BSD-3-clause license that can be
 #  found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
-import six
 from coremltools import TensorType
 import pytest
 import numpy as np
@@ -96,7 +95,7 @@ def get_tf_node_names(tf_nodes, mode="inputs"):
         tf_nodes = [tf_nodes]
     names = list()
     for n in tf_nodes:
-        tensor_name = n if isinstance(n, six.string_types) else n.name
+        tensor_name = n if isinstance(n, str) else n.name
         if mode == "outputs":
             names.append(tensor_name)
             continue

--- a/coremltools/converters/mil/frontend/tensorflow2/load.py
+++ b/coremltools/converters/mil/frontend/tensorflow2/load.py
@@ -32,7 +32,6 @@ from coremltools.converters.mil.frontend.tensorflow2.tf_graph_pass import (
     flatten_sub_graph_namespaces,
     rewrite_control_flow_functions,
 )
-from six import string_types as _string_types
 from tensorflow.lite.python.util import get_grappler_config as _get_grappler_config
 from tensorflow.lite.python.util import (
     run_graph_optimizations as _run_graph_optimizations,
@@ -81,14 +80,14 @@ class TF2Loader(TFLoader):
         if (
             isinstance(self.model, list)
             or isinstance(self.model, _tf.keras.Model)
-            or isinstance(self.model, _string_types)
+            or isinstance(self.model, str)
         ):
             cfs = []
             if isinstance(self.model, list):
                 cfs = self.model
             if isinstance(self.model, _tf.keras.Model):
                 cfs = self._concrete_fn_from_tf_keras_or_h5(self.model)
-            elif isinstance(self.model, _string_types):
+            elif isinstance(self.model, str):
                 if not _os_path.exists(self.model):
                     raise ValueError(
                         'Input model "{}" does not exist'.format(self.model)

--- a/coremltools/converters/mil/frontend/torch/converter.py
+++ b/coremltools/converters/mil/frontend/torch/converter.py
@@ -5,7 +5,6 @@
 
 from __future__ import print_function as _
 
-from six import string_types as _string_types
 import logging as _logging
 import torch as _torch
 from coremltools._deps import version_lt

--- a/coremltools/converters/mil/frontend/torch/load.py
+++ b/coremltools/converters/mil/frontend/torch/load.py
@@ -10,7 +10,6 @@ import os.path as _os_path
 
 import torch as _torch
 
-from six import string_types as _string_types
 from .converter import TorchConverter, torch_to_mil_types
 from coremltools.converters.mil.input_types import InputType, TensorType
 from coremltools.converters.mil.mil import Program, types
@@ -88,7 +87,7 @@ def load(model_spec, debug=False, **kwargs):
 
 
 def _torchscript_from_model(model_spec):
-    if isinstance(model_spec, _string_types) and (model_spec.endswith(".pt") or model_spec.endswith(".pth")):
+    if isinstance(model_spec, str) and (model_spec.endswith(".pt") or model_spec.endswith(".pth")):
         filename = _os_path.abspath(model_spec)
         return _torch.jit.load(filename)
     elif isinstance(model_spec, _torch.jit.ScriptModule):

--- a/coremltools/converters/mil/frontend/torch/test/testing_utils.py
+++ b/coremltools/converters/mil/frontend/torch/test/testing_utils.py
@@ -6,7 +6,6 @@
 import numpy as np
 import torch
 import torch.nn as nn
-from six import string_types as _string_types
 from coremltools import TensorType, RangeDim
 from ..converter import torch_to_mil_types
 from coremltools.models import MLModel
@@ -148,7 +147,7 @@ def convert_and_compare(input_data, model_spec, expected_results=None, atol=1e-5
 
     - input_data: torch.tensor or list[torch.tensor]
     """
-    if isinstance(model_spec, _string_types):
+    if isinstance(model_spec, str):
         torch_model = torch.jit.load(model_spec)
     else:
         torch_model = model_spec

--- a/coremltools/converters/mil/input_types.py
+++ b/coremltools/converters/mil/input_types.py
@@ -5,7 +5,6 @@
 
 import logging
 import numpy as np
-import six
 from coremltools.converters.mil.mil.types.symbolic import is_symbolic
 from coremltools.converters.mil.mil import types
 from coremltools.converters.mil.mil.types.type_mapping import (
@@ -308,7 +307,7 @@ class Shape(object):
             if isinstance(s, RangeDim):
                 sym = s.symbol
                 self.symbolic_shape.append(sym)
-            elif isinstance(s, (np.generic, six.integer_types)) or is_symbolic(s):
+            elif isinstance(s, (np.generic, int)) or is_symbolic(s):
                 self.symbolic_shape.append(s)
             else:
                 raise ValueError(
@@ -325,7 +324,7 @@ class Shape(object):
                 )
             for idx, s in enumerate(default):
                 if not isinstance(
-                    s, (np.generic, six.integer_types)
+                    s, (np.generic, int)
                 ) and not is_symbolic(s):
                     raise ValueError(
                         "Default shape invalid, got error at index {} which is {}".format(
@@ -408,7 +407,7 @@ class EnumeratedShapes(object):
                 )
             for idx, s in enumerate(default):
                 if not isinstance(
-                    s, (np.generic, six.integer_types)
+                    s, (np.generic, int)
                 ) and not is_symbolic(s):
                     raise ValueError(
                         "Default shape invalid, got error at index {} which is {}".format(

--- a/coremltools/converters/mil/mil/block.py
+++ b/coremltools/converters/mil/mil/block.py
@@ -7,7 +7,6 @@ from collections import Counter, OrderedDict
 import copy
 import logging
 import numpy as _np
-from six import string_types as _string_types
 from . import SPACES, types
 from .var import Var, InternalVar, ListVar
 from .visitors.dot_visitor import DotVisitor

--- a/coremltools/converters/mil/mil/builder.py
+++ b/coremltools/converters/mil/mil/builder.py
@@ -6,7 +6,6 @@
 from collections import defaultdict
 import copy
 import logging
-import six
 import numbers
 import numpy as np
 
@@ -39,7 +38,7 @@ def is_python_value(val):
     return (
         isinstance(val, (np.generic, np.ndarray))
         or isinstance(val, numbers.Number)
-        or isinstance(val, six.string_types)
+        or isinstance(val, str)
         or isinstance(val, bool)
         or (isinstance(val, (tuple, list)) and all(is_python_value(v) for v in val))
     )

--- a/coremltools/converters/mil/mil/operation.py
+++ b/coremltools/converters/mil/mil/operation.py
@@ -5,7 +5,6 @@
 
 import logging
 import numpy as np
-import six
 from coremltools.converters.mil.mil import types
 from coremltools.converters.mil.mil.types.symbolic import is_symbolic, any_symbolic
 from . import SPACES
@@ -442,7 +441,7 @@ class Operation(object):
                 else:
                     val_str = (
                         '"' + self.val.sym_val + '"'
-                        if isinstance(self.val.sym_val, six.string_types)
+                        if isinstance(self.val.sym_val, str)
                         else str(self.val.sym_val)
                     )
                 s += "val=" + val_str

--- a/coremltools/converters/mil/mil/ops/defs/control_flow.py
+++ b/coremltools/converters/mil/mil/ops/defs/control_flow.py
@@ -4,7 +4,6 @@
 #  Use of this source code is governed by a BSD-3-clause license that can be
 #  found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
-import six
 from coremltools.converters.mil.mil import types
 from coremltools.converters.mil.mil.types.type_mapping import (
     numpy_val_to_builtin_val,
@@ -145,7 +144,7 @@ class const(Operation):
             value = np.float32(value)
         elif isinstance(value, bool):
             value = np.bool(value)
-        elif isinstance(value, (six.integer_types, np.int64)):
+        elif isinstance(value, (int, np.int64)):
             value = np.int32(value)
         elif isinstance(value, (tuple, list, np.ndarray)):
             value = np.array(value)
@@ -169,7 +168,7 @@ class const(Operation):
             return builtin_type, value
 
 
-        if not isinstance(value, (np.generic, np.ndarray, six.string_types, bool, mil_list)):
+        if not isinstance(value, (np.generic, np.ndarray, str, bool, mil_list)):
             raise ValueError("Unknown value for constant: {}".format(value))
 
         _, builtin_type = numpy_val_to_builtin_val(value)

--- a/coremltools/converters/mil/mil/passes/const_elimination.py
+++ b/coremltools/converters/mil/mil/passes/const_elimination.py
@@ -10,7 +10,6 @@ from __future__ import division as _
 from __future__ import absolute_import as _
 
 import numpy as np
-import six
 
 from coremltools.converters.mil.mil import Builder as mb
 from coremltools.converters.mil.mil.passes.pass_registry import register_pass
@@ -19,7 +18,7 @@ from coremltools.converters.mil.mil.passes.pass_registry import register_pass
 def get_const_mode(val):
     # Heuristics to determine if a val should be file value or immediate
     # value.
-    if isinstance(val, (six.string_types, bool, six.integer_types)):
+    if isinstance(val, (str, bool, int)):
         return "immediate_value"
     if isinstance(val, (np.generic, np.ndarray)):
         if val.size > 10:

--- a/coremltools/converters/mil/mil/passes/loop_invariant_elimination.py
+++ b/coremltools/converters/mil/mil/passes/loop_invariant_elimination.py
@@ -10,7 +10,6 @@ from __future__ import division as _
 from __future__ import absolute_import as _
 
 import numpy as np
-import six
 
 from coremltools.converters.mil.mil import Builder as mb
 from coremltools.converters.mil.mil.passes.pass_registry import register_pass

--- a/coremltools/converters/mil/mil/program.py
+++ b/coremltools/converters/mil/mil/program.py
@@ -16,7 +16,6 @@ from .block import Function
 from .var import Var
 from .types.symbolic import k_used_symbols, k_num_internal_syms
 from coremltools.converters.mil.input_types import InputType
-import six
 
 
 class Program(object):
@@ -94,7 +93,7 @@ class Placeholder(object):
         if not isinstance(sym_shape, (list, tuple, _np.ndarray)):
             raise ValueError("Illegal shape for Placeholder: {}".format(sym_shape))
         for i, d in enumerate(sym_shape):
-            if not isinstance(d, (_np.generic, six.integer_types, Symbol)):
+            if not isinstance(d, (_np.generic, int, Symbol)):
                 msg = 'Placeholder dim {} in {} is not integer or symbol'
                 raise ValueError(msg.format(i, sym_shape))
         self.sym_shape = sym_shape

--- a/coremltools/converters/mil/mil/types/annotate.py
+++ b/coremltools/converters/mil/mil/types/annotate.py
@@ -8,7 +8,6 @@
 from __future__ import print_function as _
 from __future__ import division as _
 from __future__ import absolute_import as _
-from six import string_types as _string_types
 
 
 class delay_type_cls:
@@ -112,7 +111,7 @@ def apply_delayed_types(
     for func in fnlist:
         if (
             hasattr(func, "return_type")
-            and isinstance(func.return_type, _string_types)
+            and isinstance(func.return_type, str)
             and func.return_type in type_map
         ):
             func.return_type = type_map[func.return_type]

--- a/coremltools/converters/mil/mil/types/symbolic.py
+++ b/coremltools/converters/mil/mil/types/symbolic.py
@@ -5,7 +5,6 @@
 
 import sympy as sm
 import numpy as np
-import six
 
 k_used_symbols = set()
 k_num_internal_syms = 0
@@ -59,7 +58,7 @@ def any_symbolic(val):
         return is_symbolic(val[()])
     elif isinstance(val, np.ndarray) and np.issctype(val.dtype):
         return False
-    elif isinstance(val, six.string_types):  # string is iterable
+    elif isinstance(val, str):  # string is iterable
         return False
     elif hasattr(val, "__iter__"):
         return any(any_symbolic(i) for i in val)
@@ -71,7 +70,7 @@ def any_variadic(val):
         return True
     elif isinstance(val, np.ndarray) and np.issctype(val.dtype):
         return False
-    elif isinstance(val, six.string_types):  # string is iterable
+    elif isinstance(val, str):  # string is iterable
         return False
     elif hasattr(val, "__iter__"):
         return any(any_variadic(i) for i in val)

--- a/coremltools/converters/mil/mil/types/type_mapping.py
+++ b/coremltools/converters/mil/mil/types/type_mapping.py
@@ -28,7 +28,6 @@ from .type_str import str as types_str
 from .type_unknown import unknown
 import numpy as np
 import sympy as sm
-import six
 from .get_type_info import get_type_info
 
 _types_TO_NPTYPES = {
@@ -224,7 +223,7 @@ def numpy_type_to_builtin_type(nptype):
     elif np.issubclass_(nptype, np.float64) or np.issubclass_(nptype, np.double):
         return types_fp64
     elif (
-        np.issubclass_(nptype, six.string_types)
+        np.issubclass_(nptype, str)
         or np.issubclass_(nptype, np.string_)
         or np.issubclass_(nptype, np.str_)
     ):
@@ -243,9 +242,9 @@ def type_to_builtin_type(type):
     # Otherwise, try to infer from a few generic python types
     if np.issubclass_(type, bool):
         return types_bool
-    elif np.issubclass_(type, six.integer_types):
+    elif np.issubclass_(type, int):
         return types_int32
-    elif np.issubclass_(type, six.string_types):
+    elif np.issubclass_(type, str):
         return types_str
     elif np.issubclass_(type, float):
         return types_fp32

--- a/coremltools/converters/mil/mil/types/type_spec.py
+++ b/coremltools/converters/mil/mil/types/type_spec.py
@@ -8,7 +8,6 @@
 from __future__ import print_function as _
 from __future__ import division as _
 from __future__ import absolute_import as _
-from six import string_types as _string_types
 
 
 class Type:
@@ -26,7 +25,7 @@ class Type:
     def __init__(self, name, tparam=None, python_class=None):
         if tparam is None:
             tparam = []
-        assert isinstance(name, _string_types)
+        assert isinstance(name, str)
         assert isinstance(tparam, list)
         self.name = name
         self.tparam = tparam

--- a/coremltools/converters/mil/mil/types/type_str.py
+++ b/coremltools/converters/mil/mil/types/type_str.py
@@ -10,7 +10,6 @@ from __future__ import division as _
 from __future__ import absolute_import as _
 from .annotate import class_annotate, annotate, delay_type
 from .type_spec import Type
-from six import string_types as _string_types
 
 
 @class_annotate()
@@ -24,5 +23,5 @@ class str:
 
     @annotate(delay_type.str, other=delay_type.str)
     def __add__(self, other):
-        assert isinstance(other, _string_types)
+        assert isinstance(other, str)
         return str(self.val + other.val)

--- a/coremltools/converters/onnx/_backend.py
+++ b/coremltools/converters/onnx/_backend.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals as _
 from typing import Any, Text, Dict, Tuple
 from onnx import ModelProto
 from onnx.backend.base import Backend
-from six import string_types as _string_types
 from ._backend_rep import CoreMLRep
 from ._converter import convert
 import onnx
@@ -20,7 +19,7 @@ def _get_onnx_outputs_info(model):  # type: (...) -> Dict[Text, EdgeInfo]
     Takes in an onnx model and returns a dictionary
     of onnx output names mapped to a tuple that is (output_name, type, shape)
     """
-    if isinstance(model, _string_types):
+    if isinstance(model, str):
         onnx_model = onnx.load(model)
     elif isinstance(model, onnx.ModelProto):
         onnx_model = model

--- a/coremltools/converters/sklearn/_converter_internal.py
+++ b/coremltools/converters/sklearn/_converter_internal.py
@@ -22,7 +22,6 @@ if _HAS_SKLEARN:
 
 from collections import namedtuple as _namedtuple
 import numpy as _np
-from six import string_types as _string_types
 
 from . import _one_hot_encoder
 from . import _dict_vectorizer
@@ -176,7 +175,7 @@ def _convert_sklearn_model(
         dv_obj = obj_list[0].sk_obj
         output_dim = len(_dict_vectorizer.get_input_feature_names(dv_obj))
 
-        if not isinstance(input_features, _string_types):
+        if not isinstance(input_features, str):
             raise TypeError(
                 "If the first transformer in a pipeline is a "
                 "DictVectorizer, then the input feature must be the name "
@@ -192,7 +191,7 @@ def _convert_sklearn_model(
             if output_feature_names is None:
                 output_feature_name = "transformed_features"
 
-            elif isinstance(output_feature_names, _string_types):
+            elif isinstance(output_feature_names, str):
                 output_feature_name = output_feature_names
 
             else:
@@ -303,7 +302,7 @@ def _convert_sklearn_model(
     elif overall_mode == "regressor":
         if output_feature_names is None:
             output_features = [("prediction", datatypes.Double())]
-        elif isinstance(output_feature_names, _string_types):
+        elif isinstance(output_feature_names, str):
             output_features = [(output_feature_names, datatypes.Double())]
         else:
             raise TypeError(
@@ -321,7 +320,7 @@ def _convert_sklearn_model(
                 ("transformed_features", datatypes.Array(final_output_dimension))
             ]
 
-        elif isinstance(output_feature_names, _string_types):
+        elif isinstance(output_feature_names, str):
             output_features = [
                 (output_feature_names, datatypes.Array(final_output_dimension))
             ]

--- a/coremltools/converters/sklearn/_dict_vectorizer.py
+++ b/coremltools/converters/sklearn/_dict_vectorizer.py
@@ -3,8 +3,6 @@
 # Use of this source code is governed by a BSD-3-clause license that can be
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
-import six as _six
-
 from . import _sklearn_util
 
 from ... import SPECIFICATION_VERSION
@@ -70,14 +68,14 @@ def convert(model, input_features, output_features):
     tr_spec = dv_spec.dictVectorizer
     is_str = None
     for feature_name in model.feature_names_:
-        if isinstance(feature_name, _six.string_types):
+        if isinstance(feature_name, str):
             if is_str == False:
                 raise ValueError("Mapping of DictVectorizer mixes int and str types.")
 
             tr_spec.stringToIndex.vector.append(feature_name)
             is_str == True
 
-        if isinstance(feature_name, _six.integer_types):
+        if isinstance(feature_name, int):
             if is_str == True:
                 raise ValueError("Mapping of DictVectorizer mixes int and str types.")
 

--- a/coremltools/converters/sklearn/_k_neighbors_classifier.py
+++ b/coremltools/converters/sklearn/_k_neighbors_classifier.py
@@ -16,7 +16,6 @@ if _HAS_SKLEARN:
 
 import numpy as np
 import scipy as sp
-import six as _six
 
 model_type = "classifier"
 sklearn_class = _neighbors.KNeighborsClassifier
@@ -273,7 +272,7 @@ def _is_algorithm_kd_tree(model):
 
 def _is_printable(obj):
     """Check if the object is a valid text type."""
-    return isinstance(obj, _six.string_types)
+    return isinstance(obj, str)
 
 
 def _is_valid_sparse_format(obj):

--- a/coremltools/converters/xgboost/_tree_ensemble.py
+++ b/coremltools/converters/xgboost/_tree_ensemble.py
@@ -10,7 +10,6 @@ from ...models.tree_ensemble import (
 from ..._deps import _HAS_XGBOOST
 
 import numpy as _np
-from six import string_types as _string_types
 
 if _HAS_XGBOOST:
     import xgboost as _xgboost
@@ -213,7 +212,7 @@ def convert_tree_ensemble(
             feature_map = {f: i for i, f in enumerate(model.feature_names)}
 
     # Path on the file system where the XGboost model exists.
-    elif isinstance(model, _string_types):
+    elif isinstance(model, str):
         if not os.path.exists(model):
             raise TypeError("Invalid path %s." % model)
         with open(model) as f:

--- a/coremltools/models/_feature_management.py
+++ b/coremltools/models/_feature_management.py
@@ -31,7 +31,7 @@ def process_or_validate_classifier_output_features(
     class_labels = list(class_labels)
 
     # First, we need to determine the type of the classes.
-    _int_types = int + (bool, _np.bool_, _np.int32, _np.int64)
+    _int_types = (int, bool, _np.bool_, _np.int32, _np.int64)
 
     if all(isinstance(cl, _int_types) for cl in class_labels):
         output_class_type = datatypes.Int64()

--- a/coremltools/models/_feature_management.py
+++ b/coremltools/models/_feature_management.py
@@ -8,10 +8,6 @@ from copy import copy
 from functools import reduce
 import numpy as _np
 import operator as op
-from six import (
-    integer_types as _integer_types,
-    string_types as _string_types,
-)
 
 from . import datatypes
 from .. import SPECIFICATION_VERSION
@@ -35,12 +31,12 @@ def process_or_validate_classifier_output_features(
     class_labels = list(class_labels)
 
     # First, we need to determine the type of the classes.
-    _int_types = _integer_types + (bool, _np.bool_, _np.int32, _np.int64)
+    _int_types = int + (bool, _np.bool_, _np.int32, _np.int64)
 
     if all(isinstance(cl, _int_types) for cl in class_labels):
         output_class_type = datatypes.Int64()
 
-    elif all(isinstance(cl, _string_types) for cl in class_labels):
+    elif all(isinstance(cl, str) for cl in class_labels):
         output_class_type = datatypes.String()
 
     else:
@@ -53,7 +49,7 @@ def process_or_validate_classifier_output_features(
         if supports_class_scores:
             out += [("classProbability", datatypes.Dictionary(output_class_type))]
 
-    elif isinstance(output_features, _string_types):
+    elif isinstance(output_features, str):
 
         out = [(output_features, output_class_type)]
 
@@ -62,7 +58,7 @@ def process_or_validate_classifier_output_features(
 
     elif (
         isinstance(output_features, (list, tuple))
-        and all(isinstance(fn, _string_types) for fn in output_features)
+        and all(isinstance(fn, str) for fn in output_features)
         and len(output_features) == 2
     ):
 
@@ -129,7 +125,7 @@ def is_valid_feature_list(features):
         type(features) is list
         and len(features) >= 1
         and all(type(t) is tuple and len(t) == 2 for t in features)
-        and all(isinstance(n, _string_types) for n, td in features)
+        and all(isinstance(n, str) for n, td in features)
         and all(datatypes._is_valid_datatype(td) for n, td in features)
     )
 
@@ -207,7 +203,7 @@ def process_or_validate_features(features, num_dimensions=None, feature_type_map
 
     original_features = copy(features)
 
-    if num_dimensions is not None and not isinstance(num_dimensions, _integer_types):
+    if num_dimensions is not None and not isinstance(num_dimensions, int):
         raise TypeError(
             "num_dimensions must be None, an integer or a long, not '%s'"
             % str(type(num_dimensions))
@@ -238,7 +234,7 @@ def process_or_validate_features(features, num_dimensions=None, feature_type_map
         # datatype class -- e.g. translate str to datatypes.String().
         return [(k, datatypes._normalize_datatype(dt)) for k, dt in features]
 
-    if isinstance(features, _string_types):
+    if isinstance(features, str):
         if num_dimensions is None:
             raise_type_error(
                 "If a single feature name is given, then "
@@ -252,7 +248,7 @@ def process_or_validate_features(features, num_dimensions=None, feature_type_map
         mapping = defaultdict(lambda: [])
 
         for i, k in enumerate(features):
-            if not isinstance(k, _string_types):
+            if not isinstance(k, str):
                 raise_type_error(
                     "List of feature names must either be a list of strings, or a list of (name, datatypes.Array instance) tuples."
                 )
@@ -280,7 +276,7 @@ def process_or_validate_features(features, num_dimensions=None, feature_type_map
 
     for k, v in list(features.items()):
 
-        if not isinstance(k, _string_types):
+        if not isinstance(k, str):
             raise_type_error("Feature names must be strings.")
 
         def test_index(val):
@@ -308,7 +304,7 @@ def process_or_validate_features(features, num_dimensions=None, feature_type_map
             # Replace and update
             features[k] = v = list(sorted(v))
 
-        elif isinstance(v, _integer_types):
+        elif isinstance(v, int):
             test_index(v)
             features[k] = v = [v]
         else:

--- a/coremltools/models/array_feature_extractor.py
+++ b/coremltools/models/array_feature_extractor.py
@@ -3,8 +3,6 @@
 # Use of this source code is governed by a BSD-3-clause license that can be
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
-from six import integer_types as _integer_types
-
 from . import datatypes
 from .. import SPECIFICATION_VERSION
 from ..proto import Model_pb2 as _Model_pb2
@@ -33,13 +31,13 @@ def create_array_feature_extractor(
     spec = _Model_pb2.Model()
     spec.specificationVersion = SPECIFICATION_VERSION
 
-    if isinstance(extract_indices, _integer_types):
+    if isinstance(extract_indices, int):
         extract_indices = [extract_indices]
         if output_type is None:
             output_type = datatypes.Double()
 
     elif isinstance(extract_indices, (list, tuple)):
-        if not all(isinstance(x, _integer_types) for x in extract_indices):
+        if not all(isinstance(x, int) for x in extract_indices):
             raise TypeError("extract_indices must be an integer or a list of integers.")
 
         if output_type is None:

--- a/coremltools/models/datatypes.py
+++ b/coremltools/models/datatypes.py
@@ -6,7 +6,6 @@
 """
 Basic Data Types.
 """
-from six import integer_types as _integer_types
 import numpy as _np
 
 from ..proto import FeatureTypes_pb2 as _FeatureTypes_pb2
@@ -81,7 +80,7 @@ class Array(_DatatypeBase):
         """
         assert len(dimensions) >= 1
         assert all(
-            isinstance(d, _integer_types + (_np.int64, _np.int32)) for d in dimensions
+            isinstance(d, int + (_np.int64, _np.int32)) for d in dimensions
         ), "Dimensions must be ints, not {}".format(str(dimensions))
         self.dimensions = dimensions
 

--- a/coremltools/models/datatypes.py
+++ b/coremltools/models/datatypes.py
@@ -80,7 +80,7 @@ class Array(_DatatypeBase):
         """
         assert len(dimensions) >= 1
         assert all(
-            isinstance(d, int + (_np.int64, _np.int32)) for d in dimensions
+            isinstance(d, (int, _np.int64, _np.int32)) for d in dimensions
         ), "Dimensions must be ints, not {}".format(str(dimensions))
         self.dimensions = dimensions
 

--- a/coremltools/models/feature_vectorizer.py
+++ b/coremltools/models/feature_vectorizer.py
@@ -3,8 +3,6 @@
 # Use of this source code is governed by a BSD-3-clause license that can be
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
-from six import string_types as _string_types
-
 from . import datatypes
 from .. import SPECIFICATION_VERSION
 from ..proto import Model_pb2 as _Model_pb2
@@ -82,7 +80,7 @@ def create_feature_vectorizer(input_features, output_feature_name, known_size_ma
         new_feature.inputColumn = n
         new_feature.inputDimensions = dim
 
-    if not isinstance(output_feature_name, _string_types):
+    if not isinstance(output_feature_name, str):
         if (
             is_valid_feature_list(output_feature_name)
             and len(output_feature_name) == 1

--- a/coremltools/models/model.py
+++ b/coremltools/models/model.py
@@ -7,7 +7,6 @@ import os as _os
 import tempfile as _tempfile
 import warnings as _warnings
 from copy import deepcopy as _deepcopy
-from six import string_types as _string_types
 
 from .utils import _has_custom_layer as _has_custom_layer
 from .utils import load_spec as _load_spec
@@ -191,7 +190,7 @@ class MLModel(object):
         >>> loaded_model = MLModel('my_model_file.mlmodel')
         """
 
-        if isinstance(model, _string_types):
+        if isinstance(model, str):
             self.__proxy__, self._spec, self._framework_error = _get_proxy_and_spec(
                 model, useCPUOnly
             )

--- a/coremltools/models/nearest_neighbors/builder.py
+++ b/coremltools/models/nearest_neighbors/builder.py
@@ -9,7 +9,6 @@ from .. import datatypes
 import coremltools
 
 import numpy as _np
-import six as _six
 
 
 class KNearestNeighborsClassifierBuilder(object):
@@ -509,7 +508,7 @@ class KNearestNeighborsClassifierBuilder(object):
         :param obj: the object to check
         :return: True if a valid text type, False otherwise
         """
-        return isinstance(obj, _six.string_types)
+        return isinstance(obj, str)
 
     @staticmethod
     def _is_valid_number_type(obj):
@@ -518,4 +517,4 @@ class KNearestNeighborsClassifierBuilder(object):
         :param obj: the object to check
         :return: True if a valid number type, False otherwise
         """
-        return isinstance(obj, (_six.integer_types, _np.integer))
+        return isinstance(obj, (int, _np.integer))

--- a/coremltools/models/neural_network/builder.py
+++ b/coremltools/models/neural_network/builder.py
@@ -24,7 +24,6 @@ import numpy as _np
 from .quantization_utils import _unpack_to_bytes, _convert_array_to_nbit_quantized_bytes
 from .spec_inspection_utils import _summarize_network_layer_info
 from .update_optimizer_utils import AdamParams, SgdParams
-from six import string_types as _string_types
 from math import floor as _math_floor
 
 _SUPPORTED_UPDATABLE_LAYERS = ["innerProduct", "convolution"]
@@ -35,7 +34,7 @@ def _set_recurrent_activation(param, activation):
         activation = activation.decode("utf8")
 
     activation = (
-        activation.upper() if isinstance(activation, _string_types) else activation
+        activation.upper() if isinstance(activation, str) else activation
     )
 
     if activation == "SIGMOID":
@@ -584,7 +583,7 @@ class NeuralNetworkBuilder(object):
         if len(class_labels) == 0:
             return
         class_type = type(class_labels[0])
-        if not isinstance(class_labels[0], (int, _string_types)):
+        if not isinstance(class_labels[0], (int, str)):
             raise TypeError(
                 "Class labels must be of type Integer or String. (not %s)" % class_type
             )
@@ -1011,7 +1010,7 @@ class NeuralNetworkBuilder(object):
             )
 
         (fname, ftype) = input_feature
-        if not isinstance(fname, _string_types):
+        if not isinstance(fname, str):
             raise ValueError(
                 "Loss layer input must be a tuple of type (string, datatype)"
             )
@@ -1753,7 +1752,7 @@ class NeuralNetworkBuilder(object):
         # Fill in the parameters
         non_linearity = (
             non_linearity.upper()
-            if isinstance(non_linearity, _string_types)
+            if isinstance(non_linearity, str)
             else non_linearity
         )
         if non_linearity == "RELU":
@@ -1869,7 +1868,7 @@ class NeuralNetworkBuilder(object):
         spec_layer = self._add_generic_layer(name, input_names, [output_name])
 
         # add one of the following layers
-        mode = mode.upper() if isinstance(mode, _string_types) else mode
+        mode = mode.upper() if isinstance(mode, str) else mode
         if mode == "CONCAT":
             spec_layer.concat.sequenceConcat = False
         elif mode == "SEQUENCE_CONCAT":
@@ -1946,10 +1945,10 @@ class NeuralNetworkBuilder(object):
 
         """
 
-        mode = mode.upper() if isinstance(mode, _string_types) else mode
+        mode = mode.upper() if isinstance(mode, str) else mode
         linear_upsample_mode = (
             linear_upsample_mode.upper()
-            if isinstance(linear_upsample_mode, _string_types)
+            if isinstance(linear_upsample_mode, str)
             else linear_upsample_mode
         )
         if not mode in ["NN", "BILINEAR"]:
@@ -2301,12 +2300,12 @@ class NeuralNetworkBuilder(object):
 
         border_mode = (
             border_mode.lower()
-            if isinstance(border_mode, _string_types)
+            if isinstance(border_mode, str)
             else border_mode
         )
         same_padding_asymmetry_mode = (
             same_padding_asymmetry_mode.upper()
-            if isinstance(same_padding_asymmetry_mode, _string_types)
+            if isinstance(same_padding_asymmetry_mode, str)
             else same_padding_asymmetry_mode
         )
 
@@ -2654,12 +2653,12 @@ class NeuralNetworkBuilder(object):
 
         padding_type = (
             padding_type.upper()
-            if isinstance(padding_type, _string_types)
+            if isinstance(padding_type, str)
             else padding_type
         )
         same_padding_asymmetry_mode = (
             same_padding_asymmetry_mode.upper()
-            if isinstance(same_padding_asymmetry_mode, _string_types)
+            if isinstance(same_padding_asymmetry_mode, str)
             else same_padding_asymmetry_mode
         )
 
@@ -2896,7 +2895,7 @@ class NeuralNetworkBuilder(object):
         # Set the parameters
         padding_type = (
             padding_type.lower()
-            if isinstance(padding_type, _string_types)
+            if isinstance(padding_type, str)
             else padding_type
         )
         if padding_type == "constant":
@@ -3570,7 +3569,7 @@ class NeuralNetworkBuilder(object):
         spec_layer_params.endIndex = end_index
         spec_layer_params.stride = stride
 
-        axis = axis.lower() if isinstance(axis, _string_types) else axis
+        axis = axis.lower() if isinstance(axis, str) else axis
         if axis == "channel":
             spec_layer_params.axis = _NeuralNetwork_pb2.SliceLayerParams.SliceAxis.Value(
                 "CHANNEL_AXIS"
@@ -3676,7 +3675,7 @@ class NeuralNetworkBuilder(object):
             )
         spec_layer_params.blockSize = block_size
 
-        mode = mode.upper() if isinstance(mode, _string_types) else mode
+        mode = mode.upper() if isinstance(mode, str) else mode
         if mode == "SPACE_TO_DEPTH":
             spec_layer_params.mode = _NeuralNetwork_pb2.ReorganizeDataLayerParams.ReorganizationType.Value(
                 "SPACE_TO_DEPTH"
@@ -3904,7 +3903,7 @@ class NeuralNetworkBuilder(object):
         spec_layer_params = spec_layer.reduce
         spec_layer_params.epsilon = epsilon
 
-        mode = mode.lower() if isinstance(mode, _string_types) else mode
+        mode = mode.lower() if isinstance(mode, str) else mode
         if mode == "sum":
             spec_layer_params.mode = _NeuralNetwork_pb2.ReduceLayerParams.ReduceOperation.Value(
                 "SUM"
@@ -3948,7 +3947,7 @@ class NeuralNetworkBuilder(object):
         else:
             raise NotImplementedError("Unknown reduction operation %s." % mode)
 
-        axis = axis.upper() if isinstance(axis, _string_types) else axis
+        axis = axis.upper() if isinstance(axis, str) else axis
         if axis == "CHW":
             spec_layer_params.axis = _NeuralNetwork_pb2.ReduceLayerParams.ReduceAxis.Value(
                 "CHW"
@@ -4142,7 +4141,7 @@ class NeuralNetworkBuilder(object):
         spec_layer_params.shift = shift
         spec_layer_params.scale = scale
 
-        mode = mode.lower() if isinstance(mode, _string_types) else mode
+        mode = mode.lower() if isinstance(mode, str) else mode
         if mode == "sqrt":
             spec_layer_params.type = _NeuralNetwork_pb2.UnaryFunctionLayerParams.Operation.Value(
                 "SQRT"
@@ -4316,7 +4315,7 @@ class NeuralNetworkBuilder(object):
         spec_layer_params = spec_layer.resizeBilinear
         spec_layer_params.targetSize.append(target_height)
         spec_layer_params.targetSize.append(target_width)
-        mode = mode.upper() if isinstance(mode, _string_types) else mode
+        mode = mode.upper() if isinstance(mode, str) else mode
         if mode == "ALIGN_ENDPOINTS_MODE":
 
             spec_layer_params.mode.samplingMethod = _NeuralNetwork_pb2.SamplingMode.Method.Value(
@@ -4409,10 +4408,10 @@ class NeuralNetworkBuilder(object):
         spec_layer_params.normalizedCoordinates = normalized_roi
         spec_layer_params.spatialScale = spatial_scale
 
-        mode = mode.upper() if isinstance(mode, _string_types) else mode
+        mode = mode.upper() if isinstance(mode, str) else mode
         box_indices_mode = (
             box_indices_mode.upper()
-            if isinstance(box_indices_mode, _string_types)
+            if isinstance(box_indices_mode, str)
             else box_indices_mode
         )
 
@@ -4508,7 +4507,7 @@ class NeuralNetworkBuilder(object):
 
         image_format = (
             image_format.upper()
-            if isinstance(image_format, _string_types)
+            if isinstance(image_format, str)
             else image_format
         )
         if image_format != "NCHW" and image_format != "NHWC":
@@ -5961,7 +5960,7 @@ class NeuralNetworkBuilder(object):
         add_equal, add_not_equal, add_less_than
         """
 
-        if isinstance(input_names, _string_types):
+        if isinstance(input_names, str):
             input_names = [input_names]
         spec_layer = self._add_generic_layer(name, input_names, [output_name])
         if use_greater_than_equal:
@@ -6003,7 +6002,7 @@ class NeuralNetworkBuilder(object):
         add_equal, add_not_equal, add_greater_than
         """
 
-        if isinstance(input_names, _string_types):
+        if isinstance(input_names, str):
             input_names = [input_names]
         spec_layer = self._add_generic_layer(name, input_names, [output_name])
         if use_less_than_equal:
@@ -6038,7 +6037,7 @@ class NeuralNetworkBuilder(object):
         add_not_equal, add_greater_than, add_less_than
         """
 
-        if isinstance(input_names, _string_types):
+        if isinstance(input_names, str):
             input_names = [input_names]
         spec_layer = self._add_generic_layer(name, input_names, [output_name])
         spec_layer.equal.MergeFromString(b"")
@@ -6068,7 +6067,7 @@ class NeuralNetworkBuilder(object):
         add_equal, add_greater_than, add_less_than
         """
 
-        if isinstance(input_names, _string_types):
+        if isinstance(input_names, str):
             input_names = [input_names]
         spec_layer = self._add_generic_layer(name, input_names, [output_name])
         spec_layer.notEqual.MergeFromString(b"")
@@ -6096,7 +6095,7 @@ class NeuralNetworkBuilder(object):
             Logical operation mode in [AND | OR | XOR | NOT].
         """
 
-        if isinstance(input_names, _string_types):
+        if isinstance(input_names, str):
             input_names = [input_names]
 
         spec_layer = self._add_generic_layer(name, input_names, [output_name])
@@ -6276,7 +6275,7 @@ class NeuralNetworkBuilder(object):
         spec_layer_params = spec_layer.scatter
         spec_layer_params.axis = axis
 
-        mode = mode.upper() if isinstance(mode, _string_types) else mode
+        mode = mode.upper() if isinstance(mode, str) else mode
         if mode == "UPDATE":
             spec_layer_params.mode = _NeuralNetwork_pb2.ScatterMode.Value(
                 "SCATTER_UPDATE"
@@ -6357,7 +6356,7 @@ class NeuralNetworkBuilder(object):
         spec_layer_params = spec_layer.scatterAlongAxis
         spec_layer_params.axis = axis
 
-        mode = mode.upper() if isinstance(mode, _string_types) else mode
+        mode = mode.upper() if isinstance(mode, str) else mode
         if mode == "UPDATE":
             spec_layer_params.mode = _NeuralNetwork_pb2.ScatterMode.Value(
                 "SCATTER_UPDATE"
@@ -6436,7 +6435,7 @@ class NeuralNetworkBuilder(object):
         spec_layer = self._add_generic_layer(name, input_names, [output_name])
         spec_layer_params = spec_layer.scatterND
 
-        mode = mode.upper() if isinstance(mode, _string_types) else mode
+        mode = mode.upper() if isinstance(mode, str) else mode
         if mode == "UPDATE":
             spec_layer_params.mode = _NeuralNetwork_pb2.ScatterMode.Value(
                 "SCATTER_UPDATE"

--- a/coremltools/models/neural_network/quantization_utils.py
+++ b/coremltools/models/neural_network/quantization_utils.py
@@ -14,7 +14,6 @@ from __future__ import absolute_import as _
 import numpy as _np
 from sys import stdout as _stdout
 from os import listdir as _listdir
-from six import string_types as _string_types
 from .optimization_utils import _optimize_nn
 
 from coremltools.models import (
@@ -215,7 +214,7 @@ class MatrixMultiplyLayerSelector(QuantizedLayerSelector):
         if not (
             isinstance(self.include_layers_with_names, (list, tuple))
             and all(
-                [isinstance(s, _string_types) for s in self.include_layers_with_names]
+                [isinstance(s, str) for s in self.include_layers_with_names]
             )
         ):
             raise ValueError(
@@ -1393,7 +1392,7 @@ def compare_models(full_precision_model, quantized_model, sample_data):
 
     spec = full_precision_model.get_spec()
     num_inputs = len(spec.description.input)
-    if isinstance(sample_data, _string_types):
+    if isinstance(sample_data, str):
         input_type = spec.description.input[0].type.WhichOneof("Type")
         if num_inputs != 1 or input_type != "imageType":
             raise Exception(

--- a/coremltools/models/neural_network/utils.py
+++ b/coremltools/models/neural_network/utils.py
@@ -1,7 +1,6 @@
 from .builder import NeuralNetworkBuilder
 from coremltools.models.utils import _get_model
 import copy as _copy
-import six as _six
 
 
 def make_image_input(
@@ -120,7 +119,7 @@ def make_nn_classifier(
     elif isinstance(classes_in, list):  # list[int or str]
         classes = classes_in
         assert all([isinstance(x, \
-            (_six.integer_types, _six.string_types)) for x in classes]), message
+            (int, str)) for x in classes]), message
     else:
         raise ValueError(message)
 

--- a/coremltools/models/utils.py
+++ b/coremltools/models/utils.py
@@ -9,7 +9,6 @@ Utilities for the entire package.
 import math as _math
 import numpy as _np
 import os as _os
-import six as _six
 import warnings as _warnings
 import sys as _sys
 from coremltools.proto import Model_pb2 as _Model_pb2
@@ -21,7 +20,7 @@ if _HAS_SKLEARN:
 
 
 def _to_unicode(x):
-    if isinstance(x, _six.binary_type):
+    if isinstance(x, bytes):
         return x.decode()
     else:
         return x
@@ -564,7 +563,7 @@ def _sanitize_value(x):
     Performs cleaning steps on the data so various type comparisons can
     be performed correctly.
     """
-    if isinstance(x, _six.string_types + _six.integer_types + (float,)):
+    if isinstance(x, str + int + (float,)):
         return x
     elif _HAS_SKLEARN and _sp.issparse(x):
         return x.todense()

--- a/coremltools/models/utils.py
+++ b/coremltools/models/utils.py
@@ -563,7 +563,7 @@ def _sanitize_value(x):
     Performs cleaning steps on the data so various type comparisons can
     be performed correctly.
     """
-    if isinstance(x, str + int + (float,)):
+    if isinstance(x, (str, int, float,)):
         return x
     elif _HAS_SKLEARN and _sp.issparse(x):
         return x.todense()

--- a/coremltools/test/api/test_api_examples.py
+++ b/coremltools/test/api/test_api_examples.py
@@ -352,7 +352,7 @@ class TestTensorFlow2ConverterExamples:
         )
 
         # Download class labels (from a separate file)
-        from six.moves import urllib
+        import urllib.request
         label_url = 'https://storage.googleapis.com/download.tensorflow.org/data/ImageNetLabels.txt'
         class_labels = urllib.request.urlopen(label_url).read().splitlines()
         class_labels = class_labels[1:]  # remove the first class which is background

--- a/coremltools/test/neural_network/test_keras.py
+++ b/coremltools/test/neural_network/test_keras.py
@@ -8,7 +8,6 @@ import unittest
 from coremltools._deps import _HAS_KERAS_TF
 from coremltools.proto import FeatureTypes_pb2
 import pytest
-import six
 
 if _HAS_KERAS_TF:
     import tensorflow as tf
@@ -50,11 +49,11 @@ class KerasSingleLayerTest(unittest.TestCase):
 
         # Test the inputs and outputs
         self.assertEquals(len(spec.description.input), len(input_names))
-        six.assertCountEqual(
+        self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
         self.assertEquals(len(spec.description.output), len(output_names))
-        six.assertCountEqual(
+        self.assertCountEqual(
             self, output_names, [x.name for x in spec.description.output]
         )
 
@@ -106,11 +105,11 @@ class KerasSingleLayerTest(unittest.TestCase):
 
             # Test the inputs and outputs
             self.assertEquals(len(spec.description.input), len(input_names))
-            six.assertCountEqual(
+            self.assertCountEqual(
                 self, input_names, [x.name for x in spec.description.input]
             )
             self.assertEquals(len(spec.description.output), len(output_names))
-            six.assertCountEqual(
+            self.assertCountEqual(
                 self, output_names, [x.name for x in spec.description.output]
             )
 
@@ -142,11 +141,11 @@ class KerasSingleLayerTest(unittest.TestCase):
 
         # Test the inputs and outputs
         self.assertEquals(len(spec.description.input), len(input_names))
-        six.assertCountEqual(
+        self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
         self.assertEquals(len(spec.description.output), len(output_names))
-        six.assertCountEqual(
+        self.assertCountEqual(
             self, output_names, [x.name for x in spec.description.output]
         )
 
@@ -180,11 +179,11 @@ class KerasSingleLayerTest(unittest.TestCase):
 
         # Test the inputs and outputs
         self.assertEquals(len(spec.description.input), len(input_names))
-        six.assertCountEqual(
+        self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
         self.assertEquals(len(spec.description.output), len(output_names))
-        six.assertCountEqual(
+        self.assertCountEqual(
             self, output_names, [x.name for x in spec.description.output]
         )
 
@@ -227,11 +226,11 @@ class KerasSingleLayerTest(unittest.TestCase):
 
         # Test the inputs and outputs
         self.assertEquals(len(spec.description.input), len(input_names))
-        six.assertCountEqual(
+        self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
         self.assertEquals(len(spec.description.output), len(output_names))
-        six.assertCountEqual(
+        self.assertCountEqual(
             self, output_names, [x.name for x in spec.description.output]
         )
 
@@ -263,11 +262,11 @@ class KerasSingleLayerTest(unittest.TestCase):
 
         # Test the inputs and outputs
         self.assertEquals(len(spec.description.input), len(input_names))
-        six.assertCountEqual(
+        self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
         self.assertEquals(len(spec.description.output), len(output_names))
-        six.assertCountEqual(
+        self.assertCountEqual(
             self, output_names, [x.name for x in spec.description.output]
         )
 
@@ -313,11 +312,11 @@ class KerasSingleLayerTest(unittest.TestCase):
 
         # Test the inputs and outputs
         self.assertEquals(len(spec.description.input), len(input_names))
-        six.assertCountEqual(
+        self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
         self.assertEquals(len(spec.description.output), len(output_names))
-        six.assertCountEqual(
+        self.assertCountEqual(
             self, output_names, [x.name for x in spec.description.output]
         )
 
@@ -347,11 +346,11 @@ class KerasSingleLayerTest(unittest.TestCase):
 
         # Test the inputs and outputs
         self.assertEquals(len(spec.description.input), len(input_names))
-        six.assertCountEqual(
+        self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
         self.assertEquals(len(spec.description.output), len(output_names))
-        six.assertCountEqual(
+        self.assertCountEqual(
             self, output_names, [x.name for x in spec.description.output]
         )
 
@@ -591,11 +590,11 @@ class KerasSingleLayerTest(unittest.TestCase):
 
         # Test the inputs and outputs
         self.assertEquals(len(spec.description.input), len(input_names))
-        six.assertCountEqual(
+        self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
         self.assertEquals(len(spec.description.output), len(output_names))
-        six.assertCountEqual(
+        self.assertCountEqual(
             self, output_names, [x.name for x in spec.description.output]
         )
 
@@ -626,11 +625,11 @@ class KerasSingleLayerTest(unittest.TestCase):
 
         # Test the inputs and outputs
         self.assertEquals(len(spec.description.input), len(input_names))
-        six.assertCountEqual(
+        self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
         self.assertEquals(len(spec.description.output), len(output_names))
-        six.assertCountEqual(
+        self.assertCountEqual(
             self, output_names, [x.name for x in spec.description.output]
         )
 
@@ -676,11 +675,11 @@ class KerasSingleLayerTest(unittest.TestCase):
 
         # Test the inputs and outputs
         self.assertEquals(len(spec.description.input), len(input_names))
-        six.assertCountEqual(
+        self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
         self.assertEquals(len(spec.description.output), len(output_names))
-        six.assertCountEqual(
+        self.assertCountEqual(
             self, output_names, [x.name for x in spec.description.output]
         )
 
@@ -704,11 +703,11 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
         # Test the inputs and outputs
         self.assertEquals(len(spec.description.input), len(input_names))
-        six.assertCountEqual(
+        self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
         self.assertEquals(len(spec.description.output), len(output_names))
-        six.assertCountEqual(
+        self.assertCountEqual(
             self, output_names, [x.name for x in spec.description.output]
         )
         layers = spec.neuralNetwork.layers
@@ -896,7 +895,7 @@ class KerasSingleLayerTest(unittest.TestCase):
 
         # Test the inputs and outputs
         self.assertEquals(len(spec.description.input), len(input_names))
-        six.assertCountEqual(
+        self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
         self.assertEquals(len(spec.description.output), len(expected_output_names))
@@ -928,7 +927,7 @@ class KerasSingleLayerTest(unittest.TestCase):
             spec.neuralNetworkClassifier.WhichOneof("ClassLabels"), "stringClassLabels"
         )
         class_from_proto = list(spec.neuralNetworkClassifier.stringClassLabels.vector)
-        six.assertCountEqual(self, classes, class_from_proto)
+        self.assertCountEqual(self, classes, class_from_proto)
 
     def test_classifier_file(self):
         from keras.layers import Dense
@@ -960,7 +959,7 @@ class KerasSingleLayerTest(unittest.TestCase):
 
         # Test the inputs and outputs
         self.assertEquals(len(spec.description.input), len(input_names))
-        six.assertCountEqual(
+        self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
         self.assertEquals(len(spec.description.output), len(expected_output_names))
@@ -1010,7 +1009,7 @@ class KerasSingleLayerTest(unittest.TestCase):
 
         # Test the inputs and outputs
         self.assertEquals(len(spec.description.input), len(input_names))
-        six.assertCountEqual(
+        self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
         self.assertEquals(len(spec.description.output), len(expected_output_names))
@@ -1042,7 +1041,7 @@ class KerasSingleLayerTest(unittest.TestCase):
             spec.neuralNetworkClassifier.WhichOneof("ClassLabels"), "int64ClassLabels"
         )
         class_from_proto = list(spec.neuralNetworkClassifier.int64ClassLabels.vector)
-        six.assertCountEqual(self, classes, class_from_proto)
+        self.assertCountEqual(self, classes, class_from_proto)
 
     def test_classifier_custom_class_name(self):
         from keras.layers import Dense
@@ -1073,7 +1072,7 @@ class KerasSingleLayerTest(unittest.TestCase):
 
         # Test the inputs and outputs
         self.assertEquals(len(spec.description.input), len(input_names))
-        six.assertCountEqual(
+        self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
         self.assertEquals(len(spec.description.output), len(expected_output_names))
@@ -1107,7 +1106,7 @@ class KerasSingleLayerTest(unittest.TestCase):
             spec.neuralNetworkClassifier.WhichOneof("ClassLabels"), "stringClassLabels"
         )
         class_from_proto = list(spec.neuralNetworkClassifier.stringClassLabels.vector)
-        six.assertCountEqual(self, classes, class_from_proto)
+        self.assertCountEqual(self, classes, class_from_proto)
 
     def test_default_interface_names(self):
         from keras.layers import Dense
@@ -1129,7 +1128,7 @@ class KerasSingleLayerTest(unittest.TestCase):
 
         # Test the inputs and outputs
         self.assertEquals(len(spec.description.input), len(expected_input_names))
-        six.assertCountEqual(
+        self.assertCountEqual(
             self, expected_input_names, [x.name for x in spec.description.input]
         )
         self.assertEquals(len(spec.description.output), len(expected_output_names))

--- a/coremltools/test/neural_network/test_numpy_nn_layers.py
+++ b/coremltools/test/neural_network/test_numpy_nn_layers.py
@@ -10,7 +10,6 @@ import unittest
 import uuid
 import pytest
 from packaging import version
-from six import string_types as _string_types
 
 import numpy as np
 from coremltools._deps import _HAS_TF, MSG_TF1_NOT_FOUND
@@ -120,7 +119,7 @@ class CorrectnessTest(unittest.TestCase):
         def get_moment(data, k):
             return np.mean(np.power(data - np.mean(data), k))
 
-        if isinstance(model, _string_types):
+        if isinstance(model, str):
             model = coremltools.models.MLModel(model)
 
         model = coremltools.models.MLModel(model, useCPUOnly=use_cpu_only)
@@ -157,7 +156,7 @@ class CorrectnessTest(unittest.TestCase):
 
         model_dir = None
         # if we're given a path to a model
-        if isinstance(model, _string_types):
+        if isinstance(model, str):
             model = coremltools.models.MLModel(model)
 
         # If we're passed in a specification, save out the model
@@ -4040,7 +4039,7 @@ class NewLayersSimpleTest(CorrectnessTest):
             inputs = {input_name: x}
 
             model = builder.spec
-            if isinstance(model, _string_types):
+            if isinstance(model, str):
                 model = coremltools.models.MLModel(model)
 
             model = coremltools.models.MLModel(model, useCPUOnly=True)
@@ -4134,7 +4133,7 @@ class NewLayersSimpleTest(CorrectnessTest):
             inputs = {input_name: np.reshape(probs, shape)}
 
             model = builder.spec
-            if isinstance(model, _string_types):
+            if isinstance(model, str):
                 model = coremltools.models.MLModel(model)
 
             model = coremltools.models.MLModel(model, useCPUOnly=True)

--- a/coremltools/test/sklearn_tests/test_feature_names.py
+++ b/coremltools/test/sklearn_tests/test_feature_names.py
@@ -23,9 +23,7 @@ class FeatureManagementTests(unittest.TestCase):
         self.assertTrue(fm.is_valid_feature_list(out))
 
     def test_single_array(self):
-        # test both int and long as input to num_dimensions
-        for t in [int]:
-            self.assertEquals(
-                fm.process_or_validate_features("a", num_dimensions=t(10)),
-                [("a", dt.Array(10))],
-            )
+        self.assertEquals(
+            fm.process_or_validate_features("a", num_dimensions=10),
+            [("a", dt.Array(10))],
+        )

--- a/coremltools/test/sklearn_tests/test_feature_names.py
+++ b/coremltools/test/sklearn_tests/test_feature_names.py
@@ -5,7 +5,6 @@
 
 import coremltools.models._feature_management as fm
 import coremltools.models.datatypes as dt
-import six
 import unittest
 from coremltools._deps import _HAS_SKLEARN
 
@@ -25,7 +24,7 @@ class FeatureManagementTests(unittest.TestCase):
 
     def test_single_array(self):
         # test both int and long as input to num_dimensions
-        for t in six.integer_types:
+        for t in [int]:
             self.assertEquals(
                 fm.process_or_validate_features("a", num_dimensions=t(10)),
                 [("a", dt.Array(10))],


### PR DESCRIPTION
This PR removes all six code except thoes under `deps`. Let's finally say goodbye to Python 2.7 in 2021.