### PR TITLE
Adding support for torch.minimum and torch.maximum

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -743,6 +743,26 @@ def max_pool3d(context, node):
 
 
 @register_torch_op
+def minimum(context, node):
+    inputs = _get_inputs(context, node, expected=2)
+    assert len(node.outputs) == 1
+    x = context[node.inputs[0]]
+    y = context[node.inputs[1]]
+    out = mb.minimum(x=x, y=y, name=node.name)
+    context.add(out)
+
+
+@register_torch_op
+def maximum(context, node):
+    inputs = _get_inputs(context, node, expected=2)
+    assert len(node.outputs) == 1
+    x = context[node.inputs[0]]
+    y = context[node.inputs[1]]
+    out = mb.maximum(x=x, y=y, name=node.name)
+    context.add(out)
+
+
+@register_torch_op
 def div(context, node):
     inputs = _get_inputs(context, node, expected=2)
 

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -966,6 +966,29 @@ class TestMaxPool(TorchBaseTest):
         )
         self.run_compare_torch(input_shape, model, backend=backend)
 
+class TestMaximumMinimum(TorchBaseTest):
+
+    @pytest.mark.parametrize(
+        "input_shape, mode, backend",
+        itertools.product(
+            [(2, 5, 7, 3), (3, 2, 9)],
+            ["minimum", "maximum"],
+            backends,
+        ),
+    )
+    def test_minimum_maximum(self, input_shape, mode, backend):
+        class TestModel(torch.nn.Module):
+            def forward(self, x, y):
+                if mode == "minimum":
+                    return torch.minimum(x, y)
+                elif mode == "maximum":
+                    return torch.maximum(x, y)
+                else:
+                    raise ValueError(f"Unsupported mode: {mode}")
+
+        model = TestModel()
+        self.run_compare_torch([input_shape] * 2, model, backend=backend)
+
 class TestPoolSymbolicInput(TorchBaseTest):
     def test_max_pool(self):
         model = nn.MaxPool2d(


### PR DESCRIPTION
This adds support for `torch.maximum` and `torch.minimum` for the MIL converter with the `torch` frontend.

This closes: https://github.com/apple/coremltools/issues/1045