### PR TITLE
Add option to create "developer wheels"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ cmake_install.cmake
 /docs/generated/
 /coremltools.egg-info/
 /dist/
+/envs/
 .DS_Store
 *.xcodeproj/
 mlmodel_test_runner

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,14 @@ else()
   message(FATAL_ERROR "Unsupported build platform. Supported platforms are Linux and macOS.")
 endif()
 
+
+if(BUILD_TAG)
+  set(BUILD_TAG_OPTION "--build-number=${BUILD_TAG}")
+  message(STATUS "Using ${BUILD_TAG} as build tag for wheels.")
+else()
+  set(BUILD_TAG_OPTION "")
+endif()
+
 # Add a target for each platform, and then a 'dist' that will build all of them.
 # Parallel invocations of setup.py is not safe, so we serialize them.
 set(plat_targets "")
@@ -224,6 +232,7 @@ foreach(platform IN ITEMS ${PLAT_NAME})
       bdist_wheel
       --plat-name=${platform}
       --python-tag=${PYTHON_TAG}
+      ${BUILD_TAG_OPTION}
       --dist-dir=${PROJECT_BINARY_DIR}/dist
     DEPENDS "caffeconverter;coremlpython;${plat_targets}"
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}

--- a/scripts/build_tag.py
+++ b/scripts/build_tag.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+# Construct a valid wheel build tag with ``git describe``.
+#
+# We do this with python because it is available and much more straightforward
+# than doing it in the shell.
+
+import subprocess
+import os.path
+
+
+def main():
+    # ensure that no matter where this script is called, it reports git info
+    # for the working directory where it has been checked out
+    git_dir = os.path.dirname(__file__)
+    version_str = subprocess.check_output(
+        ["git", "-C", git_dir, "describe", "--tags"], text=True
+    )
+    build_tag = version_str.split("-", maxsplit=1)[1].replace("-", "_").strip()
+    print(build_tag)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_tag.py
+++ b/scripts/build_tag.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
+#
+# Copyright (c) 2021, Apple Inc. All rights reserved.
+#
+# Use of this source code is governed by a BSD-3-clause license that can be
+# found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
 # Construct a valid wheel build tag with ``git describe``.
 #


### PR DESCRIPTION
This adds a `--dist-dev` option to `scripts/build.sh`, which creates wheels in the normal fashion, but adds a "build tag" (sometimes also called a "build number", although it can be more than a number, see https://www.python.org/dev/peps/pep-0427/#file-name-convention).  By default, the build tag will be generated from `git describe --tags` to include the integer count of commits between the current commit and the last tag, as well as the short git hash.

For example, a wheel built with `--dist` will have the filename:

`coremltools-4.0-cp38-none-macosx_10_12_intel.whl`

which is what is uploaded to PyPI.  A wheel built instead with `--dist-dev` will have a filename like:

`coremltools-4.0-22_g1b72c29-cp38-none-macosx_10_12_intel.whl`

which indicates 22 commits between commit `1b72c29` and the tag for version 4.0.  Note that the entire string `22_g1b72c29` is considered the build tag or build number, but only the leading digits are evaluated to determine the priority for installation.  When multiple wheels of the same version are candidates for installation, pip will select the one with the numerically largest build tag, which means these dev wheels will be favored over the release wheels on PyPI when the user has added an extra index including the dev wheels.

If for some reason it is necessary to override the build tag, the environment variable `BUILD_TAG` can be set before calling `scripts/build.sh`.  The tag itself is passed to cmake via `-DBUILD_TAG=tag`.

(Let me know if you would prefer a different option name than `--dist-dev`.)
