### PR TITLE
Change version link from specific to generic

### DIFF
--- a/docs-api-version3/index.html
+++ b/docs-api-version3/index.html
@@ -175,8 +175,7 @@
             
   <div class="section" id="coremltools">
 <h1>coremltools<a class="headerlink" href="#coremltools" title="Permalink to this headline">¶</a></h1>
-        <p><strong>This documentation describes an older version. For the newest version,
-          see <a href="http://coremltools.readme.io/">Version 4.0</a>.</strong>
+        <p><strong>This documentation describes an old version. See <a href="http://coremltools.readme.io/">the newest version</a>.</strong>
     </p>
     <hr>
 


### PR DESCRIPTION
Change the documentation link in version 3.4 introduction from "Version 4.0" to "newest version". This was done directly in the HTML file because we are not re-generating the HTML files for the older version 3.4.

