### PR TITLE
Add type_as operation for PyTorch

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -1172,6 +1172,13 @@ def _bool(context, node):
 def _int(context, node):
     _cast(context, node, int, "int32")
 
+@register_torch_op
+def type_as(context, node):
+    inputs = _get_inputs(context, node, expected=2)
+    nptype = types.nptype_from_builtin(inputs[1].sym_type.get_primitive())
+    dtype = NUM_TO_DTYPE_STRING[NUMPY_DTYPE_TO_TORCH_NUM[nptype]]
+    res = mb.cast(x=inputs[0], dtype=dtype, name=node.name)
+    context.add(res, node.name)
 
 @register_torch_op
 def layer_norm(context, node):


### PR DESCRIPTION
Add PyTorch's type_as operation. The need for this method arose when tracing a network comprising a BiLSTM followed by a Linear layer.

Possible testcase:

```python
import torch
from torch import nn
import coremltools as ct
import numpy as np

class Caster(nn.Module):
    def __init__(self, num_embeddings, embedding_dim=3):
        super().__init__()
        self.embedding = nn.Embedding(10, embedding_dim)

    def forward(self, x, y):
        z = self.embedding(x.type_as(y))
        return z.type_as(y)


num_embeddings = 10

x = torch.randint(num_embeddings, (5, 1), dtype=torch.float32)
y = torch.tensor([1], dtype=torch.int32)

model = Caster(num_embeddings)
traced_model = torch.jit.trace(model, (x, y))

mlmodel = ct.convert(
    traced_model,
    inputs=[
        ct.TensorType(name="x", shape=(ct.RangeDim(1, -1), 1)),
        ct.TensorType(name="y", shape=y.shape, dtype=np.int32)
    ],
)

mloutput = mlmodel.predict({
    "x": x.numpy(),
    "y": y.numpy()
}, useCPUOnly=True)

print(mloutput)

# Converting Frontend ==> MIL Ops:  80%|████████████████████████████████████████████████████████████████████████████████████▊                     | 4/5 [00:00<00:00, 2493.64 ops/s]
# Running MIL optimization passes: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████| 18/18 [00:00<00:00, 10381.94 passes/s]
# WARNING:root:Output var 7 of type i32 in function main is cast to type fp32
# Translating MIL ==> MLModel Ops: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:00<00:00, 25400.78 ops/s]
# {'7': array([[[-0.,  1.,  0.]],
#
#        [[-0.,  1.,  0.]],
#
#        [[-0.,  0.,  0.]],
#
#        [[-1.,  1.,  0.]],
#
#        [[-0.,  0.,  0.]]], dtype=float32)}
```

I'm not sure however why the converter casts the final output type back to fp32, but the rounding of the values works as expected.