### PR TITLE
Added an alias to PyTorch `hardsigmoid` op to fix conversion error

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -1965,7 +1965,7 @@ def sigmoid(context, node):
     res = mb.sigmoid(x=inputs[0], name=node.name)
     context.add(res)
 
-@register_torch_op
+@register_torch_op(torch_alias=["hardsigmoid_"])
 def hardsigmoid(context, node):
     inputs = _get_inputs(context, node, expected=1)
 


### PR DESCRIPTION
Added the `hardsigmoid_` alias to the PyTorch `hardsigmoid` operation (see [here](https://github.com/pytorch/pytorch/blob/16fc18bf82b271621ad675cb44beb439a7b89e9b/aten/src/ATen/native/native_functions.yaml#L7243) for a reference to the alias in the PyTorch docs). Note that a similar alias already exists for PyTorch's `hardtanh` operation.

Adding this alias enabled me to successfully convert the [torchvision implementation of MobileNetV3](https://pytorch.org/vision/stable/_modules/torchvision/models/mobilenetv3.html) to the CoreML format. Before adding the alias, I encountered the error "RuntimeError: PyTorch convert function for op 'hardsigmoid_' not implemented." when attempting to convert the model.