### PR TITLE
Docs: Clean up formatting errors in converter.mil.ops

### DIFF
--- a/coremltools/converters/_converters_entry.py
+++ b/coremltools/converters/_converters_entry.py
@@ -43,7 +43,7 @@ def convert(
     **kwargs
 ):
     """
-    Convert TensorFlow or Pytorch models to Core ML model format. Whether a
+    Convert TensorFlow or Pytorch models to the Core ML model format. Whether a
     parameter is required may differ between frameworks (see below). Note that
     this function is aliased as `ct.convert` in the tutorials.
 
@@ -51,96 +51,96 @@ def convert(
     ----------
     model:
         TensorFlow 1, TensorFlow 2 or Pytorch model in one of the following
-        format:
+        formats:
 
         For TensorFlow versions 1.x:
             - Frozen `tf.Graph <https://www.tensorflow.org/api_docs/python/tf/Graph>`_
-            - Frozen graph (`.pb`) file path
+            - Frozen graph (``.pb``) file path
             - `tf.keras.Model <https://www.tensorflow.org/api_docs/python/tf/keras>`_
-            -  `HDF5 <https://keras.io/api/models/model_saving_apis/>`_ file path (`.h5`)
+            -  `HDF5 <https://keras.io/api/models/model_saving_apis/>`_ file path (``.h5``)
             - `SavedModel <https://www.tensorflow.org/guide/saved_model>`_ directory path
         For TensorFlow versions 2.x:
             - `tf.keras.Model <https://www.tensorflow.org/api_docs/python/tf/keras>`_
-            - `HDF5 file path <https://keras.io/api/models/model_saving_apis/>`_ (`.h5`)
+            - `HDF5 file path <https://keras.io/api/models/model_saving_apis/>`_ (``.h5``)
             - `SavedModel <https://www.tensorflow.org/guide/saved_model>`_ directory path
             - A `concrete function <https://www.tensorflow.org/guide/concrete_function>`_
         For Pytorch:
             - A `TorchScript <https://pytorch.org/docs/stable/jit.html>`_ object
-            - Path to a `.pt` file
+            - Path to a ``.pt`` file
 
     source: str (optional)
-        One of [`auto`, `tensorflow`, `pytorch`, `mil`]. `auto` determines the
+        One of [``auto``, ``tensorflow``, ``pytorch``, ``mil``]. `auto` determines the
         framework automatically for most cases. Raise ValueError if it fails
         to determine the source framework.
 
     inputs: list of `TensorType` or `ImageType`
         TensorFlow 1 and 2:
-            - `inputs` are optional. If not provided, the inputs are
-              `Placeholder` nodes in the model (if model is frozen graph) or
+            - ``inputs`` are optional. If not provided, the inputs are
+              Placeholder nodes in the model (if model is frozen graph) or
               function inputs (if model is tf function)
-            - `inputs` must corresponds to all or some of the Placeholder
+            - ``inputs`` must corresponds to all or some of the Placeholder
               nodes in the TF model
-            - `TensorType` and `ImageType` in `inputs` must have `name`
-              specified. `shape` is optional.
-            - If `inputs` is provided, it must be a flat list.
+            - ``TensorType`` and ``ImageType`` in ``inputs`` must have ``name``
+              specified. ``shape`` is optional.
+            - If ``inputs`` is provided, it must be a flat list.
 
         PyTorch:
-            - `inputs` are required.
-            - `inputs` may be nested list or tuple.
-            - `TensorType` and `ImageType` in `inputs` must have `name`
-              and `shape` specified.
+            - ``inputs`` are required.
+            - ``inputs`` may be nested list or tuple.
+            - ``TensorType`` and ``ImageType`` in ``inputs`` must have ``name``
+              and ``shape`` specified.
 
     outputs: list[str] (optional)
 
         TensorFlow 1 and 2:
-            - `outputs` are optional.
+            - ``outputs`` are optional.
 
-            - If specified, `outputs` is a list of string representing node
+            - If specified, ``outputs`` is a list of string representing node
               names.
 
-            - If `outputs` are not specified, converter infers outputs as all
+            - If ``outputs`` are not specified, converter infers outputs as all
               terminal identity nodes.
 
         PyTorch:
-            - `outputs` must not be specified.
+            - ``outputs`` must not be specified.
 
     classifier_config: ClassifierConfig class (optional)
         The configuration if the mlmodel is intended to be a classifier.
 
     minimum_deployment_target: coremltools.target enumeration (optional)
-        - one of the members of enum "coremltools.target."
+        - one of the members of enum ``coremltools.target``.
         - When not-specified or None, converter aims for as minimum of a
           deployment target as possible
 
     convert_to: str (optional)
-        - Must be one of ['nn_proto', 'mil'].
-        - 'nn_proto': Returns MLModel containing a NeuralNetwork
+        - Must be one of [``'nn_proto'``, ``'mil'``].
+        - ``'nn_proto'``: Returns MLModel containing a NeuralNetwork
           proto
-        - 'mil': Returns MIL program object. MIL program is primarily used
+        - ``'mil'``: Returns MIL program object. MIL program is primarily used
           for debugging purpose and currently cannot be compiled to
           executable.
 
     Returns
     -------
-    model: `coremltools.models.MLModel` or
-    `coremltools.converters.mil.Program`
-        A Core ML MLModel object or MIL Program object (see `convert_to`)
+    model: `coremltools.models.MLModel` or `coremltools.converters.mil.Program`
+        A Core ML MLModel object or MIL Program object (see ``convert_to``)
 
     Examples
     --------
-    TensorFlow 1, 2 (`model` is a frozen graph):
+    TensorFlow 1, 2 (``model`` is a frozen graph):
 
         >>> with tf.Graph().as_default() as graph:
         >>>     x = tf.placeholder(tf.float32, shape=(1, 2, 3), name="input")
         >>>     y = tf.nn.relu(x, name="output")
-
+        
         # Automatically infer inputs and outputs
+        
         >>> mlmodel = ct.convert(graph)
 	    >>> test_input = np.random.rand(1, 2, 3) - 0.5
         >>> results = mlmodel.predict({"input": test_input})
         >>> print(results['output'])
 
-    TensorFlow 2 (`model` is tf.Keras model path):
+    TensorFlow 2 (``model`` is tf.Keras model path):
 
         >>> x = tf.keras.Input(shape=(32,), name='input')
         >>> y = tf.keras.layers.Dense(16, activation='softmax')(x)
@@ -165,8 +165,8 @@ def convert(
         >>> results = mlmodel.predict({"input": example_input.numpy()})
         >>> print(results['1651']) # 1651 is the node name given by PyTorch's JIT
 
-    See `here <https://coremltools.readme.io/docs/neural-network-conversion>`_ for
-    more advanced options
+    See `neural-network-conversion <https://coremltools.readme.io/docs/neural-network-conversion>`_ for
+    more advanced options.
     """
     _check_deployment_target(minimum_deployment_target)
     exact_source = _determine_source(model, source, outputs)

--- a/coremltools/converters/caffe/_caffe_converter.py
+++ b/coremltools/converters/caffe/_caffe_converter.py
@@ -26,7 +26,7 @@ def convert(
     model_precision=_MLMODEL_FULL_PRECISION,
 ):
     """
-    Convert a Caffe model to Core ML format.
+    Convert a Caffe model to the Core ML format.
 
     Parameters
     ----------
@@ -34,16 +34,17 @@ def convert(
 
         A trained Caffe neural network model which can be represented as:
 
-        - Path on disk to a trained Caffe model (.caffemodel)
-        - A tuple of two paths, where the first path is the path to the .caffemodel
-          file while the second is the path to the deploy.prototxt.
-        - A tuple of three paths, where the first path is the path to the
-          trained .caffemodel file, the second is the path to the
-          deploy.prototxt while the third is a path to the mean image binary, data in
+        - Path on disk to a trained Caffe model (``.caffemodel``).
+        - A tuple of two paths. The first path is the path to the ``.caffemodel``
+          file. The second is the path to the ``deploy.prototxt``.
+        - A tuple of three paths. The first path is the path to the
+          trained ``.caffemodel`` file. The second is the path to the
+          ``deploy.prototxt``. The third is a path to the mean image binary, data
           which is subtracted from the input image as a preprocessing step.
-        - A tuple of two paths to .caffemodel and .prototxt and a dict with image input names
-          as keys and paths to mean image binaryprotos as values. The keys should be same as
-          the input names provided via the argument 'image_input_name'.
+        - A tuple of two paths to ``.caffemodel`` and ``.prototxt`` and a ``dict`` with
+          image input names as keys and paths to mean image ``binaryprotos`` as values.
+          The keys should be the same as the input names provided via the argument
+          ``image_input_name``.
 
     image_input_names: [str] | str
         The name(s) of the input blob(s) in the Caffe model that can be treated
@@ -54,60 +55,65 @@ def convert(
         Flag indicating the channel order the model internally uses to represent
         color images. Set to True if the internal channel order is BGR,
         otherwise it will be assumed RGB. This flag is applicable only if
-        image_input_names is specified. To specify a different value for each
+        ``image_input_names`` is specified. To specify a different value for each
         image input, provide a dictionary with input names as keys.
         Note that this flag is about the models internal channel order.
         An input image can be passed to the model in any color pixel layout
-        containing red, green and blue values (e.g. 32BGRA or 32ARGB). This flag
+        containing red, green and blue values (e.g. ``32BGRA`` or ``32ARGB``). This flag
         determines how those pixel values get mapped to the internal multiarray
         representation.
 
     red_bias: float | dict()
-        Bias value to be added to the red channel of the input image.
-        Defaults to 0.0.
-        Applicable only if image_input_names is specified.
-        To specify different values for each image input provide a dictionary with input names as keys.
+        Bias value to be added to the red channel of the input image. Defaults to ``0.0``.
+        Applicable only if ``image_input_names`` is specified. To specify different
+        values for each image input, provide a dictionary with input names as keys.
 
     blue_bias: float | dict()
         Bias value to be added to the the blue channel of the input image.
-        Defaults to 0.0.
-        Applicable only if image_input_names is specified.
-        To specify different values for each image input provide a dictionary with input names as keys.
+        Defaults to ``0.0``.
+        Applicable only if ``image_input_names`` is specified.
+        To specify different values for each image input, provide a dictionary
+        with input names as keys.
 
     green_bias: float | dict()
         Bias value to be added to the green channel of the input image.
-        Defaults to 0.0.
-        Applicable only if image_input_names is specified.
-        To specify different values for each image input provide a dictionary with input names as keys.
+        Defaults to ``0.0``.
+        Applicable only if ``image_input_names`` is specified.
+        To specify different values for each image input provide a dictionary
+        with input names as keys.
 
     gray_bias: float | dict()
-        Bias value to be added to the input image (in grayscale). Defaults to 0.0.
-        Applicable only if image_input_names is specified.
-        To specify different values for each image input provide a dictionary with input names as keys.
+        Bias value to be added to the input image (in grayscale). Defaults to ``0.0``.
+        Applicable only if ``image_input_names`` is specified.
+        To specify different values for each image input provide a dictionary
+        with input names as keys.
 
     image_scale: float | dict()
         Value by which the input images will be scaled before bias is added and
-        Core ML model makes a prediction. Defaults to 1.0.
-        Applicable only if image_input_names is specified.
-        To specify different values for each image input provide a dictionary with input names as keys.
+        Core ML model makes a prediction. Defaults to ``1.0``.
+        Applicable only if ``image_input_names`` is specified.
+        To specify different values for each image input provide a dictionary
+        with input names as keys.
 
     class_labels: str
         Filepath where classes are parsed as a list of newline separated
-        strings. Class labels map the index of the output of a neural network to labels in a classifier.
-        Provide this argument to get a model of type classifier.
+        strings. Class labels map the index of the output of a neural network
+        to labels in a classifier. Provide this argument to get a model of
+        type classifier.
 
     predicted_feature_name: str
         Name of the output feature for the class labels exposed in the Core ML
-        model (applies to classifiers only). Defaults to 'classLabel'
+        model (applies to classifiers only). Defaults to ``classLabel``.
 
     model_precision: str
-        Precision at which model will be saved. Currently full precision (float) and half precision
-        (float16) models are supported. Defaults to '_MLMODEL_FULL_PRECISION' (full precision).
+        Precision at which model will be saved. Currently full precision
+        (float) and half precision (float16) models are supported. Defaults to
+        ``_MLMODEL_FULL_PRECISION`` (full precision).
 
     Returns
     -------
     model: MLModel
-        Model in Core ML format.
+        Model in the Core ML format.
 
     Examples
     --------
@@ -119,16 +125,18 @@ def convert(
 
 		# Saving the Core ML model to a file.
 		>>> coreml_model.save('my_model.mlmodel')
-
+		
+        
     Sometimes, critical information in the Caffe converter is missing from the
-    .caffemodel file. This information is present in the deploy.prototxt file.
+    ``.caffemodel`` file. This information is present in the ``deploy.prototxt`` file.
     You can provide us with both files in the conversion process.
 
     .. sourcecode:: python
 
 		>>> coreml_model = coremltools.converters.caffe.convert(('my_caffe_model.caffemodel', 'my_deploy.prototxt'))
-
-    Some models (like Resnet-50) also require a mean image file which is
+        
+        
+    Some models (such as Resnet-50) also require a mean image file, which is
     subtracted from the input image before passing through the network. This
     file can also be provided during conversion:
 
@@ -148,18 +156,20 @@ def convert(
         ...                     green_bias = {'image1': -90, 'image2': -125},
         ...                     blue_bias = {'image1': -105, 'image2': -120},
         ...                     image_input_names = ['image1', 'image2'])
+        
+        
+    Input and output names used in the interface of the converted Core ML
+    model are inferred from the ``.prototxt`` file, which contains a
+    description of the network architecture. Input names are read from the
+    input layer definition in the ``.prototxt``. By default, they are of type
+    MultiArray. Argument ``"image_input_names"`` can be used to assign image
+    type to specific inputs. All the blobs that are "dangling" -- which do not
+    feed as input to any other layer -- are taken as outputs. The
+    ``.prototxt`` file can be modified to specify custom input and output
+    names.
 
-
-
-    Input and output names used in the interface of the converted Core ML model are inferred from the .prototxt file,
-    which contains a description of the network architecture.
-    Input names are read from the input layer definition in the .prototxt. By default, they are of type MultiArray.
-    Argument "image_input_names" can be used to assign image type to specific inputs.
-    All the blobs that are "dangling", i.e.
-    which do not feed as input to any other layer are taken as outputs. The .prototxt file can be modified to specify
-    custom input and output names.
-
-    The converted Core ML model is of type classifier when the argument "class_labels" is specified.
+    The converted Core ML model is of type classifier when the argument
+    ``"class_labels"`` is specified.
 
     Advanced usage with custom classifiers, and images:
 
@@ -172,11 +182,13 @@ def convert(
 		# Export as a classifier with classes from a file
 		>>> coreml_model = coremltools.converters.caffe.convert(('my_caffe_model.caffemodel', 'my_caffe_model.prototxt'),
 		...         image_input_names = 'my_image_input', class_labels = 'labels.txt')
-
-
-    Sometimes the converter might return a message about not able to infer input data dimensions.
-    This happens when the input size information is absent from the deploy.prototxt file. This can be easily provided by editing
-    the .prototxt in a text editor. Simply add a snippet in the beginning, similar to the following, for each of the inputs to the model:
+		
+		
+    Sometimes the converter might return a message about not able to infer
+    input data dimensions. This happens when the input size information is
+    absent from the ``deploy.prototxt`` file. This can be easily provided by
+    editing the ``.prototxt`` in a text editor. Simply add a snippet in the
+    beginning, similar to the following, for each of the inputs to the model:
 
     .. code-block:: bash
 
@@ -185,9 +197,13 @@ def convert(
         input_dim: 3
         input_dim: 227
         input_dim: 227
-
-    Here we have specified an input with dimensions (1,3,227,227), using Caffe's convention, in the order (batch, channel, height, width).
-    Input name string ("my_image_input") must also match the name of the input (or "bottom", as inputs are known in Caffe) of the first layer in the .prototxt.
+        
+        
+    In this example we have specified an input with dimensions ``(1,3,227,227)``, using
+    Caffe's convention, in the order (batch, channel, height, width). Input
+    name string (``"my_image_input"``) must also match the name of the input (or
+    "bottom", as inputs are known in Caffe) of the first layer in the
+    ``.prototxt``.
 
     """
     from ...models import MLModel

--- a/coremltools/converters/mil/mil/ops/defs/activation.py
+++ b/coremltools/converters/mil/mil/ops/defs/activation.py
@@ -17,13 +17,13 @@ class clamped_relu(Operation):
 
     Parameters
     ----------
-    x: tensor<*?, T> (Required)
+    x: tensor<\*?, T> (Required)
     alpha: const fp32 (Required)
     beta: const fp32 (Required)
 
     Returns
     -------
-    tensor<*?, T>
+    tensor<\*?, T>
         * A tensor of the same type and shape as ``x``.
 
     Attributes
@@ -57,13 +57,13 @@ class elu(Operation):
 
     Parameters
     ----------
-    x: tensor<*?, T> (Required)
+    x: tensor<\*?, T> (Required)
     alpha: const fp32 (Optional)
         * Default is ``1``.
 
     Returns
     -------
-    tensor<*?, T>
+    tensor<\*?, T>
         * A tensor of the same shape and type as ``x``.
 
     Attributes
@@ -114,7 +114,7 @@ class gelu(Operation):
     
     Parameters
     ----------
-    x: tensor<*?, T> (Required)
+    x: tensor<\*?, T> (Required)
     
     mode: const str (Optional)
         * Use ``'EXACT'``, ``'TANH_APPROXIMATION'``, or ``'SIGMOID_APPROXIMATION'`` for ``str``.
@@ -122,7 +122,7 @@ class gelu(Operation):
 
     Returns
     -------
-    tensor<*?, T>
+    tensor<\*?, T>
         * A tensor of the same shape and type as ``x``.
 
     Attributes
@@ -168,7 +168,7 @@ class leaky_relu(Operation):
 
     Returns
     -------
-    tensor<*?, fp32>
+    tensor<\*?, fp32>
         * A tensor of the same shape and type as ``x``.
 
     Attributes
@@ -200,14 +200,14 @@ class linear_activation(Operation):
 
     Parameters
     ----------
-    x: tensor<*?, T> (Required)
+    x: tensor<\*?, T> (Required)
     alpha: const fp32 (Required)
     beta: const fp32 (Optional)
         * Default is ``0``.
 
     Returns
     -------
-    tensor<*?, T>
+    tensor<\*?, T>
         * A tensor of the same shape and type as ``x``.
 
     Attributes
@@ -286,11 +286,11 @@ class relu(elementwise_unary):
 
     Parameters
     ----------
-    x: tensor<*?, fp32> (Required)
+    x: tensor<\*?, fp32> (Required)
 
     Returns
     -------
-    tensor<*?, fp32>
+    tensor<\*?, fp32>
         * A tensor of the same shape and type as ``x``.
 
     Attributes
@@ -313,11 +313,11 @@ class relu6(elementwise_unary):
 
     Parameters
     ----------
-    x: tensor<*?, T> (Required)
+    x: tensor<\*?, T> (Required)
 
     Returns
     -------
-    tensor<*?, T>
+    tensor<\*?, T>
         * A tensor of the same shape and type as ``x``.
 
     Attributes
@@ -340,7 +340,7 @@ class scaled_tanh(Operation):
 
     Parameters
     ----------
-    x: tensor<*?, T> (Required)
+    x: tensor<\*?, T> (Required)
         * Input range is ``(-inf, inf)``.
     alpha: const fp32 (Optional)
         * Default is ``1``.
@@ -349,7 +349,7 @@ class scaled_tanh(Operation):
 
     Returns
     -------
-    tensor<*?, fp32>
+    tensor<\*?, fp32>
         * A tensor of the same shape and type as ``x``.
 
     Attributes
@@ -381,11 +381,11 @@ class sigmoid(elementwise_unary):
 
     Parameters
     ----------
-    x: tensor<*?, T> (Required)
+    x: tensor<\*?, T> (Required)
 
     Returns
     -------
-    tensor<*?, T>
+    tensor<\*?, T>
         * A tensor of the same shape as ``x``.
 
     Attributes
@@ -408,7 +408,7 @@ class sigmoid_hard(Operation):
 
     Parameters
     ----------
-    x: tensor<*?, T> (Required)
+    x: tensor<\*?, T> (Required)
     alpha: const fp32 (Optional)
         * Default is ``0.2``.
     beta: const fp32 (Optional)
@@ -416,7 +416,7 @@ class sigmoid_hard(Operation):
 
     Returns
     -------
-    tensor<*?, fp32>
+    tensor<\*?, fp32>
         * A tensor of the same shape and type as ``x``.
 
     Attributes
@@ -450,11 +450,11 @@ class softplus(elementwise_unary):
 
     Parameters
     ----------
-    x: tensor<*?, T> (Required)
+    x: tensor<\*?, T> (Required)
 
     Returns
     -------
-    tensor<*?, T>
+    tensor<\*?, T>
         * A tensor of the same shape and type as ``x``.
 
     Attributes
@@ -536,13 +536,13 @@ class softmax(Operation):
 
     Parameters
     ----------
-    x: tensor<*?, T> (Required)
+    x: tensor<\*?, T> (Required)
     axis: const i32 (Optional)
         * Default is ``-1``.
 
     Returns
     -------
-    tensor<*?, fp32>
+    tensor<\*?, fp32>
         * A tensor of the same shape and type as ``x``.
 
     Attributes
@@ -574,11 +574,11 @@ class softsign(elementwise_unary):
 
     Parameters
     ----------
-    x: tensor<*?, T> (Required)
+    x: tensor<\*?, T> (Required)
 
     Returns
     -------
-    tensor<*?, T>
+    tensor<\*?, T>
         * A tensor of the same shape and type as ``x``.
     """
 
@@ -597,13 +597,13 @@ class thresholded_relu(Operation):
 
     Parameters
     ----------
-    x: tensor<*?, T> (Required)
+    x: tensor<\*?, T> (Required)
     alpha: const fp32 (Optional)
         * Default is ``1``.
 
     Returns
     -------
-    tensor<*, T>
+    tensor<\*, T>
         * A tensor of the same shape and type as ``x``.
     """
 

--- a/coremltools/converters/mil/mil/ops/defs/control_flow.py
+++ b/coremltools/converters/mil/mil/ops/defs/control_flow.py
@@ -112,11 +112,11 @@ class const(Operation):
         * For  large constants such as convolution weights, use ``file_value``.
         * For smaller-size constants such as values of a stride, use ``immediate_value``.
     
-    val: const<*,T> (Required)
+    val: const<\*,T> (Required)
     
     Returns
     -------
-    const<*,T>
+    const<\*,T>
     
     Attributes
     ----------
@@ -204,25 +204,26 @@ class select(Operation):
     
     Parameters
     ----------
-    cond: tensor<[*D1], T> (Required)
+    cond: tensor<[\*D1], T> (Required)
         * Tensor. When ``True`` (non-zero), select element from ``x``, otherwise, ``y``.
     
-    a: tensor<[*D2], T> (Optional)
+    a: tensor<[\*D2], T> (Optional)
         * Values selected at indices where ``cond`` is ``True``.
         * Default is ``None``.
     
-    b: tensor<[*D3], T> (Optional)
+    b: tensor<[\*D3], T> (Optional)
         * Values selected at indices where ``cond`` is ``False``.
         * Default is ``None``.
     
     Returns
     -------
-    tensor<[*D_out], T> or tensor<[n, len(D1)], int32>
+    tensor<[\*D_out], T> or tensor<[n, len(D1)], int32>
         *  If ``a, b`` are both provided, the return shape is based on broadcast rules
            from ``cond, a, b``.
         *  If ``a, b`` are ``None``, the return shape is 2-D, where the first dimension
            ``n`` is the number of matching indices in ``cond``, and ``len(D1)`` is the
            rank of ``cond``.
+    
     Attributes
     ----------
     T: fp32
@@ -608,14 +609,14 @@ class list_read(Operation):
     
     Parameters
     ----------
-    ls: List[*] (Required)
+    ls: List[\*] (Required)
     
     index: <i32> (Required)
         * Size of the list.
     
     Returns
     -------
-    <*,T>
+    <\*,T>
         * The element's value.
     
     Attributes
@@ -646,14 +647,14 @@ class list_gather(Operation):
     
     Parameters
     ----------
-    ls: List[*] (Required)
+    ls: List[\*] (Required)
     
     indices: <K,i32> (Required)
         * Gather from indices, whose element must be in ``[0, ls.length)`` at runtime.
     
     Returns
     -------
-    <*K,T>
+    <\*K,T>
         * Selected tensors packed into a ``len(ls.elem_shape)+1`` rank tensor.
         * ``K[0] == len(indices)``.
     

--- a/coremltools/converters/mil/mil/ops/defs/conv.py
+++ b/coremltools/converters/mil/mil/ops/defs/conv.py
@@ -15,7 +15,7 @@ class conv(Operation):
     
     Parameters
     ----------
-    x: tensor<[n, C_in, *d_in], T> (Required)
+    x: tensor<[n, C_in, \*d_in], T> (Required)
     
         * ``d_in`` are (possibly runtime-determined) spatial dimensions. For example,
           ``d_in = [224, 224]`` for 2D convolution.
@@ -23,7 +23,7 @@ class conv(Operation):
         * ``C_in`` is the number of input channels or depth dimensions.
         * ``n``  is the batch dimension.
     
-    weight: tensor<[C_out, C_in/groups, *K], T> (Required)
+    weight: tensor<[C_out, C_in/groups, \*K], T> (Required)
     
         * Filter weights.
         * ``C_in`` is the number of input channels.
@@ -98,7 +98,7 @@ class conv(Operation):
     
     Returns
     -------
-    tensor<[n, C_out, *d_out], T>
+    tensor<[n, C_out, \*d_out], T>
         * Output activation has the same rank and spatial dimension as the input.
           That is, ``len(d_out) == len(d_in)``.
         * For ``i=0,..,len(d_in)-1, d_out[i] = floor [(D_in[i] + pad[2*i] +

--- a/coremltools/converters/mil/mil/ops/defs/elementwise_binary.py
+++ b/coremltools/converters/mil/mil/ops/defs/elementwise_binary.py
@@ -82,15 +82,15 @@ class add(elementwise_binary):
     
     Parameters
     ----------
-    x: <*,T> (Required)
+    x: <\*,T> (Required)
         * Shape must be compatible with ``y`` in broadcast.
     
-    y: <*,T> (Required)
+    y: <\*,T> (Required)
         * Shape must be compatible with ``x`` in broadcast.
     
     Returns
     -------
-    <*,T>
+    <\*,T>
     
     Attributes
     ----------
@@ -113,15 +113,15 @@ class equal(elementwise_binary):
     
     Parameters
     ----------
-    x: <*,T> (Required)
+    x: <\*,T> (Required)
         * Shape must be compatible with ``y`` in broadcast.
     
-    y: <*,T> (Required)
+    y: <\*,T> (Required)
         * Shape must be compatible with ``x`` in broadcast.
     
     Returns
     -------
-    <*, bool>
+    <\*, bool>
         * A boolean tensor with the same shape as the inputs.
     
     Attributes
@@ -148,15 +148,15 @@ class floor_div(elementwise_binary):
     
     Parameters
     ----------
-    x: tensor<*, T> (Required)
+    x: tensor<\*, T> (Required)
         * Shape must be compatible with ``y`` in broadcast.
     
-    y: tensor<*, T> (Required)
+    y: tensor<\*, T> (Required)
         * Shape must be compatible with ``x`` in broadcast.
     
     Returns
     -------
-    tensor<*, T>
+    tensor<\*, T>
         * A tensor of the same type and shape as the inputs.
     
     Attributes
@@ -180,15 +180,15 @@ class greater(elementwise_binary):
 
     Parameters
     ----------
-    x: tensor<*, T> (Required)
+    x: tensor<\*, T> (Required)
         * Shape must be compatible with ``y`` in broadcast.
     
-    y: tensor<*, T> (Required)
+    y: tensor<\*, T> (Required)
         * Shape must be compatible with ``x`` in broadcast.
     
     Returns
     -------
-    tensor<*, bool>
+    tensor<\*, bool>
         * A boolean tensor with the same shape as the inputs.
 
     Attributes
@@ -215,15 +215,15 @@ class greater_equal(elementwise_binary):
     
     Parameters
     ----------
-    x: tensor<*, T> (Required)
+    x: tensor<\*, T> (Required)
         * Shape must be compatible with ``y`` in broadcast.
     
-    y: tensor<*, T> (Required)
+    y: tensor<\*, T> (Required)
         * Shape must be compatible with ``x`` in broadcast.
     
     Returns
     -------
-    tensor<*?, bool>
+    tensor<\*?, bool>
         * A boolean tensor with the same shape as the inputs.
     
     Attributes
@@ -250,15 +250,15 @@ class less(elementwise_binary):
     
     Parameters
     ----------
-    x: tensor<*, T> (Required)
+    x: tensor<\*, T> (Required)
         * Shape must be compatible with ``y`` in broadcast.
     
-    y: tensor<*, T> (Required)
+    y: tensor<\*, T> (Required)
         * Shape must be compatible with ``x`` in broadcast.
     
     Returns
     -------
-    tensor<*?, bool>
+    tensor<\*?, bool>
         * A boolean tensor with the same shape as the inputs.
     
     Attributes
@@ -285,15 +285,15 @@ class less_equal(elementwise_binary):
     
     Parameters
     ----------
-    x: tensor<*, T> (Required)
+    x: tensor<\*, T> (Required)
         * Shape must be compatible with ``y`` in broadcast.
     
-    y: tensor<*, T> (Required)
+    y: tensor<\*, T> (Required)
         * Shape must be compatible with ``x`` in broadcast.
     
     Returns
     -------
-    tensor<*?, bool>
+    tensor<\*?, bool>
         * A boolean tensor with the same shape as the inputs.
     
     Attributes
@@ -321,15 +321,15 @@ class logical_and(elementwise_binary):
 
     Parameters
     ----------
-    x: tensor<*, T> (Required)
+    x: tensor<\*, T> (Required)
         * Shape must be compatible with ``y`` in broadcast.
     
-    y: tensor<*, T> (Required)
+    y: tensor<\*, T> (Required)
         * Shape must be compatible with ``x`` in broadcast.
     
     Returns
     -------
-    tensor<*?, bool>
+    tensor<\*?, bool>
         * A boolean tensor with the same shape as the inputs.
     
     Attributes
@@ -358,15 +358,15 @@ class logical_or(elementwise_binary):
     
     Parameters
     ----------
-    x: tensor<*, T> (Required)
+    x: tensor<\*, T> (Required)
         * Shape must be compatible with ``y`` in broadcast.
     
-    y: tensor<*, T> (Required)
+    y: tensor<\*, T> (Required)
         * Shape must be compatible with ``x`` in broadcast.
     
     Returns
     -------
-    tensor<*?, bool>
+    tensor<\*?, bool>
         * A boolean tensor with the same shape as the inputs.
     
     Attributes
@@ -395,15 +395,15 @@ class logical_xor(elementwise_binary):
     
     Parameters
     ----------
-    x: tensor<*, T> (Required)
+    x: tensor<\*, T> (Required)
         * Shape must be compatible with ``y`` in broadcast.
     
-    y: tensor<*, T> (Required)
+    y: tensor<\*, T> (Required)
         * Shape must be compatible with ``x`` in broadcast.
     
     Returns
     -------
-    tensor<*?, bool>
+    tensor<\*?, bool>
         * A boolean tensor with the same shape as the inputs.
     
     Attributes
@@ -430,15 +430,15 @@ class maximum(elementwise_binary):
     
     Parameters
     ----------
-    x: tensor<*, T> (Required)
+    x: tensor<\*, T> (Required)
         * Shape must be compatible with ``y`` in broadcast.
     
-    y: tensor<*, T> (Required)
+    y: tensor<\*, T> (Required)
         * Shape must be compatible with ``x`` in broadcast.
     
     Returns
     -------
-    tensor<*?, bool>
+    tensor<\*?, bool>
         * A boolean tensor with the same shape as the inputs.
     
     Attributes
@@ -461,15 +461,15 @@ class minimum(elementwise_binary):
     
     Parameters
     ----------
-    x: tensor<*, T> (Required)
+    x: tensor<\*, T> (Required)
         * Shape must be compatible with ``y`` in broadcast.
     
-    y: tensor<*, T> (Required)
+    y: tensor<\*, T> (Required)
         * Shape must be compatible with ``x`` in broadcast.
     
     Returns
     -------
-    tensor<*?, bool>
+    tensor<\*?, bool>
         * A boolean tensor with the same shape as the inputs.
     
     Attributes
@@ -492,15 +492,15 @@ class mod(elementwise_binary):
 
     Parameters
     ----------
-    x: tensor<*, T> (Required)
+    x: tensor<\*, T> (Required)
         * Shape must be compatible with ``y`` in broadcast.
     
-    y: tensor<*, T> (Required)
+    y: tensor<\*, T> (Required)
         * Shape must be compatible with ``x`` in broadcast.
     
     Returns
     -------
-    tensor<*?, bool>
+    tensor<\*?, bool>
         * A boolean tensor with the same shape as the inputs.
     
     Attributes
@@ -523,15 +523,15 @@ class mul(elementwise_binary):
 
     Parameters
     ----------
-    x: tensor<*, T> (Required)
+    x: tensor<\*, T> (Required)
         * Shape must be compatible with ``y`` in broadcast.
     
-    y: tensor<*, T> (Required)
+    y: tensor<\*, T> (Required)
         * Shape must be compatible with ``x`` in broadcast.
     
     Returns
     -------
-    tensor<*?, bool>
+    tensor<\*?, bool>
         * A boolean tensor with the same shape as the inputs.
     
     Attributes
@@ -555,15 +555,15 @@ class not_equal(elementwise_binary):
     
     Parameters
     ----------
-    x: tensor<*, T> (Required)
+    x: tensor<\*, T> (Required)
         * Shape must be compatible with ``y`` in broadcast.
     
-    y: tensor<*, T> (Required)
+    y: tensor<\*, T> (Required)
         * Shape must be compatible with ``x`` in broadcast.
     
     Returns
     -------
-    tensor<*?, bool>
+    tensor<\*?, bool>
         * A boolean tensor with the same shape as the inputs.
 
     Attributes
@@ -589,15 +589,15 @@ class real_div(elementwise_binary):
 
     Parameters
     ----------
-    x: tensor<*, T> (Required)
+    x: tensor<\*, T> (Required)
         * Shape must be compatible with ``y`` in broadcast.
     
-    y: tensor<*, T> (Required)
+    y: tensor<\*, T> (Required)
         * Shape must be compatible with ``x`` in broadcast.
     
     Returns
     -------
-    tensor<*?, bool>
+    tensor<\*?, bool>
         * A boolean tensor with the same shape as the inputs.
     
     Attributes
@@ -623,15 +623,15 @@ class pow(elementwise_binary):
 
     Parameters
     ----------
-    x: tensor<*, T> (Required)
+    x: tensor<\*, T> (Required)
         * Shape must be compatible with ``y`` in broadcast.
     
-    y: tensor<*, T> (Required)
+    y: tensor<\*, T> (Required)
         * Shape must be compatible with ``x`` in broadcast.
     
     Returns
     -------
-    tensor<*?, bool>
+    tensor<\*?, bool>
         * A boolean tensor with the same shape as the inputs.
     
     Attributes
@@ -654,15 +654,15 @@ class sub(elementwise_binary):
 
     Parameters
     ----------
-    x: tensor<*, T> (Required)
+    x: tensor<\*, T> (Required)
         * Shape must be compatible with ``y`` in broadcast.
     
-    y: tensor<*, T> (Required)
+    y: tensor<\*, T> (Required)
         * Shape must be compatible with ``x`` in broadcast.
     
     Returns
     -------
-    tensor<*?, bool>
+    tensor<\*?, bool>
         * A boolean tensor with the same shape as the inputs.
     
     Attributes

--- a/coremltools/converters/mil/mil/ops/defs/elementwise_unary.py
+++ b/coremltools/converters/mil/mil/ops/defs/elementwise_unary.py
@@ -33,11 +33,11 @@ class abs(elementwise_unary):
     
     Parameters
     ----------
-    x: tensor<[*d], T> (Required)
+    x: tensor<[\*d], T> (Required)
     
     Returns
     -------
-    tensor<[*d], f32>
+    tensor<[\*d], f32>
         * A tensor of the same shape as ``x``.
     
     Attributes
@@ -60,11 +60,11 @@ class acos(elementwise_unary):
     
     Parameters
     ----------
-    x: tensor<[*d], T> (Required)
+    x: tensor<[\*d], T> (Required)
     
     Returns
     -------
-    tensor<[*d], f32>
+    tensor<[\*d], f32>
         * A tensor of the same shape as ``x``.
     
     Attributes
@@ -87,11 +87,11 @@ class asin(elementwise_unary):
     
     Parameters
     ----------
-    x: tensor<[*d], T> (Required)
+    x: tensor<[\*d], T> (Required)
     
     Returns
     -------
-    tensor<[*d], f32>
+    tensor<[\*d], f32>
         * A tensor of the same shape as ``x``.
     
     Attributes
@@ -114,11 +114,11 @@ class atan(elementwise_unary):
     
     Parameters
     ----------
-    x: tensor<[*d], T> (Required)
+    x: tensor<[\*d], T> (Required)
     
     Returns
     -------
-    tensor<[*d], f32>
+    tensor<[\*d], f32>
         * A tensor of the same shape as ``x``.
     
     Attributes
@@ -142,11 +142,11 @@ class atanh(elementwise_unary):
     
     Parameters
     ----------
-    x: tensor<[*d], T> (Required)
+    x: tensor<[\*d], T> (Required)
     
     Returns
     -------
-    tensor<[*d], f32>
+    tensor<[\*d], f32>
         * A tensor of the same shape as ``x``.
     
     Attributes
@@ -169,11 +169,11 @@ class ceil(elementwise_unary):
     
     Parameters
     ----------
-    x: tensor<[*d], T> (Required)
+    x: tensor<[\*d], T> (Required)
     
     Returns
     -------
-    tensor<[*d], f32>
+    tensor<[\*d], f32>
         * A tensor of the same shape as ``x``.
     
     Attributes
@@ -198,13 +198,13 @@ class clip(Operation):
     
     Parameters
     ----------
-    x: tensor<[*d], T> (Required)
+    x: tensor<[\*d], T> (Required)
     alpha: const f32 (Required)
     beta: const f32 (Required)
     
     Returns
     -------
-    tensor<[*d], f32>
+    tensor<[\*d], f32>
         * A tensor of the same shape as ``x``.
     
     Attributes
@@ -237,11 +237,11 @@ class cos(elementwise_unary):
     
     Parameters
     ----------
-    x: tensor<[*d], T> (Required)
+    x: tensor<[\*d], T> (Required)
     
     Returns
     -------
-    tensor<[*d], T>
+    tensor<[\*d], T>
     
     Attributes
     ----------
@@ -263,11 +263,11 @@ class cosh(elementwise_unary):
     
     Parameters
     ----------
-    x: tensor<[*d], T> (Required)
+    x: tensor<[\*d], T> (Required)
     
     Returns
     -------
-    tensor<[*d], T>
+    tensor<[\*d], T>
         * A tensor of the same shape as ``x``.
     
     Attributes
@@ -290,11 +290,11 @@ class erf(elementwise_unary):
     
     Parameters
     ----------
-    x: tensor<[*d], T> (Required)
+    x: tensor<[\*d], T> (Required)
     
     Returns
     -------
-    tensor<[*d], f32>
+    tensor<[\*d], f32>
         * A tensor of the same shape as ``x``.
     
     Attributes
@@ -317,11 +317,11 @@ class exp(elementwise_unary):
     
     Parameters
     ----------
-    x: tensor<[*d], T> (Required)
+    x: tensor<[\*d], T> (Required)
     
     Returns
     -------
-    tensor<[*d], f32>
+    tensor<[\*d], f32>
         * A tensor of the same shape as ``x``.
     
     Attributes
@@ -344,11 +344,11 @@ class exp2(elementwise_unary):
     
     Parameters
     ----------
-    x: tensor<[*d], T> (Required)
+    x: tensor<[\*d], T> (Required)
     
     Returns
     -------
-    tensor<[*d], f32>
+    tensor<[\*d], f32>
         * A tensor of the same shape as ``x``.
     
     Attributes
@@ -372,11 +372,11 @@ class floor(elementwise_unary):
     
     Parameters
     ----------
-    x: tensor<[*d], T> (Required)
+    x: tensor<[\*d], T> (Required)
     
     Returns
     -------
-    tensor<[*d], f32>
+    tensor<[\*d], f32>
         * A tensor of the same shape as ``x``.
     
     Attributes
@@ -399,7 +399,7 @@ class inverse(Operation):
     
     Parameters
     ----------
-    x: tensor<[*d], T> (Required)
+    x: tensor<[\*d], T> (Required)
     epsilon: const fp32 (Optional, default=1e-4)
         * This is a small constant that is added to the input, before taking its
           inverse, for stability.
@@ -407,7 +407,7 @@ class inverse(Operation):
     
     Returns
     -------
-    tensor<[*d], f32>
+    tensor<[\*d], f32>
         * A tensor of the same shape as ``x``.
     
     Attributes
@@ -438,14 +438,14 @@ class log(Operation):
     
     Parameters
     ----------
-    x: tensor<[*d], T> (Required)
+    x: tensor<[\*d], T> (Required)
     epsilon: const fp32 (Optional, default=1e-45)
         * This is a small constant that is added to the input, before taking log.
         * ``y = log(x + epsilon)``.
     
     Returns
     -------
-    tensor<[*d], f32>
+    tensor<[\*d], f32>
         * A tensor of the same shape as ``x``.
     
     Attributes
@@ -478,11 +478,11 @@ class logical_not(elementwise_unary):
     
     Parameters
     ----------
-    x: tensor<[*d], T> (Required)
+    x: tensor<[\*d], T> (Required)
     
     Returns
     -------
-    tensor<[*d], f32>
+    tensor<[\*d], f32>
         * A tensor of the same shape as ``x``.
     
     Attributes
@@ -505,11 +505,11 @@ class round(elementwise_unary):
     
     Parameters
     ----------
-    x: tensor<[*d], T> (Required)
+    x: tensor<[\*d], T> (Required)
     
     Returns
     -------
-    tensor<[*d], f32>
+    tensor<[\*d], f32>
         * A tensor of the same shape as ``x``.
     
     Attributes
@@ -532,7 +532,7 @@ class rsqrt(Operation):
     
     Parameters
     ----------
-    x: tensor<[*d], T> (Required)
+    x: tensor<[\*d], T> (Required)
     epsilon: const fp32 (Optional, default=1e-12)
         * This is a small constant that is added to the input, before applying the
           ``rsqrt`` function, for stability.
@@ -540,7 +540,7 @@ class rsqrt(Operation):
     
     Returns
     -------
-    tensor<[*d], f32>
+    tensor<[\*d], f32>
         * A tensor of the same shape as ``x``.
     
     Attributes
@@ -571,11 +571,11 @@ class sign(elementwise_unary):
     
     Parameters
     ----------
-    x: tensor<[*d], T> (Required)
+    x: tensor<[\*d], T> (Required)
     
     Returns
     -------
-    tensor<[*d], f32>
+    tensor<[\*d], f32>
         * A tensor of the same shape as ``x``.
     
     Attributes
@@ -598,11 +598,11 @@ class sin(elementwise_unary):
     
     Parameters
     ----------
-    x: tensor<[*d], T> (Required)
+    x: tensor<[\*d], T> (Required)
     
     Returns
     -------
-    tensor<[*d], f32>
+    tensor<[\*d], f32>
         * A tensor of the same shape as ``x``.
     
     Attributes
@@ -625,11 +625,11 @@ class sinh(elementwise_unary):
     
     Parameters
     ----------
-    x: tensor<[*d], T> (Required)
+    x: tensor<[\*d], T> (Required)
     
     Returns
     -------
-    tensor<[*d], f32>
+    tensor<[\*d], f32>
         * A tensor of the same shape as ``x``.
     
     Attributes
@@ -652,11 +652,11 @@ class sqrt(elementwise_unary):
     
     Parameters
     ----------
-    x: tensor<[*d], T> (Required)
+    x: tensor<[\*d], T> (Required)
     
     Returns
     -------
-    tensor<[*d], f32>
+    tensor<[\*d], f32>
         * A tensor of the same shape as ``x``.
     
     Attributes
@@ -679,11 +679,11 @@ class square(elementwise_unary):
     
     Parameters
     ----------
-    x: tensor<[*d], T> (Required)
+    x: tensor<[\*d], T> (Required)
     
     Returns
     -------
-    tensor<[*d], f32>
+    tensor<[\*d], f32>
         * A tensor of the same shape as ``x``.
     
     Attributes
@@ -707,11 +707,11 @@ class tan(elementwise_unary):
     
     Parameters
     ----------
-    x: tensor<[*d], T> (Required)
+    x: tensor<[\*d], T> (Required)
     
     Returns
     -------
-    tensor<[*d], f32>
+    tensor<[\*d], f32>
         * A tensor of the same shape as ``x``.
     
     Attributes
@@ -735,11 +735,11 @@ class tanh(elementwise_unary):
     
     Parameters
     ----------
-    x: tensor<[*d], T> (Required)
+    x: tensor<[\*d], T> (Required)
     
     Returns
     -------
-    tensor<[*d], f32>
+    tensor<[\*d], f32>
         * A tensor of the same shape as ``x``.
     
     Attributes
@@ -763,12 +763,12 @@ class threshold(Operation):
     
     Parameters
     ----------
-    x: tensor<[*d], T> (Required)
+    x: tensor<[\*d], T> (Required)
     alpha: const fp32 (Required)
     
     Returns
     -------
-    tensor<[*d], f32>
+    tensor<[\*d], f32>
         * A tensor of the same shape as ``x``.
     
     Attributes
@@ -798,13 +798,13 @@ class cast(Operation):
     
     Parameters
     ----------
-    x: tensor<[*d], T> (Required)
+    x: tensor<[\*d], T> (Required)
     dtype: const str (Required)
         * Can be one of the following types: ``int32``, ``int64``, ``fp32``, ``fp64``.
     
     Returns
     -------
-    tensor<[*d], dtype>
+    tensor<[\*d], dtype>
         * A tensor of the same shape as ``x``, with type ``dtype``.
     
     Attributes

--- a/coremltools/converters/mil/mil/ops/defs/image_resizing.py
+++ b/coremltools/converters/mil/mil/ops/defs/image_resizing.py
@@ -15,7 +15,7 @@ class upsample_nearest_neighbor(Operation):
     
     Parameters
     ----------
-    x: tensor<[*D, H1, W1],T>  (Required)
+    x: tensor<[\*D, H1, W1],T>  (Required)
         * Must be at least rank ``3``.
     upscale_factor_height: const<i32> (Optional, default=1)
         * Scale factor for the height dimension (``axis=-2``).
@@ -24,7 +24,7 @@ class upsample_nearest_neighbor(Operation):
 
     Returns
     -------
-    tensor<[*D, H2, W2],T>
+    tensor<[\*D, H2, W2],T>
         * Tensor with same type as the input.
         * ``H2`` = ``H1`` * ``upscale_factor_height``.
         * ``W2`` = ``W1`` * ``upscale_factor_width``.
@@ -63,7 +63,7 @@ class upsample_bilinear(Operation):
     
     Parameters
     ----------
-    x: tensor<[*D, H1, W1],T>  (Required)
+    x: tensor<[\*D, H1, W1],T>  (Required)
         * Must be at least rank ``3``.
     scale_factor_height: const<T2> (Optional, default=1)
         * Scale factor for the height dimension (``axis=-2``).
@@ -119,7 +119,7 @@ class upsample_bilinear(Operation):
 
     Returns
     -------
-    tensor<[*D, H2, W2],T>
+    tensor<[\*D, H2, W2],T>
         * Tensor with same type as the input.
         * ``H2`` = floor(``H1`` * ``scale_factor_height``).
         * ``W2`` = floor(``W1`` * ``scale_factor_width``).
@@ -162,7 +162,7 @@ class resize_bilinear(Operation):
     
     Parameters
     ----------
-    x: tensor<[*D, H1, W1],T> (Required)
+    x: tensor<[\*D, H1, W1],T> (Required)
         * Must be at least rank ``3``.
     target_size_height: const<int32> (Optional, default=1)
         * Target spatial size for the height dimension (``axis=-2``).
@@ -232,7 +232,7 @@ class resize_bilinear(Operation):
     
     Returns
     -------
-    tensor<[*D, H2, W2],T>
+    tensor<[\*D, H2, W2],T>
         * Tensor with same type as the input.
         * ``H2`` = ``target_size_height``.
         * ``W2`` = ``target_size_width``.
@@ -419,7 +419,7 @@ class crop(Operation):
 
     Parameters
     ----------
-    x: tensor<[*D, H1, W1],T> (Required)
+    x: tensor<[\*D, H1, W1],T> (Required)
         * Must be at least rank ``3``.
     crop_height: const<2, i32> (Required)
         * Amount to be cropped from the top and bottom of the height dimension
@@ -429,7 +429,7 @@ class crop(Operation):
     
     Returns
     -------
-    tensor<[*D, H2, W2],T>
+    tensor<[\*D, H2, W2],T>
         * Tensor with same type as the input.
         * ``H2`` = ``H1`` - crop_height[0] - crop_height[1].
         * ``W2`` = ``W1`` - crop_width[0] - crop_width[1].

--- a/coremltools/converters/mil/mil/ops/defs/linear.py
+++ b/coremltools/converters/mil/mil/ops/defs/linear.py
@@ -15,7 +15,7 @@ class linear(Operation):
     
     Parameters
     ----------
-    x: tensor<[*D,D_in], T> (Required)
+    x: tensor<[\*D,D_in], T> (Required)
         * ``1 <= rank <= 3``.
         * ``0 <= rank(*D) <= 2``.
     weight: const tensor<[D_out,D_in], T> (Required)
@@ -24,7 +24,7 @@ class linear(Operation):
     
     Returns
     -------
-    tensor<[*D,D_out], T>
+    tensor<[\*D,D_out], T>
         * Same rank as the input ``x``.
     
     Attributes
@@ -108,9 +108,9 @@ class matmul(Operation):
     
     Parameters
     ----------
-    x: tensor<[*,K1], T> (Required)
+    x: tensor<[\*,K1], T> (Required)
         * ``x`` must be 1-D or higher.
-    y: tensor<[*,K2], T> (Required)
+    y: tensor<[\*,K2], T> (Required)
         * ``y`` must be 1-D or higher.
     transpose_x: const bool (Optional)
         * Default to ``False``.
@@ -123,7 +123,7 @@ class matmul(Operation):
     
     Returns
     -------
-    tensor<*, T>
+    tensor<\*, T>
         * Scalar or tensor output.
     
     Attributes

--- a/coremltools/converters/mil/mil/ops/defs/normalization.py
+++ b/coremltools/converters/mil/mil/ops/defs/normalization.py
@@ -130,7 +130,7 @@ class l2_norm(Operation):
 
     Returns
     -------
-    tensor<[*D,C,H,W], T>
+    tensor<[\*D,C,H,W], T>
         * Same type and shape as the input tensor ``x``.
     
     Attributes
@@ -162,26 +162,31 @@ class layer_norm(Operation):
     
     Parameters
     ----------
-    x: tensor<*?, T> (Required)
+    x: tensor<\*?, T> (Required)
         * Input tensor.
+    
     axes: const<[K], i32> (Optional)
         * Dimensions to perform layer normalization.
         * Default is ``None`` (all dimensions).
+    
     gamma: const tensor<[K], T> (Optional)
-        * if provided, the shape must be be ``x.shape[axes]``,
-        *  for instance, if with input ``x`` with shape ``(3,4,5,6)`` and ``axes = [2,3]``,
-          gamma must have shape ``(5,6)``.
+        * if provided, the shape must be be ``x.shape[axes]``. For instance, if
+          input ``x`` with shape ``(3,4,5,6)`` and ``axes = [2,3]``, gamma must have
+          shape ``(5,6)``.
         * Default is all ones.
+    
     beta: const tensor<[K], T> (Optional)
         * Same shape as gamma.
         * Default is all zeros.
+    
     epsilon: const fp32 (Optional)
         * Small constant to avoid division by ``0``.
         * Default is ``1e-5``.
     
+    
     Returns
     -------
-    tensor<*?, T>:
+    tensor<\*?, T>:
      * Tensor with same shape and type as the input tensor ``x``.
 
     Attributes

--- a/coremltools/converters/mil/mil/ops/defs/pool.py
+++ b/coremltools/converters/mil/mil/ops/defs/pool.py
@@ -52,11 +52,11 @@ class avg_pool(Pooling):
     
     Parameters
     ----------
-    x: tensor<[n,C_in,*D_in],T> (Required)
+    x: tensor<[n,C_in,\*D_in],T> (Required)
         *  ``3 <= rank <= 5``.
-        *  ``D_in`` are spatial dimensions,  ``1 <= len(D_in) <= 2``.
+        *  ``D_in`` are spatial dimensions, ``1 <= len(D_in) <= 2``.
         *  ``C_in`` is the number of input channels or depth dimensions.
-        *  ``n``  is the batch dimension.
+        *  ``n`` is the batch dimension.
     
     kernel_sizes: const tensor<[K],T> (Required)
         * The size of the window for each spatial dimension ``D_in`` of the
@@ -70,11 +70,16 @@ class avg_pool(Pooling):
     pad_type: const str (Required)
         Must be one of the following:
         
-        * ``valid``: No padding. This is equivalent to custom pad with ``pad[i] = 0, for all i``.
-        * ``custom``: Specify custom padding in the parameter pad. note that "same" padding is equivalent to custom padding with ``pad[2*i] + pad[2*i+1] = kernel_size[i]``.
+        * ``valid``: No padding. This is equivalent to custom pad with ``pad[i] = 0, for
+          all i``.
+        * ``custom``: Specify custom padding in the parameter pad. note that "same"
+          padding is equivalent to custom padding with
+          ``pad[2*i] + pad[2*i+1] = kernel_size[i]``.
     
     pad: const<[P],i32> (Optional. Default to all 0s)
-        *  ``pad`` represents the number of elements to pad before and after each dimension: `pad[2*i], pad[2*i+1]` are the pad size before and after spatial dimension ``i``.
+        * ``pad`` represents the number of elements to pad before and after each 
+          dimension: `pad[2*i], pad[2*i+1]` are the pad size before and after spatial
+          dimension ``i``.
         * ``P = 2 * len(D_in)``.
         * ``pad`` should be specified if and only if ``pad_type == custom``
     
@@ -84,11 +89,12 @@ class avg_pool(Pooling):
     
     Returns
     -------
-    tensor<[n, C_out,*D_out],T>
+    tensor<[n, C_out,\*D_out],T>
         * Same rank as ``x``.
         * ``D_out[i] = floor[(D_in[i] + pad[2*i] + pad[2*i+1] - kernel_sizes[i]) /
           strides[i]] +1, for i = 0, .., len(D_in) - 1`` is mathematically the same
           as (when all parameters involved are integers):
+          
               * ``D_out[i] = ceil [(D_in[i] + pad[2*i] + pad[2*i+1] - kernel_size[i] - 1) / stride[i]], for i = 0, .., len(D_in) - 1``.
               * ``*D_out`` is all 1s if ``global_pooling`` is ``true``.
     

--- a/coremltools/converters/mil/mil/ops/defs/random.py
+++ b/coremltools/converters/mil/mil/ops/defs/random.py
@@ -61,7 +61,7 @@ class random_bernoulli(RandomDistribution):
     
     Returns
     -------
-    <*, T>
+    <\*, T>
         * A tensor of the given target output shape filled with random values.
     
     See Also
@@ -89,7 +89,7 @@ class random_categorical(Operation):
     
     Parameters
     ----------
-    shape: <*D_in, T>
+    shape: <\*D_in, T>
         * N-dimensional tensor, one of ``logits`` (event log-probabilities) or ``probs``
           (event probabilities). The first ``N - 1`` dimensions specifies distributions,
           and the last dimension represents a vector of probabilities.
@@ -105,7 +105,7 @@ class random_categorical(Operation):
     
     Returns
     -------
-    <*D_in[:-1] + [size], T>
+    <\*D_in[:-1] + [size], T>
         * A tensor of the given target output shape filled with random values.
     
     See Also
@@ -149,7 +149,7 @@ class random_normal(RandomDistribution):
     
     Returns
     -------
-    <*, T>
+    <\*, T>
         * A tensor of the given target output shape filled with random values.
     
     See Also
@@ -201,7 +201,7 @@ class random_uniform(RandomDistribution):
     
     Returns
     -------
-    <*, T>
+    <\*, T>
         * A tensor of the given target output shape filled with random values.
     
     See Also

--- a/coremltools/converters/mil/mil/ops/defs/reduction.py
+++ b/coremltools/converters/mil/mil/ops/defs/reduction.py
@@ -123,7 +123,7 @@ class reduce_argmax(reduce_arg):
     
     Parameters
     ----------
-    x: <*,T> (Required)
+    x: <\*,T> (Required)
         * Must be 1-dimensional or higher.
     
     axis: const<i32> (Optional)
@@ -135,7 +135,7 @@ class reduce_argmax(reduce_arg):
     
     Returns
     -------
-    <*, int32>
+    <\*, int32>
     
     Attributes
     ----------
@@ -162,7 +162,7 @@ class reduce_argmin(reduce_arg):
     
     Parameters
     ----------
-    x: <*,T> (Required)
+    x: <\*,T> (Required)
         * Must be 1-dimensional or higher.
     
     axis: const<i32> (Optional)
@@ -174,7 +174,7 @@ class reduce_argmin(reduce_arg):
     
     Returns
     -------
-    <*, int32>
+    <\*, int32>
     
     Attributes
     ----------
@@ -200,7 +200,7 @@ class reduce_l1_norm(ReductionAxes):
     
     Parameters
     ----------
-    x: <*,T> (Required)
+    x: <\*,T> (Required)
         * Must be 1-dimensional or higher.
     
     axes: const<K,i32> (Optional, default="None", reduce on all axes.)
@@ -212,7 +212,7 @@ class reduce_l1_norm(ReductionAxes):
     
     Returns
     -------
-    <*,T>
+    <\*,T>
         * Scalar or tensor: The reduced tensor.
     
     Attributes
@@ -242,7 +242,7 @@ class reduce_l2_norm(ReductionAxes):
     
     Parameters
     ----------
-    x: <*,T> (Required)
+    x: <\*,T> (Required)
         * Must be 1-dimensional or higher.
     
     axes: const<K,i32> (Optional, default="None", reduce on all axes.)
@@ -254,7 +254,7 @@ class reduce_l2_norm(ReductionAxes):
     
     Returns
     -------
-    <*,T>
+    <\*,T>
         * Scalar or tensor: The reduced tensor.
     
     Attributes
@@ -281,7 +281,7 @@ class reduce_log_sum(ReductionAxes):
     
     Parameters
     ----------
-    x: <*,T> (Required)
+    x: <\*,T> (Required)
         * Must be 1-dimensional or higher.
     
     axes: const<K,i32> (Optional, default="None", reduce on all axes.)
@@ -293,7 +293,7 @@ class reduce_log_sum(ReductionAxes):
     
     Returns
     -------
-    <*,T>
+    <\*,T>
         * Scalar or tensor: The reduced tensor.
     
     Attributes
@@ -323,7 +323,7 @@ class reduce_log_sum_exp(ReductionAxes):
     
     Parameters
     ----------
-    x: <*,T> (Required)
+    x: <\*,T> (Required)
         * Must be 1-dimensional or higher.
     
     axes: const<K,i32> (Optional, default="None", reduce on all axes.)
@@ -335,7 +335,7 @@ class reduce_log_sum_exp(ReductionAxes):
     
     Returns
     -------
-    <*,T>
+    <\*,T>
         * Scalar or tensor: The reduced tensor.
     
     Attributes
@@ -362,7 +362,7 @@ class reduce_max(ReductionAxes):
     
     Parameters
     ----------
-    x: <*,T> (Required)
+    x: <\*,T> (Required)
         * Must be 1-dimensional or higher.
     
     axes: const<K,i32> (Optional, default="None", reduce on all axes.)
@@ -374,7 +374,7 @@ class reduce_max(ReductionAxes):
     
     Returns
     -------
-    <*,T>
+    <\*,T>
         * Scalar or tensor: The reduced tensor.
     
     Attributes
@@ -397,7 +397,7 @@ class reduce_mean(ReductionAxes):
     
     Parameters
     ----------
-    x: <*,T> (Required)
+    x: <\*,T> (Required)
         * Must be 1-dimensional or higher.
     
     axes: const<K,i32> (Optional, default="None", reduce on all axes.)
@@ -409,7 +409,7 @@ class reduce_mean(ReductionAxes):
     
     Returns
     -------
-    <*,T>
+    <\*,T>
         * Scalar or tensor: The reduced tensor.
     
     Attributes
@@ -435,7 +435,7 @@ class reduce_min(ReductionAxes):
     
     Parameters
     ----------
-    x: <*,T> (Required)
+    x: <\*,T> (Required)
         * Must be 1-dimensional or higher.
     
     axes: const<K,i32> (Optional, default="None", reduce on all axes.)
@@ -447,7 +447,7 @@ class reduce_min(ReductionAxes):
     
     Returns
     -------
-    <*,T>
+    <\*,T>
         * Scalar or tensor: The reduced tensor.
     
     Attributes
@@ -470,7 +470,7 @@ class reduce_prod(ReductionAxes):
     
     Parameters
     ----------
-    x: <*,T> (Required)
+    x: <\*,T> (Required)
         * Must be 1-dimensional or higher.
     
     axes: const<K,i32> (Optional, default="None", reduce on all axes.)
@@ -482,7 +482,7 @@ class reduce_prod(ReductionAxes):
     
     Returns
     -------
-    <*,T>
+    <\*,T>
         * Scalar or tensor: The reduced tensor.
     
     Attributes
@@ -505,7 +505,7 @@ class reduce_sum(ReductionAxes):
     
     Parameters
     ----------
-    x: <*,T> (Required)
+    x: <\*,T> (Required)
         * Must be 1-dimensional or higher.
     
     axes: const<K,i32> (Optional, default="None", reduce on all axes.)
@@ -517,7 +517,7 @@ class reduce_sum(ReductionAxes):
     
     Returns
     -------
-    <*,T>
+    <\*,T>
         * Scalar or tensor: The reduced tensor.
     
     Attributes
@@ -540,7 +540,7 @@ class reduce_sum_square(ReductionAxes):
     
     Parameters
     ----------
-    x: <*,T> (Required)
+    x: <\*,T> (Required)
         * Must be 1-dimensional or higher.
     
     axes: const<K,i32> (Optional, default="None", reduce on all axes.)
@@ -552,7 +552,7 @@ class reduce_sum_square(ReductionAxes):
     
     Returns
     -------
-    <*,T>
+    <\*,T>
         * Scalar or tensor: The reduced tensor.
     
     Attributes

--- a/coremltools/converters/mil/mil/ops/defs/scatter_gather.py
+++ b/coremltools/converters/mil/mil/ops/defs/scatter_gather.py
@@ -44,15 +44,15 @@ class gather(Operation):
     
     Parameters
     ----------
-    x: tensor<*D,T> (Required)
-    indices: tensor<*N,i32> (Required)
+    x: tensor<\*D,T> (Required)
+    indices: tensor<\*N,i32> (Required)
         * Indices values may be negative. More precisely, ``-D[axis]<= v < D[axis]`` for ``v`` in ``indices``.
     axis: const i32 (Optional. Default=``0``)
         * Negative axis is supported.
     
     Returns
     -------
-    tensor<*K,T>
+    tensor<\*K,T>
         * Where ``K = D[:axis] + N + D[axis+1:]``.
     
     Attributes
@@ -156,10 +156,10 @@ class scatter(Operation):
     
     Parameters
     ----------
-    data: tensor<*D, T> (Required)
+    data: tensor<\*D, T> (Required)
     indices: tensor<[C],T> (Required)
         * 1-D tensor.
-    updates: tensor<*K, T> (Required)
+    updates: tensor<\*K, T> (Required)
         * ``K = data.shape[:axis] + [len(indices)] + data.shape[axis+1:]``.
     axis: const i32 (Optional)
         * Default to ``0``.
@@ -169,7 +169,7 @@ class scatter(Operation):
     
     Returns
     -------
-    tensor<*D, T>
+    tensor<\*D, T>
         * With the same type and shape as input ``x``.
 
     Attributes
@@ -218,15 +218,15 @@ class gather_along_axis(Operation):
     
     Parameters
     ----------
-    x: tensor<*D, T> (Required)
-    indices: tensor<*K, T> (Required)
+    x: tensor<\*D, T> (Required)
+    indices: tensor<\*K, T> (Required)
         * ``rank(indices) == rank(x)``.
     axis: const i32 (Optional):
         * Default to ``0``.
     
     Returns
     -------
-    tensor<*D, T>:
+    tensor<\*D, T>:
         * Output tensor has the same shape as ``indices``.
     
     Attributes
@@ -323,10 +323,10 @@ class scatter_along_axis(Operation):
     
     Parameters
     ----------
-    data: tensor<*D, T> (Required)
-    indices: tensor<*K,T> (Required)
+    data: tensor<\*D, T> (Required)
+    indices: tensor<\*K,T> (Required)
         * ``rank(indices) == rank(data)``.
-    updates: tensor<*K, T> (Required)
+    updates: tensor<\*K, T> (Required)
         * Must be the same shape as ``indices``.
     axis: const i32 (Optional)
         * Default to ``0``.
@@ -337,7 +337,7 @@ class scatter_along_axis(Operation):
     
     Returns
     -------
-    tensor<*D, T>
+    tensor<\*D, T>
         * With the same type and shape as input ``x``.
 
     Attributes
@@ -402,12 +402,12 @@ class gather_nd(Operation):
     
     Parameters
     ----------
-    x: tensor<*D,T> (Required)
-    indices: tensor<*K,i32> (Required)
+    x: tensor<\*D,T> (Required)
+    indices: tensor<\*K,i32> (Required)
 
     Returns
     -------
-    tensor<*V,T>
+    tensor<\*V,T>
         * ``V = K[:-1] + D[K[-1]:]``, where ``D = x.shape`` and ``K = indices.shape``.
 
     Attributes
@@ -453,9 +453,9 @@ class scatter_nd(Operation):
     
     Parameters
     ----------
-    data: tensor<*D,T> (Required)
-    indices: tensor<*K,i32> (Required)
-    updates: tensor<*K, T> (Required)
+    data: tensor<\*D,T> (Required)
+    indices: tensor<\*K,i32> (Required)
+    updates: tensor<\*K, T> (Required)
         * Must be the shape as ``K[:-1]+data.shape[K[-1]:]``.
     mode: const string (Optional)
         * Default to ``add``.
@@ -464,7 +464,7 @@ class scatter_nd(Operation):
     
     Returns
     -------
-    tensor<*D,T>
+    tensor<\*D,T>
         * A tensor with the same shape and type as ``data``.
 
     Attributes

--- a/coremltools/converters/mil/mil/ops/defs/tensor_operation.py
+++ b/coremltools/converters/mil/mil/ops/defs/tensor_operation.py
@@ -34,7 +34,7 @@ class band_part(Operation):
 
     Parameters
     ----------
-    x: tensor<*?, T> (Required)
+    x: tensor<\*?, T> (Required)
         * Input tensor.
     lower: const<i32> (Optional)
         * Number of lower / below sub-diagonals to keep. If negative, keep entire
@@ -47,7 +47,7 @@ class band_part(Operation):
     
     Returns
     -------
-    tensor<*?, T>
+    tensor<\*?, T>
         * Same type and shape as the input tensor.
     """
     
@@ -71,7 +71,7 @@ class cumsum(Operation):
 
     Parameters
     ----------
-    x: tensor<*?, T> (Required)
+    x: tensor<\*?, T> (Required)
         * Input tensor.
     axis: const<i32> (Optional)
         * default to ``0``.
@@ -88,7 +88,7 @@ class cumsum(Operation):
 
     Returns
     -------
-    tensor<*?, T>
+    tensor<\*?, T>
         * Same type and shape as the input tensor.
 
     Attributes
@@ -149,7 +149,7 @@ class fill(Operation):
 
     Returns
     -------
-    tensor<*?, T>
+    tensor<\*?, T>
         * Tensor with shape determined by the input shape.
 
     Attributes
@@ -262,7 +262,7 @@ class non_zero(Operation):
 
     Parameters
     ----------
-    x: tensor<*?, T> (Required)
+    x: tensor<\*?, T> (Required)
         * Tensor, values selected at indices where its values is not equal to ``0``.
 
     Returns
@@ -315,7 +315,7 @@ class one_hot(Operation):
 
     Returns
     -------
-    tensor<*?,T>
+    tensor<\*?,T>
         * A tensor that contains one-hot vectors.
 
     Attributes
@@ -373,36 +373,35 @@ class one_hot(Operation):
 class pad(Operation):
     """
     Pad a tensor.
-
+    
     Parameters
     ----------
-    x: tensor<[*D_in],T>  (Required)
-    pad: tensor<[2*N],i32> (Required)
-        ``N <= D_in``: Last ``N`` dimensions of ``x`` are padded as follows: For
-        each dimension ``i`` of ``x`` if ``i >= D_in - N``:
+    x: tensor<[\*D_in],T>  (Required)
+    
+    pad: tensor<[2\*N],i32> (Required)
+        * ``N <= D_in``: Last ``N`` dimensions of ``x`` are padded as follows: For
+          each dimension ``i`` of ``x`` if ``i >= D_in - N``:
             * pad ``pad[2*i]`` elements before ``x[..,i,..]``
             * pad ``pad[2*i+1]`` elements after ``x[..,i,..]``
-            
-        If mode is "reflect" then ``pad[2*i]`` and ``pad[2*i+1]`` can be at
+        * If mode is "reflect" then ``pad[2*i]`` and ``pad[2*i+1]`` can be at
         most ``D[i]-1``.
-        
-        If mode is "replicate" then ``pad[2*i]`` and ``pad[2*i+1]`` can be
+        * If mode is "replicate" then ``pad[2*i]`` and ``pad[2*i+1]`` can be
         at most ``D[i]``.
-
+    
     mode: const<str> (Optional)
         * Default to ``constant``.
         * Must be one of the following values:
           ``constant``, ``reflect``, or ``replicate``.
-            
+    
     constant_val: const<T> (Optional)
         * Default to ``0``.
         * Constant value to pad. Ignored if ``mode != constant``.
     
     Returns
     -------
-    tensor<[*D_out],T>
+    tensor<[\*D_out],T>
         * Tensor with same type as the input.
-
+    
     Attributes
     ----------
     T: fp32
@@ -534,14 +533,14 @@ class tile(Operation):
 
     Parameters
     ----------
-    x: tensor<*?, T> (Required)
+    x: tensor<\*?, T> (Required)
         * Input tensor.
     reps: tensor<[rank(x)], int32> (Required)
         * A 1-D tensor with length ``rank(x)``, which indicates the number to replicate the input along each dimension.
 
     Returns
     -------
-    tensor<*?, T>:
+    tensor<\*?, T>:
         * An n-D tensor with same type as the input.
 
     Attributes
@@ -593,9 +592,9 @@ class argsort(Operation):
     Returns a tensor containing the indices of the sorted values along a given axis
     of the input tensor.
 
-    Paramters
-    ---------
-    x: <*?, T> (Required)
+    Parameters
+    ----------
+    x: <\*?, T> (Required)
         * Input tensor.
     * axis: const<i32> (Optional)
         * Default to ``-1`` (the last dimension).
@@ -606,7 +605,7 @@ class argsort(Operation):
     
     Returns
     -------
-    tensor<*?, int32>
+    tensor<\*?, int32>
         * Tensor containing the indices of the sorted values
 
     Attributes
@@ -641,7 +640,7 @@ class topk(Operation):
 
     Parameters
     ----------
-    x: <*?, T> (Required)
+    x: <\*?, T> (Required)
         * Input tensor.
     k: const<i32> (Optional)
         * Default to ``1``.
@@ -655,9 +654,9 @@ class topk(Operation):
     
     Returns
     -------
-    tensor<*?, T>
+    tensor<\*?, T>
         * Values of top/bottom ``k`` elements.
-    tensor<*?, int32>
+    tensor<\*?, int32>
         * Indices of the top/bottom ``k`` elements along axis.
     
     Attributes
@@ -954,22 +953,23 @@ class concat(Operation):
 class split(Operation):
     """
     Split tensors into a tuple
-
+    
     Parameters
     ----------
-    x: <*?,T>  (Required)
+    x: <\*?,T>  (Required)
         * The tensor to split.
         * The tensors may be variadic, but the number of tensors must be determined
           at compile time (i.e. a tuple).
-
+    
     num_splits: <i32> (Optional)
         If specified, divide ``x`` into ``num_splits`` tensors along ``axis``.
         Its behavior depends on ``split_sizes``:
+        
             * If ``split_sizes`` is defined, ``num_splits == S``, and the output
               sizes may be uneven.
             * If ``split_sizes`` is not defined, ``value.shape[axis]`` must be
               divisible by ``num_splits``, and the output sizes must be even.
-              
+        
         At least one of ``num_splits`` or ``split_sizes`` must be provided.
         If ``split_sizes`` length ``S`` cannot be determined at compile time,
         ``num_splits`` must be supplied to determine the number of outputs.
@@ -981,13 +981,13 @@ class split(Operation):
     axis: const<i32> (Required)
         * The dimension along which to concatenate. Must be in the
           range ``[-rank(x), rank(x))``.
-
+    
     Returns
     -------
-    Tuple[tensor<*?,T>]
+    Tuple[tensor<\*?,T>]
         * Where the length of the tuple is the number of splits (determined
           from ``num_splits`` or ``split_sizes``).
-
+    
     Attributes
     ----------
     T: fp32
@@ -1151,12 +1151,12 @@ class identity(Operation):
     
     Parameters
     ----------
-    x: tensor<*?, T> (Required)
+    x: tensor<\*?, T> (Required)
         * Input tensor.
     
     Returns
     -------
-    tensor<*?, T>
+    tensor<\*?, T>
         * Same type and shape as the input tensor.
     
     """

--- a/coremltools/converters/mil/mil/ops/defs/tensor_transformation.py
+++ b/coremltools/converters/mil/mil/ops/defs/tensor_transformation.py
@@ -64,7 +64,7 @@ class expand_dims(Operation):
     
     Parameters
     ----------
-    x: tensor<*?, T> (Required)
+    x: tensor<\*?, T> (Required)
         * Scalar or tensor.
     axes: const tensor<[K], i32> Required
         * ``K`` is the number of dimensions expanded.
@@ -74,7 +74,7 @@ class expand_dims(Operation):
     
     Returns
     -------
-    tensor<*(rank(x)+K), T>
+    tensor<\*(rank(x)+K), T>
         * Same type as the input ``x`` with rank ``rank(x)+K``.
     
     Attributes
@@ -147,7 +147,7 @@ class reshape(Operation):
     
     Parameters
     ----------
-    x: tensor<*?, T> (Required)
+    x: tensor<\*?, T> (Required)
     
         * A n-D tensor or a scalar.
         * If ``x`` is fixed rank (and possibly contains symbolic dimension),
@@ -171,7 +171,7 @@ class reshape(Operation):
     
     Returns
     -------
-    tensor<*?, T>
+    tensor<\*?, T>
         * Tensor with shape determined by the input shape.
     
     Attributes
@@ -277,15 +277,16 @@ class reverse(Operation):
     
     Parameters
     ----------
-    x: tensor<*?, T> (Required)
+    x: tensor<\*?, T> (Required)
         * Input tensor.
+    
     axes: const<D, i32> (Optional)
         * Dimension(s) to reverse. Each axis must be in the range ``[-rank(x), rank(x))``.
         * Defaults to None (reverse on all dimensions).
     
     Returns
     -------
-    tensor<*?, T>
+    tensor<\*?, T>
         * Same type and shape as the input tensor.
     
     Attributes
@@ -294,8 +295,8 @@ class reverse(Operation):
     
     References
     ----------
-        * `tf.reverse <https://www.tensorflow.org/api_docs/python/tf/reverse>`_
-        * `TORCH <https://pytorch.org/docs/stable/torch.html#torch.flip>`_
+    See `tf.reverse <https://www.tensorflow.org/api_docs/python/tf/reverse>`_
+    and `TORCH <https://pytorch.org/docs/stable/torch.html#torch.flip>`_.
     """
     
     input_spec = InputSpec(
@@ -327,7 +328,7 @@ class reverse_sequence(Operation):
 
     Parameters
     ----------
-    x: tensor<*?, T> (Required)
+    x: tensor<\*?, T> (Required)
         * Input tensor.
     lengths: tensor<L, i32> (Required)
         * 1-dimensional tensor of length ``x.shape[batch_axis]`` specifying the length
@@ -342,7 +343,7 @@ class reverse_sequence(Operation):
     
     Returns
     -------
-    tensor<*?, T>
+    tensor<\*?, T>
         * Same type and shape as the input tensor.
     
     Attributes
@@ -386,21 +387,28 @@ class slice_by_index(Operation):
     
     Parameters
     ----------
-    x: tensor<*?, T> (Required)
+    x: tensor<\*?, T> (Required)
         * Input tensor.
+    
     begin: tensor<[rank<x>], i32> (Required)
         * Starting index for the dimension of slicing.
+    
     end: tensor<[rank(x)], i32> (Required)
         * Ending index for the dimension of slicing.
+    
     stride: tensor<[rank(x)], i32> (Optional)
-        * Default as all ``1``s.
+        * Default to all ones (``1``).
         * Stride for the dimension of slicing.
+    
     begin_mask: tensor<[rank(x)], bool> (Optional)
         * Default to all ``False``.
         * If ``begin_mask[i]==True``, neglect ``begin[i]``, and set ``begin[i]`` to ``0``.
+    
     end_mask: tensor<[rank(x)], bool> (Optional)
         * Default to all ``False``.
-        * If ``end_mask[i]==True``, neglect ``end[i]``, and set ``end[i]`` to ``x.shape[i]``.
+        * If ``end_mask[i]==True``, neglect ``end[i]``, and set ``end[i]``
+          to ``x.shape[i]``.
+    
     squeeze_mask: tensor<[rank(x)], bool> (Optional)
         * Default to all ``False``.
         * If ``squeeze_mask[i]==true``, neglect ``end[i]``, and do the pure index at
@@ -408,7 +416,7 @@ class slice_by_index(Operation):
     
     Returns
     -------
-    tensor<*?, T>
+    tensor<\*?, T>
         * Scalar or tensor.
     
     Attributes
@@ -583,7 +591,7 @@ class slice_by_size(Operation):
     
     Parameters
     ----------
-    x: tensor<*?, T> (Required)
+    x: tensor<\*?, T> (Required)
         * Input tensor.
     begin: tensor<[rank(x)], i32> Required
         * The begin index for slice.
@@ -593,7 +601,7 @@ class slice_by_size(Operation):
     
     Returns
     -------
-    tensor<*?, T>
+    tensor<\*?, T>
         * Scalar or tensor. Same type as the input tensor.
     
     Attributes
@@ -717,7 +725,7 @@ class squeeze(Operation):
     
     Parameters
     ----------
-    x: tensor<*?,T> (Required)
+    x: tensor<\*?,T> (Required)
         * Must be at least 1-D.
     axes: const<K,i32> (Optional)
         * Axes to squeeze out.
@@ -725,7 +733,7 @@ class squeeze(Operation):
     
     Returns
     -------
-    tensor<*(rank(x)-K),T>
+    tensor<\*(rank(x)-K),T>
         * Tensor with same type as input ``x`` and rank ``rank(x)-K``.
     
     Attributes
@@ -777,14 +785,14 @@ class transpose(Operation):
     
     Parameters
     ----------
-    x: tensor<*?, T> (Required)
+    x: tensor<\*?, T> (Required)
         * Must be at least 1-D. ``x`` may have a symbolic shape.
     perm: const<[rank(x)], i32> (Required)
         * Permutation order. Must be non-negative integers.
     
     Returns
     -------
-    tensor<*?,T>
+    tensor<\*?,T>
         * Tensor with same rank and type as ``x``.
     
     Attributes
@@ -871,20 +879,24 @@ class sliding_windows(Operation):
     
     Parameters
     ----------
-    x: tensor<[*d0, d_axis, *dn], T>
+    x: tensor<[\*d0, d_axis, *dn], T>
         * Input tensor.
+    
     axis: const<i32>
         * Axis to perform the operation.
+    
     size: const<i32>
         * Number of elements in the sliding window.
+    
     stride: const<i32> Optional
         * Default to ``1``.
         * The stride of the input elements in the sliding window.
     
     Returns
     -------
-    tensor<[*d0, d_axis - size // stride + 1, size, *dn], T>
-        * The output will be a tensor of rank ``N+1`` where ``N`` is the input tensor rank.
+    tensor<[\*d0, d_axis - size // stride + 1, size, \*dn], T>
+        * The output will be a tensor of rank ``N+1`` where ``N`` is the input tensor
+          rank.
     
     Attributes
     ----------

--- a/coremltools/converters/onnx/_converter.py
+++ b/coremltools/converters/onnx/_converter.py
@@ -485,57 +485,74 @@ def convert(
     # type: (...) -> MLModel
     """
     Convert ONNX model to CoreML.
+    
     Parameters
     ----------
     model:
-        An ONNX model with parameters loaded in onnx package or path to file
+        An ONNX model with parameters loaded in the ONNX package, or path to file
         with models.
+        
     mode: 'classifier', 'regressor' or None
+    
         Mode of the converted coreml model:
-        'classifier', a NeuralNetworkClassifier spec will be constructed.
-        'regressor', a NeuralNetworkRegressor spec will be constructed.
+        
+        * ``'classifier'``: a NeuralNetworkClassifier spec will be constructed.
+        * ``'regressor'``: a NeuralNetworkRegressor spec will be constructed.
+        
     preprocessing_args:
-        'is_bgr', 'red_bias', 'green_bias', 'blue_bias', 'gray_bias',
-        'image_scale' keys with the same meaning as
-        https://apple.github.io/coremltools/generated/coremltools.models.neural_network.html#coremltools.models.neural_network.NeuralNetworkBuilder.set_pre_processing_parameters
+        The ``'is_bgr'``, ``'red_bias'``, ``'green_bias'``, ``'blue_bias'``, ``'gray_bias'``,
+        and ``'image_scale'`` keys have the same meaning as the pre-processing arguments for
+        `NeuralNetworkBuilder <https://coremltools.readme.io/reference/modelsneural_network>`_.
+    
     deprocessing_args:
-        Same as 'preprocessing_args' but for deprocessing.
+        Same as ``'preprocessing_args'`` but for de-processing.
+    
     class_labels:
-        As a string it represents the name of the file which contains
-        the classification labels (one per line).
-        As a list of strings it represents a list of categories that map
-        the index of the output of a neural network to labels in a classifier.
+        * As a string, it represents the name of the file which contains
+          the classification labels (one per line).
+        * As a list of strings, it represents a list of categories that map
+          the index of the output of a neural network to labels in a classifier.
+    
     predicted_feature_name:
         Name of the output feature for the class labels exposed in the Core ML
-        model (applies to classifiers only). Defaults to 'classLabel'
+        model (applies to classifiers only). Defaults to ``'classLabel'``.
+    
     add_custom_layers: bool
-        Flag to turn on addition of custom CoreML layers for unsupported ONNX ops or attributes within
-        a supported op.
+        Flag to turn on additional custom CoreML layers for unsupported ONNX ops or
+    	attributes within a supported op.
+    
     custom_conversion_functions: dict()
-        A dictionary with keys corresponding to the names/types of onnx ops and values as functions taking
-        an object of class coreml-tools's 'NeuralNetworkBuilder', Graph' (see onnx-coreml/_graph.Graph),
-        'Node' (see onnx-coreml/_graph.Node), ErrorHandling (see onnx-coreml/_error_utils.ErrorHandling).
-        This custom conversion function gets full control and responsibility for converting given onnx op.
-        This function returns nothing and is responsible for adding a equivalent CoreML layer via 'NeuralNetworkBuilder'
-    onnx_coreml_input_shape_map: dict()
-        (Optional) A dictionary with keys corresponding to the model input names. Values are a list of integers that specify
-        how the shape of the input is mapped to CoreML. Convention used for CoreML shapes is
-        0: Sequence, 1: Batch, 2: channel, 3: height, 4: width.
-        For example, an input of rank 2 could be mapped as [3,4] (i.e. H,W) or [1,2] (i.e. B,C) etc.
-        This is ignored if "minimum_ios_deployment_target" is set to 13.
+        * A dictionary with keys corresponding to the names/types of ONNX ops and values as 
+          functions taking an object of the ``coreml-tools`` class:
+          ``'NeuralNetworkBuilder'``, ``'Graph'`` (see ``onnx-coreml/_graph.Graph``),
+          ``'Node'`` (see ``onnx-coreml/_graph.Node``), and 
+          ``'ErrorHandling'`` (see ``onnx-coreml/_error_utils.ErrorHandling``).
+        * This custom conversion function gets full control and responsibility for 
+          converting a given ONNX op.
+        * The function returns nothing and is responsible for adding an equivalent CoreML
+          layer via ``'NeuralNetworkBuilder'``.
+    
+    onnx_coreml_input_shape_map: dict() (Optional) 
+        * A dictionary with keys corresponding to the model input names.
+        * Values are a list of integers that specify how the shape of the input is mapped
+          to CoreML.
+        * Convention used for CoreML shapes is ``0: Sequence``, ``1: Batch``,
+          ``2: channel``, ``3: height``, ``4: width``. For example, an input of rank 2
+          could be mapped as ``[3,4]`` (H,W) or ``[1,2]`` (B,C), and so on. This is
+          ignored if ``minimum_ios_deployment_target`` is set to ``13``.
+    
     minimum_ios_deployment_target: str
-        Target Deployment iOS Version (default: '12')
-        Supported iOS version options: '11.2', '12', '13'
-        CoreML model produced by the converter will be compatible with the iOS version specified in this argument.
-        e.g. if minimum_ios_deployment_target = '12', the converter would only utilize CoreML features released till iOS12 (equivalently macOS 10.14, watchOS 5 etc).
-
-        iOS 11.2 (CoreML 0.8) does not support resize_bilinear, crop_resize layers
-         - (Supported features: https://github.com/apple/coremltools/releases/tag/v0.8)
-        iOS 12 (CoreML 2.0)
-         - (Supported features: https://github.com/apple/coremltools/releases/tag/v2.0)
-        iSO 13 (CoreML 3.0)
-         - (Supported features: https://github.com/apple/coremltools/releases/tag/3.0-beta6)
-
+        Target Deployment iOS Version (default: ``'12'``). Supported iOS version options:
+        ``'11.2'``, ``'12'``, ``'13'``. CoreML model produced by the converter will be
+        compatible with the iOS version specified in this argument. For example, if
+        ``minimum_ios_deployment_target = '12'``, the converter would utilize only CoreML
+        features released up to version iOS12 (equivalent to macOS 10.14, watchOS 5, and
+        so on). iOS 11.2 (CoreML 0.8) does not support ``resize_bilinear`` and
+        ``crop_resize`` layers. See `supported v0.8 features <https://github.com/apple/coremltools/releases/tag/v0.8>`_.
+        iOS 12 (CoreML 2.0), see `supported v2.0 features <https://github.com/apple/coremltools/releases/tag/v2.0>`_.
+        iSO 13 (CoreML 3.0), see `supported v3.0 features <https://github.com/apple/coremltools/releases/tag/3.0-beta6>`_.
+    
+    
     Returns
     -------
     model: A coreml model.

--- a/docs/Models/coremltools.models.nearest_neighbors.rst
+++ b/docs/Models/coremltools.models.nearest_neighbors.rst
@@ -1,6 +1,6 @@
-**********
+*****************
 Nearest Neighbors
-**********
+*****************
 
 .. automodule:: coremltools.models.nearest_neighbors
 

--- a/docs/Models/coremltools.models.neural_network.rst
+++ b/docs/Models/coremltools.models.neural_network.rst
@@ -1,6 +1,6 @@
-**********
+**************
 Neural Network
-**********
+**************
 
 .. automodule:: coremltools.models.neural_network
 

--- a/docs/Models/coremltools.models.tree_ensemble.rst
+++ b/docs/Models/coremltools.models.tree_ensemble.rst
@@ -1,6 +1,6 @@
-**********
+*************
 Tree Ensemble
-**********
+*************
 
 .. automodule:: coremltools.models.tree_ensemble
 

--- a/docs/Models/coremltools.models.utils.rst
+++ b/docs/Models/coremltools.models.utils.rst
@@ -1,6 +1,6 @@
-**********
+***********
 Model Utils
-**********
+***********
 
 .. automodule:: coremltools.models.utils
     :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@
     convert
     keras.convert
     caffe.convert
+    onnx.convert
     libsvm.convert
     sklearn.convert
     xgboost.convert


### PR DESCRIPTION
Fixes Sphinx errors and warnings across the API.

Mostly `WARNING: Inline emphasis start-string without end-string` errors.
Some indentation and blank-line errors.
"References" rubric error.
Title "overline" errors.

Also added onnx.convert to the API. The fix-up commit makes editorial changes.

See [preview](https://coremltools.readme.io/v1.0/reference).
