### PR TITLE
Fix imports when in "editable mode"

### DIFF
--- a/coremltools/converters/mil/converter.py
+++ b/coremltools/converters/mil/converter.py
@@ -7,10 +7,14 @@ from .mil.passes.apply_common_pass_pipeline import apply_common_pass_pipeline
 from coremltools.converters._profile_utils import _profile
 from coremltools.converters.mil.mil import Builder as mb
 from coremltools.converters.mil.mil.passes.quantization_passes import AbstractQuantizationPass
-from coremltools.libmodelpackage import ModelPackage
 from coremltools.models import MLModel
 from coremltools.models.model import _MODEL_FILE_NAME, _WEIGHTS_DIR_NAME
 from coremltools.models.utils import _MLMODEL_EXTENSION, _MLPACKAGE_EXTENSION
+
+try:
+    from coremltools.libmodelpackage import ModelPackage
+except ModuleNotFoundError:
+    pass
 
 import os as _os
 import shutil as _shutil

--- a/coremltools/models/utils.py
+++ b/coremltools/models/utils.py
@@ -17,8 +17,11 @@ import warnings as _warnings
 from coremltools.proto import Model_pb2 as _Model_pb2
 
 from .._deps import _HAS_SKLEARN
-from ..libmodelpackage import ModelPackage
 
+try:
+    from ..libmodelpackage import ModelPackage
+except ModuleNotFoundError:
+    pass
 
 _MLMODEL_EXTENSION = ".mlmodel"
 _MLPACKAGE_EXTENSION = ".mlpackage"


### PR DESCRIPTION
Building the documentation, without first building the code, requires that coremltools be both installable and importable in editable mode (i.e. setuptools "develop mode"). So `import` statements can't assume shared library files are built.