### PR TITLE
Docs: Add input_types and other P1 elements to reference section

### DIFF
--- a/coremltools/converters/mil/input_types.py
+++ b/coremltools/converters/mil/input_types.py
@@ -24,23 +24,25 @@ class ClassifierConfig(object):
         """
         Configuration for classifier models.
 
-        Attributes:
-
+        Parameters
+        ----------
         class_labels: str / list of int / list of str
-            If a list if given, the list maps the index of the output of a
+            If a ``list`` if given, the ``list`` maps the index of the output of a
             neural network to labels in a classifier.
-            If a str is given, the str points to a file which maps the index
+            
+            If a ``str`` is given, the ``str`` points to a file which maps the index
             to labels in a classifier.
-
+        
         predicted_feature_name: str
             Name of the output feature for the class labels exposed in the
-            Core ML neural network classifier, defaults: 'classLabel'.
-
+            Core ML neural network classifier. Default: ``'classLabel'``.
+        
         predicted_probabilities_output: str
             If provided, then this is the name of the neural network blob which
             generates the probabilities for each class label (typically the output
-            of a softmax layer). If not provided, then the last output layer is
-            assumed.
+            of a softmax layer). 
+            
+            If not provided, then the last output layer is assumed.
         """
         self.class_labels = class_labels
         self.predicted_feature_name = predicted_feature_name
@@ -52,13 +54,15 @@ class InputType(object):
         """
         The Input Type for inputs fed into the model.
 
-        Attributes:
-
+        Parameters
+        ----------
         name: (str)
             The name of the input.
-        shape: list, tuple, Shape object, EnumeratedShapes object or None
+        
+        shape: list, tuple, Shape object, EnumeratedShapes object, or None
             The shape(s) that are valid for this input.
-            If set to None, the shape will be infered from the model itself.
+            
+            If set to ``None``, the shape will be infered from the model itself.
         """
 
         self.name = name
@@ -82,23 +86,31 @@ class ImageType(InputType):
         """
         Configuration class used for image inputs in CoreML.
 
-        Attributes:
-
+        Parameters
+        ----------
         scale: (float)
             The scaling factor for all values in the image channels.
+        
         bias: float or list of float
-            If `color_layout` is 'G', bias would be a float
-            If `color_layout` is 'RGB' or 'BGR', bias would be a list of float
+            If ``color_layout`` is ``'G'``, bias would be a ``float``.
+            
+            If `color_layout` is ``'RGB'`` or ``'BGR'``, bias would be a list of ``float``.
+        
         color_layout: string
             Color layout of the image.
+            
             Valid values:
-                'G': Grayscale
-                'RGB': [Red, Green, Blue]
-                'BGR': [Blue, Green, Red]
+                * ``'G'``: Grayscale
+                * ``'RGB'``: [Red, Green, Blue]
+                * ``'BGR'``: [Blue, Green, Red]
+            
         channel_first: (bool) or None
-            Set to True if input format is channel first.
-            Default format is for TF is channel last. (channel_first=False)
-                              for PyTorch is channel first. (channel_first=True)
+            Set to ``True`` if input format is channel first.
+            
+            Default format:
+            	For TensorFlow: channel last (``channel_first=False``).
+            	
+                For PyTorch: channel first (``channel_first=True``).
         """
         super(ImageType, self).__init__(name, shape)
         self.scale = scale
@@ -135,46 +147,45 @@ class TensorType(InputType):
         Parameters
         ----------
         name: str
-            Input name. Must match a input name in model (usually
-            Placeholder name for Tensorflow or input name for PyTorch)
-
-            Name is required except for TensorFlow model where there are
+            Input name. Must match an input name in the model (usually the
+            Placeholder name for TensorFlow or the input name for PyTorch).
+            
+            The ``name`` is required except for a TensorFlow model in which there is
             exactly one input Placeholder.
-
+        
         shape: (1) list of positive int or RangeDim, or (2) EnumeratedShapes
             The shape of the input.
-
+            
             For TensorFlow:
-              - `shape` is optional. If omitted, shape is inferred from
+              * The ``shape`` is optional. If omitted, the shape is inferred from
                 TensorFlow graph's Placeholder shape.
-
+            
             For PyTorch:
-              - `shape` is required.
-
+              * The ``shape`` is required.
+        
         dtype: np.generic or mil.type type
-            Numpy dtype (e.g., np.int32). Default is np.float32
-
+            Numpy ``dtype`` (for example, ``np.int32``). Default is ``np.float32``.
+        
         default_value: np.ndarray
             If provided, the input is considered optional. At runtime, if the
-            input is not provided, `default_value` is used instead.
-
+            input is not provided, ``default_value`` is used.
+            
             Limitations:
+              *  If ``default_value`` is ``np.ndarray``, all
+                 elements are required to have the same value.
 
-            - Currently, if `default_value` is np.ndarray, we requires all
-              elements to have the same value.
-
-            - `default_value` may not be specified if `shape` is
-              `EnumeratedShapes`
+              * The ``default_value`` may not be specified if ``shape`` is
+                ``EnumeratedShapes``.
 
         Examples
         --------
-        - `ct.TensorType(name="input", shape=(1, 2, 3))` implies `dtype ==
-          np.float32`
-
-        - `ct.TensorType(name="input", shape=(1, 2, 3), dtype=np.int32)`
-
-        - `ct.TensorType(name="input", shape=(1, 2, 3),
-          dtype=ct.converters.mil.types.fp32)`
+        * ``ct.TensorType(name="input", shape=(1, 2, 3))` implies `dtype ==
+          np.float32``
+        
+        * ``ct.TensorType(name="input", shape=(1, 2, 3), dtype=np.int32)``
+    	
+        * ``ct.TensorType(name="input", shape=(1, 2, 3),
+          dtype=ct.converters.mil.types.fp32)``
         """
         super(TensorType, self).__init__(name, shape)
         if dtype is None:
@@ -229,17 +240,22 @@ class RangeDim(object):
         """
         A class that can be used to give a range of accepted shapes.
 
-        Attribute:
-
+        Parameters
+        ----------
         lower_bound: (int)
             The minimum valid value for the shape.
+        
         upper_bound: (int)
             The maximum valid value for the shape.
-            Set to -1 if there's no upper limit.
+            
+            Set to ``-1`` if there's no upper limit.
+        
         default: (int) or None
             The default value that is used for initiating the model, and set in
-            input shape field of the model file
-            If set to None, `lower_bound` would be used as default.
+            input shape field of the model file.
+            
+            If set to ``None``, ``lower_bound`` would be used as default.
+        
         symbol: (str)
             Optional symbol name for the dim. Autogenerate a symbol name if
             not specified.
@@ -282,14 +298,16 @@ class Shape(object):
         """
         The basic shape class to be set in InputType.
 
-        Attribute:
-
+        Parameters
+        ----------
         shape: list of (int), symbolic values, RangeDim object
-            The valid shape of the input
+            The valid shape of the input.
+        
         default: tuple of int or None
             The default shape that is used for initiating the model, and set in
             the metadata of the model file.
-            If None, then `shape` would be used.
+            
+            If None, then ``shape`` is used.
         """
         from coremltools.converters.mil.mil import get_new_symbol
 
@@ -358,14 +376,19 @@ class EnumeratedShapes(object):
         """
         A shape class that is used for setting multiple valid shape in InputType.
 
+        Parameters
+        ----------
         shapes: list of Shape objects, or Shape-compatible lists.
             The valid shapes of the inputs.
+            
             If input provided is not Shape object, but can be converted to Shape,
-            the Shape object would be stored in `shapes` instead.
+            the Shape object would be stored in ``shapes`` instead.
+        
         default: tuple of int or None
             The default shape that is used for initiating the model, and set in
             the metadata of the model file.
-            If None, then the first element in `shapes` would be used.
+            
+            If None, then the first element in ``shapes`` is used.
         """
         from coremltools.converters.mil.mil import get_new_symbol
 

--- a/coremltools/models/feature_vectorizer.py
+++ b/coremltools/models/feature_vectorizer.py
@@ -15,23 +15,21 @@ from ._feature_management import is_valid_feature_list, process_or_validate_feat
 
 def create_feature_vectorizer(input_features, output_feature_name, known_size_map={}):
     """
-    Creates a feature vectorizer from input features, return the spec for
-    a feature vectorizer that puts everything into a single array of length
-    equal to the total size of all the input features.  Returns a 2-tuple
-    `(spec, num_dimension)`
+    Create a feature vectorizer from input features. This returns a 2-tuple
+    ``(spec, num_dimension)`` for a feature vectorizer that puts everything into a
+    single array with a length equal to the total size of all the input features.
 
     Parameters
     ----------
     input_features: [list of 2-tuples]
-        Name(s) of the input features, given as a list of `('name', datatype)`
+        Name(s) of the input features, given as a list of ``('name', datatype)``
         tuples.  The datatypes entry is one of the data types defined in the
-        :ref:`datatypes` module.  Allowed datatypes are :ref:`datatype.Int64`,
-        :ref:`datatype.Double`, :ref:`datatypes.Dictionary`,
-        or :ref:`datatype.Array`.
+        ``datatypes`` module.  Allowed ``datatypes`` are ``datatype.Int64``,
+        ``datatype.Double``, ``datatypes.Dictionary``, and ``datatype.Array``.
 
         If the feature is a dictionary type, then the dictionary must have integer
-        keys, and the number of dimensions to expand it into must be given by
-        `known_size_map`.
+        keys, and the number of dimensions to expand it into must be provided by
+        ``known_size_map``.
 
         Feature indices in the final array are counted sequentially from the
         from 0 through the total number of features.
@@ -39,7 +37,7 @@ def create_feature_vectorizer(input_features, output_feature_name, known_size_ma
 
     output_feature_name: str
         The name of the output feature.  The type is an Array
-        List of output feature of the network.
+        List of the output features of the network.
 
     known_size_map:
         A dictionary mapping the feature name to the expanded size in the final

--- a/coremltools/models/nearest_neighbors/builder.py
+++ b/coremltools/models/nearest_neighbors/builder.py
@@ -14,7 +14,7 @@ import six as _six
 
 class KNearestNeighborsClassifierBuilder(object):
     """
-    KNearestNeighborsClassifierBuilder class to construct a CoreML KNearestNeighborsClassifier specification.
+    Construct a CoreML KNearestNeighborsClassifier specification.
 
     Please see the Core ML Nearest Neighbors protobuf message for more information
     on KNearestNeighborsClassifier parameters.
@@ -34,10 +34,8 @@ class KNearestNeighborsClassifierBuilder(object):
 
         # save the spec by the builder
         >>> save_spec(builder.spec, 'knnclassifier.mlmodel')
+        
 
-    See Also
-    --------
-    MLModel, save_spec
     """
 
     _VALID_INDEX_TYPES = ["linear", "kd_tree"]
@@ -70,14 +68,36 @@ class KNearestNeighborsClassifierBuilder(object):
     ):
         """
         Create a KNearestNeighborsClassifierBuilder object.
-        :param input_name: Name of the model input
-        :param output_name: Name of the output
-        :param number_of_dimensions: Number of dimensions of the input data
-        :param default_class_label: The default class label to use for predictions. Must be either an int64 or a string.
-        :param number_of_neighbors: Number of neighbors to use for predictions. Default = 5 with allowed values between 1-1000.
-        :param weighting_scheme: Weight function used in prediction. One of 'uniform' (default) or 'inverse_distance'
-        :param index_type: Algorithm to compute nearest neighbors. One of 'linear' (default), or 'kd_tree'.
-        :param leaf_size: Leaf size for the kd-tree. Ignored if index type is 'linear'. Default = 30.
+        
+        Parameters
+        ----------
+        input_name
+        	Name of the model input.
+        
+        output_name
+        	Name of the output.
+        
+        number_of_dimensions
+        	Number of dimensions of the input data.
+        
+        default_class_label
+        	The default class label to use for predictions. Must be either an
+        	int64 or a string.
+        
+        number_of_neighbors
+        	Number of neighbors to use for predictions. Default = 5 with allowed values
+        	between 1-1000.
+        
+        weighting_scheme
+        	Weight function used in prediction. One of ``'uniform'`` (default) or
+        	``'inverse_distance'``.
+        
+        index_type
+        	Algorithm to compute nearest neighbors. One of ``'linear'`` (default), or
+        	``'kd_tree'``.
+        
+        leaf_size
+        	Leaf size for the kd-tree. Ignored if index type is ``'linear'``. Default = 30.
         """
         super(KNearestNeighborsClassifierBuilder, self).__init__()
 
@@ -174,42 +194,65 @@ class KNearestNeighborsClassifierBuilder(object):
     @property
     def author(self):
         """
-        Get the author for the KNearestNeighborsClassifier model
-        :return: the author
+        Get the author for the KNearestNeighborsClassifier model.
+        
+        Returns
+        -------
+        The author
         """
         return self.spec.description.metadata.author
 
     @author.setter
     def author(self, author):
         """
-        Add an author for the KNearestNeighborsClassifier model
-        :param author: the author
-        :return: None
+        Add an author for the KNearestNeighborsClassifier model.
+        
+        Parameters
+        ----------
+        author
+        	The author.
+        
+        Returns
+        -------
+        None
         """
         self.spec.description.metadata.author = author
 
     @property
     def license(self):
         """
-        Get the license for the KNearestNeighborsClassifier model
-        :return: the license
+        Get the license for the KNearestNeighborsClassifier model.
+
+        Returns
+        -------
+        The license.
         """
         return self.spec.description.metadata.license
 
     @author.setter
     def license(self, license):
         """
-        Add a license for the KNearestNeighborsClassifier model
-        :param license: the license
-        :return: None
+        Add a license for the KNearestNeighborsClassifier model.
+
+        Parameters
+        ----------
+        license
+        	The license.
+        	
+        Returns
+        -------
+        None
         """
         self.spec.description.metadata.license = license
 
     @property
     def description(self):
         """
-        Get the description for the KNearestNeighborsClassifier model
-        :return: the description
+        Get the description for the KNearestNeighborsClassifier model.
+        
+        Returns
+        -------
+        The description.
         """
         return self.spec.description.metadata.shortDescription
 
@@ -218,42 +261,68 @@ class KNearestNeighborsClassifierBuilder(object):
         """
         Add a description for the model.
 
-        :param description: the description
-        :return: None
+        Parameters
+        ----------
+        description
+        	The description
+        
+        Returns
+        -------
+        None
         """
         self.spec.description.metadata.shortDescription = description
 
     @property
     def is_updatable(self):
         """
-        Check if the KNearestNeighborsClassifier is updatable
-        :return: is updatable
+        Check if the KNearestNeighborsClassifier is updatable.
+        
+        Returns
+        -------
+        Is updatable.
         """
         return self.spec.isUpdatable
 
     @is_updatable.setter
     def is_updatable(self, is_updatable):
         """
-        Set the KNearestNeighborsClassifier to be updatable
-        :param is_updatable: boolean
-        :return:
+        Set the KNearestNeighborsClassifier to be updatable.
+        
+        Parameters
+        ----------
+        is_updatable
+        	Boolean
+
+        Returns
+        -------
+        None
         """
         self.spec.isUpdatable = is_updatable
 
     @property
     def weighting_scheme(self):
         """
-        Get the weighting scheme for the KNearestNeighborsClassifier model
-        :return: the weighting scheme
+        Get the weighting scheme for the KNearestNeighborsClassifier model.
+        
+        Returns
+        -------
+        The weighting scheme.
         """
         return self._weighting_scheme
 
     @weighting_scheme.setter
     def weighting_scheme(self, weighting_scheme):
         """
-        Set the weighting scheme for the KNearestNeighborsClassifier model
-        :param weighting_scheme: One of [ 'uniform', 'inverse_distance' ]
-        :return: None
+        Set the weighting scheme for the KNearestNeighborsClassifier model.
+        
+        Parameters
+        ----------
+        weighting_scheme
+        	One of [ ``'uniform'``, ``'inverse_distance'`` ].
+        
+        Returns
+        -------
+        None
         """
         weighting_scheme = weighting_scheme.lower()
         if weighting_scheme not in self._VALID_WEIGHTING_SCHEMES:
@@ -272,17 +341,29 @@ class KNearestNeighborsClassifierBuilder(object):
     @property
     def index_type(self):
         """
-        Get the index type for the KNearestNeighborsClassifier model
-        :return: the index type
+        Get the index type for the KNearestNeighborsClassifier model.
+        
+        Returns
+        -------
+        The index type.
         """
         return self._index_type
 
     def set_index_type(self, index_type, leaf_size=30):
         """
-        Set the index type for the KNearestNeighborsClassifier model
-        :param index_type: One of [ 'linear', 'kd_tree' ]
-        :param leaf_size: For kd_tree indexes, the leaf size to use (default = 30)
-        :return: None
+        Set the index type for the KNearestNeighborsClassifier model.
+        
+        Parameters
+        ----------
+        index_type
+        	One of [ ``'linear'``, ``'kd_tree'`` ].
+        
+        leaf_size
+        	For kd_tree indexes, the leaf size to use (default = 30).
+        
+        Returns
+        -------
+        None
         """
         index_type = index_type.lower()
         if not index_type in self._VALID_INDEX_TYPES:
@@ -305,8 +386,11 @@ class KNearestNeighborsClassifierBuilder(object):
     @property
     def leaf_size(self):
         """
-        Get the leaf size for the KNearestNeighborsClassifier
-        :return: the leaf size
+        Get the leaf size for the KNearestNeighborsClassifier.
+        
+        Returns
+        -------
+        The leaf size.
         """
         return (
             self.spec.kNearestNeighborsClassifier.nearestNeighborsIndex.singleKdTreeIndex.leafSize
@@ -316,8 +400,15 @@ class KNearestNeighborsClassifierBuilder(object):
     def leaf_size(self, leaf_size):
         """
         Set the leaf size for a KNearestNeighborsClassifier model. Only for kd-tree indexes.
-        :param leaf_size: the leaf size
-        :return:
+        
+        Parameters
+        ----------
+        leaf_size
+        	The leaf size.
+        
+        Returns
+        -------
+        None
         """
         if leaf_size <= 0:
             raise ValueError("leaf_size must be > 0")
@@ -328,8 +419,12 @@ class KNearestNeighborsClassifierBuilder(object):
     @property
     def number_of_dimensions(self):
         """
-        Get the number of dimensions of the input data for the KNearestNeighborsClassifier model
-        :return: number of dimensions
+        Get the number of dimensions of the input data for the
+        KNearestNeighborsClassifier model.
+        
+        Returns
+        -------
+        Number of dimensions.
         """
         return (
             self.spec.kNearestNeighborsClassifier.nearestNeighborsIndex.numberOfDimensions
@@ -338,8 +433,11 @@ class KNearestNeighborsClassifierBuilder(object):
     @property
     def number_of_neighbors(self):
         """
-        Get the number of neighbors value for the KNearestNeighborsClassifier model
-        :return: the number of neighbors default value
+        Get the number of neighbors value for the KNearestNeighborsClassifier model.
+        
+        Returns
+        -------
+        The number of neighbors default value.
         """
         return self.spec.kNearestNeighborsClassifier.numberOfNeighbors.defaultValue
 
@@ -348,9 +446,18 @@ class KNearestNeighborsClassifierBuilder(object):
     ):
         """
         Set the numberOfNeighbors parameter for the KNearestNeighborsClassifier model.
-        :param allowed_range: tuple of (min_value, max_value) defining the range of allowed values
-        :param allowed_values: set of allowed values for the number of neighbors
-        :return: None
+        
+        Parameters
+        ----------
+        allowed_range
+        	Tuple of (``min_value``, ``max_value``) defining the range of allowed values.
+        
+        allowed_values
+        	Set of allowed values for the number of neighbors.
+    	
+        Returns
+        -------
+        None
         """
         if number_of_neighbors <= 0:
             raise ValueError("number_of_neighbors must be > 0")
@@ -420,7 +527,10 @@ class KNearestNeighborsClassifierBuilder(object):
     def number_of_neighbors_allowed_range(self):
         """
         Get the range of allowed values for the numberOfNeighbors parameter.
-        :return: tuple of (min_value, max_value) or None if the range hasn't been set
+        
+        Returns
+        -------
+        Tuple of (``min_value``, ``max_value``) or ``None`` if the range hasn't been set.
         """
         if self.spec.kNearestNeighborsClassifier.numberOfNeighbors.HasField("range"):
             return (
@@ -432,7 +542,11 @@ class KNearestNeighborsClassifierBuilder(object):
     def number_of_neighbors_allowed_set(self):
         """
         Get the set of allowed values for the numberOfNeighbors parameter.
-        :return: set of allowed values or None if the set of allowed values hasn't been populated
+        
+        Returns
+        -------
+        Set of allowed values or ``None`` if the set of allowed values hasn't been
+        populated.
         """
         if self.spec.kNearestNeighborsClassifier.numberOfNeighbors.HasField("set"):
             spec_values = (
@@ -446,10 +560,19 @@ class KNearestNeighborsClassifierBuilder(object):
 
     def add_samples(self, data_points, labels):
         """
-        Add some samples to the KNearestNeighborsClassifier model
-        :param data_points: List of input data points
-        :param labels: List of corresponding labels
-        :return: None
+        Add some samples to the KNearestNeighborsClassifier model.
+        
+        Parameters
+        ----------
+        data_points
+        	List of input data points.
+        
+        labels
+        	List of corresponding labels.
+        
+        Returns
+        -------
+        None
         """
         if len(data_points) == 0:
             raise TypeError("data_points is empty")
@@ -490,9 +613,18 @@ class KNearestNeighborsClassifierBuilder(object):
     def _validate_label_types(self, labels):
         """
         Ensure the label types matched the expected types.
-        :param spec: the spec
-        :param labels: the list of labels
-        :return: None, throws a TypeError if not expected
+        
+        Parameters
+        ----------
+        spec
+        	The spec.
+        
+        labels
+        	The list of labels.
+        
+        Returns
+        -------
+        None, throws a TypeError if not expected.
         """
         if self.spec.kNearestNeighborsClassifier.HasField("int64ClassLabels"):
             check_is_valid = KNearestNeighborsClassifierBuilder._is_valid_number_type
@@ -506,8 +638,15 @@ class KNearestNeighborsClassifierBuilder(object):
     def _is_valid_text_type(obj):
         """
         Checks if the object is a valid text type.
-        :param obj: the object to check
-        :return: True if a valid text type, False otherwise
+        
+        Parameters
+        ----------
+        obj
+        	The object to check.
+        
+        Returns
+        -------
+        True if a valid text type, False otherwise.
         """
         return isinstance(obj, _six.string_types)
 
@@ -515,7 +654,14 @@ class KNearestNeighborsClassifierBuilder(object):
     def _is_valid_number_type(obj):
         """
         Checks if the object is a valid number type.
-        :param obj: the object to check
-        :return: True if a valid number type, False otherwise
+        
+        Parameters
+        ----------
+        obj
+        	The object to check.
+        
+        Returns
+        -------
+        True if a valid number type, False otherwise.
         """
         return isinstance(obj, (_six.integer_types, _np.integer))

--- a/coremltools/models/neural_network/builder.py
+++ b/coremltools/models/neural_network/builder.py
@@ -251,10 +251,6 @@ class NeuralNetworkBuilder(object):
 
         # save the spec by the builder
         >>> save_spec(builder.spec, 'network.mlmodel')
-
-    See Also
-    --------
-    MLModel, datatypes, save_spec
     """
 
     def __init__(

--- a/coremltools/models/neural_network/update_optimizer_utils.py
+++ b/coremltools/models/neural_network/update_optimizer_utils.py
@@ -133,6 +133,16 @@ class SgdParams(object):
 
 
 class RangeParam:
+    """
+    Range Parameter optimizer.
+
+    Attributes
+    ----------
+    value: float
+    min: float
+    max: float
+    """
+
     def __init__(self, value, min=0, max=1):
         self._value = value
         if min >= max:
@@ -154,6 +164,15 @@ class RangeParam:
 
 
 class Batch:
+    """
+    Batch optimizer.
+
+    Attributes
+    ----------
+    value: float
+    allowed_set: float
+    """
+
     def __init__(self, value, allowed_set=None):
         self._value = value
         if allowed_set is None:

--- a/coremltools/models/tree_ensemble.py
+++ b/coremltools/models/tree_ensemble.py
@@ -67,9 +67,9 @@ class TreeEnsembleBase(object):
 
             A value denoting the transform applied.  Possible values are:
 
-            - "NoTransform" (default).  Do not apply a transform.
+            - ``"NoTransform"`` (default).  Do not apply a transform.
 
-            - "Classification_SoftMax".
+            - ``"Classification_SoftMax"``.
 
               Apply a softmax function to the outcome to produce normalized,
               non-negative scores that sum to 1.  The transformation applied to
@@ -82,7 +82,7 @@ class TreeEnsembleBase(object):
               Note: This is the output transformation applied by the XGBoost package
               with multiclass classification.
 
-            - "Regression_Logistic".
+            - ``"Regression_Logistic"``.
 
               Applies a logistic transform the predicted value, specifically:
 
@@ -130,45 +130,45 @@ class TreeEnsembleBase(object):
 
         branch_mode: str
             Branch mode of the node, specifying the condition under which the node
-            referenced by `true_child_id` is called next.
+            referenced by ``true_child_id`` is called next.
 
             Must be one of the following:
 
-              - `"BranchOnValueLessThanEqual"`. Traverse to node `true_child_id`
-                if `input[feature_index] <= feature_value`, and `false_child_id`
+              - ``"BranchOnValueLessThanEqual"``. Traverse to node ``true_child_id``
+                if ``input[feature_index] <= feature_value``, and ``false_child_id``
                 otherwise.
 
-              - `"BranchOnValueLessThan"`. Traverse to node `true_child_id`
-                if `input[feature_index] < feature_value`, and `false_child_id`
+              - ``"BranchOnValueLessThan"``. Traverse to node ``true_child_id``
+                if ``input[feature_index] < feature_value``, and ``false_child_id``
                 otherwise.
 
-              - `"BranchOnValueGreaterThanEqual"`. Traverse to node `true_child_id`
-                if `input[feature_index] >= feature_value`, and `false_child_id`
+              - ``"BranchOnValueGreaterThanEqual"``. Traverse to node ``true_child_id``
+                if ``input[feature_index] >= feature_value``, and ``false_child_id``
                 otherwise.
 
-              - `"BranchOnValueGreaterThan"`. Traverse to node `true_child_id`
-                if `input[feature_index] > feature_value`, and `false_child_id`
+              - ``"BranchOnValueGreaterThan"``. Traverse to node ``true_child_id``
+                if ``input[feature_index] > feature_value``, and ``false_child_id``
                 otherwise.
 
-              - `"BranchOnValueEqual"`. Traverse to node `true_child_id`
-                if `input[feature_index] == feature_value`, and `false_child_id`
+              - ``"BranchOnValueEqual"``. Traverse to node ``true_child_id``
+                if ``input[feature_index] == feature_value``, and ``false_child_id``
                 otherwise.
 
-              - `"BranchOnValueNotEqual"`. Traverse to node `true_child_id`
-                if `input[feature_index] != feature_value`, and `false_child_id`
+              - ``"BranchOnValueNotEqual"``. Traverse to node ``true_child_id``
+                if ``input[feature_index] != feature_value``, and ``false_child_id``
                 otherwise.
 
         true_child_id: int
             ID of the child under the true condition of the split.  An error will
-            be raised at model validation if this does not match the `node_id`
-            of a node instantiated by `add_branch_node` or `add_leaf_node` within
-            this `tree_id`.
+            be raised at model validation if this does not match the ``node_id``
+            of a node instantiated by ``add_branch_node`` or ``add_leaf_node`` within
+            this ``tree_id``.
 
         false_child_id: int
             ID of the child under the false condition of the split.  An error will
-            be raised at model validation if this does not match the `node_id`
-            of a node instantiated by `add_branch_node` or `add_leaf_node` within
-            this `tree_id`.
+            be raised at model validation if this does not match the ``node_id``
+            of a node instantiated by ``add_branch_node`` or ``add_leaf_node`` within
+            this ``tree_id``.
 
         relative_hit_rate: float [optional]
             When the model is converted compiled by CoreML, this gives hints to
@@ -317,9 +317,9 @@ class TreeEnsembleRegressor(TreeEnsembleBase):
         ----------
 
         features: [list of features]
-            Name(s) of the input features, given as a list of `('name', datatype)`
-            tuples.  The features are one of :py:class:`models.datatypes.Int64`,
-            :py:class:`datatypes.Double`, or :py:class:`models.datatypes.Array`.
+            Name(s) of the input features, given as a list of ``('name', datatype)``
+            tuples.  The features are one of ``models.datatypes.Int64``,
+            ``datatypes.Double``, or ``models.datatypes.Array``.
             Feature indices in the nodes are counted sequentially from 0 through
             the features.
 
@@ -394,9 +394,9 @@ class TreeEnsembleClassifier(TreeEnsembleBase):
         Parameters
         ----------
         features: [list of features]
-            Name(s) of the input features, given as a list of `('name', datatype)`
-            tuples.  The features are one of :py:class:`models.datatypes.Int64`,
-            :py:class:`datatypes.Double`, or :py:class:`models.datatypes.Array`.
+            Name(s) of the input features, given as a list of ``('name', datatype)``
+            tuples.  The features are one of ``models.datatypes.Int64``,
+            ``datatypes.Double``, or ``models.datatypes.Array``.
             Feature indices in the nodes are counted sequentially from 0 through
             the features.
 
@@ -408,9 +408,9 @@ class TreeEnsembleClassifier(TreeEnsembleBase):
             A string or a list of two strings specifying the names of the two
             output features, the first being a class label corresponding
             to the class with the highest predicted score, and the second being
-            a dictionary mapping each class to its score. If `output_features`
+            a dictionary mapping each class to its score. If ``output_features``
             is a string, it specifies the predicted class label and the class
-            scores is set to the default value of `"classProbability."`
+            scores is set to the default value of ``"classProbability"``.
         """
         super(TreeEnsembleClassifier, self).__init__()
         spec = self.spec

--- a/docs/MIL/coremltools.converters.mil.input_types.rst
+++ b/docs/MIL/coremltools.converters.mil.input_types.rst
@@ -1,0 +1,28 @@
+***********
+Input Types
+***********
+
+Input types supported by MIL.
+
+
+.. automodule:: coremltools.converters.mil.input_types
+
+   .. autoclass:: ClassifierConfig
+      :members:
+
+   .. autoclass:: TensorType
+      :members:
+
+   .. autoclass:: ImageType
+      :members:
+
+   .. autoclass:: RangeDim
+      :members:
+
+   .. autoclass:: Shape
+      :members:
+
+   .. autoclass:: EnumeratedShapes
+      :members:
+
+

--- a/docs/Models/coremltools.models.feature_vectorizer.rst
+++ b/docs/Models/coremltools.models.feature_vectorizer.rst
@@ -1,0 +1,6 @@
+******************
+Feature Vectorizer
+******************
+
+.. automodule:: coremltools.models.feature_vectorizer
+    :members:

--- a/docs/Models/coremltools.models.neural_network.rst
+++ b/docs/Models/coremltools.models.neural_network.rst
@@ -5,6 +5,7 @@ Neural Network
 .. automodule:: coremltools.models.neural_network
 
     .. autoclass:: NeuralNetworkBuilder
+        :members:
     .. automodule:: coremltools.models.neural_network.flexible_shape_utils
         :members:
     .. automodule:: coremltools.models.neural_network.quantization_utils

--- a/docs/Models/coremltools.models.pipeline.rst
+++ b/docs/Models/coremltools.models.pipeline.rst
@@ -5,5 +5,10 @@ Pipeline
 .. automodule:: coremltools.models.pipeline
 
   .. autoclass:: Pipeline
+     :members:
+
   .. autoclass:: PipelineClassifier
+     :members:
+
   .. autoclass:: PipelineRegressor
+     :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,8 +11,12 @@
     sklearn.convert
     xgboost.convert
 
-.. currentmodule:: coremltools.converters.mil
+.. currentmodule:: coremltools.converters.mil.input_types
 .. autosummary::
+  :toctree: MIL/generated
+  
+.. currentmodule:: coremltools.converters.mil.mil.ops
+.. autosummary:: 
   :toctree: MIL/generated
 
 ..


### PR DESCRIPTION
This adds and updates the `.rst` files that were manually coded for the
MIL section to include the input_types. The input_types are now part of the MIL section.

The Model `.rst` files (also manually coded) were edited to include member elements:
Added more content to models.neural_network section and added models.feature_vectorizer to the models section.

In addition:
Added `Batch` and `RangeParam` to models.neural_network section by writing docstrings.
Extensive formatting uncovered many properties that needed to be documented in
the models.nearest_neighbors section.
Extensive formatting for models.tree_ensemble section.

See [preview](https://coremltools.readme.io/v1.0/reference/convertersmilinput_types).
