### PR TITLE
Link in build badge to CI run

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://img.shields.io/gitlab/pipeline/zach_nation/coremltools/master)](#)
+[![Build Status](https://img.shields.io/gitlab/pipeline/zach_nation/coremltools/master)](https://gitlab.com/zach_nation/coremltools/-/pipelines?page=1&scope=branches&ref=master)
 [![PyPI Release](https://img.shields.io/pypi/v/coremltools.svg)](#)
 [![Python Versions](https://img.shields.io/pypi/pyversions/coremltools.svg)](#)
 


### PR DESCRIPTION
add link of the latest CI run on master, to the build badge in readme, for easy access