### PR TITLE
Conda build recipe for dev packages built from local source checkout

### DIFF
--- a/scripts/conda/build.sh
+++ b/scripts/conda/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+set -x
+mkdir build
+cd build
+
+cmake \
+    -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} \
+    -DPYTHON_EXECUTABLE:FILEPATH=${PREFIX}/bin/python \
+    -DPYTHON_INCLUDE_DIR=$(${PYTHON} -c 'import sysconfig; print(sysconfig.get_paths()["include"])') \
+    -DPYTHON_LIBRARY=${PREFIX}/lib \
+    ..
+make -j ${CPU_COUNT}
+
+${PYTHON} -m pip install --no-deps --ignore-installed ../

--- a/scripts/conda/meta.yaml
+++ b/scripts/conda/meta.yaml
@@ -38,9 +38,7 @@ test:
   imports:
     - coremltools
   commands:
-    # TODO: change to running `coremlconverter --help`
-    # when the upstream bug is fixed.
-    - test -f ${PREFIX}/bin/coremlconverter
+    - coremlconverter --help
 
 about:
   home: https://github.com/apple/coremltools

--- a/scripts/conda/meta.yaml
+++ b/scripts/conda/meta.yaml
@@ -1,0 +1,61 @@
+# build a conda package from a local git checkout
+package:
+  name: coremltools
+  version: {{ GIT_DESCRIBE_TAG }}
+
+source:
+  path: ../..  
+
+build:
+  number: {{ GIT_DESCRIBE_NUMBER|int }}
+  string: py{{ CONDA_PY }}_{{GIT_DESCRIBE_HASH}}_{{ GIT_DESCRIBE_NUMBER }}
+
+requirements:
+  build:
+    - cmake
+    - make
+    #- {{ compiler('c') }}
+    #- {{ compiler('cxx') }}
+  host:
+    - python
+    - numpy
+    - pip
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+    - protobuf >=3.1.0
+    - six >=1.1.0
+    - attrs
+    - sympy
+    - scipy
+    - tqdm
+    - packaging
+  run_constrained:
+    - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx]
+    - pytorch >=1.4,<1.7  # inferred by testing
+
+test:
+  imports:
+    - coremltools
+  commands:
+    # TODO: change to running `coremlconverter --help`
+    # when the upstream bug is fixed.
+    - test -f ${PREFIX}/bin/coremlconverter
+
+about:
+  home: https://github.com/apple/coremltools
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: "LICENSE.txt"
+  summary: 'Core ML is an Apple framework to integrate machine learning models into your app. Core ML provides a unified representation for all models.'
+
+  description: |
+    Core ML is an Apple framework to integrate machine learning models into your app.
+
+    Use the coremltools Python package to convert models from third-party training libraries such as TensorFlow and PyTorch to the Core ML format. You can then use Core ML to integrate the models into your app.
+
+    Core ML provides a unified representation for all models. Your app uses Core ML APIs and user data to make predictions, and to fine-tune models, all on the user’s device. Running a model strictly on the user’s device removes any need for a network connection, which helps keep the user’s data private and your app responsive.
+
+    Core ML optimizes on-device performance by leveraging the CPU, GPU, and Neural Engine while minimizing its memory footprint and power consumption.
+  doc_url: https://coremltools.readme.io/docs
+  dev_url: https://github.com/apple/coremltools


### PR DESCRIPTION
This adds a conda build recipe that builds a development package from a source checkout.  The version number of the package is auto-discovered from the most recent tag, and the package build number is computed using `git describe` to count the number of commits since the most recent tag.  The git hash is also put into the build string for easier debugging.  An example invocation of conda-build looks like:

```
conda build --python=3.8 --numpy=1.16 -c conda-forge scripts/conda
```

The recipe is based on the https://github.com/conda-forge/coremltools-feedstock recipe, but with some changes.