### PR TITLE
fix: compatibility with Ubuntu 18.04

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,25 +40,25 @@ check_python_flake8:
 
 build_wheel_linux_py35:
   <<: *build_linux
-  image: registry.gitlab.com/zach_nation/coremltools/build-image-ubuntu-18.04:1.0.2
+  image: registry.gitlab.com/zach_nation/coremltools/build-image-ubuntu-18.04:1.0.0
   variables:
     PYTHON: "3.5"
 
 build_wheel_linux_py36:
   <<: *build_linux
-  image: registry.gitlab.com/zach_nation/coremltools/build-image-ubuntu-18.04:1.0.2
+  image: registry.gitlab.com/zach_nation/coremltools/build-image-ubuntu-18.04:1.0.0
   variables:
     PYTHON: "3.6"
 
 build_wheel_linux_py37:
   <<: *build_linux
-  image: registry.gitlab.com/zach_nation/coremltools/build-image-ubuntu-18.04:1.0.2
+  image: registry.gitlab.com/zach_nation/coremltools/build-image-ubuntu-18.04:1.0.0
   variables:
     PYTHON: "3.7"
 
 build_wheel_linux_py38:
   <<: *build_linux
-  image: registry.gitlab.com/zach_nation/coremltools/build-image-ubuntu-18.04:1.0.2
+  image: registry.gitlab.com/zach_nation/coremltools/build-image-ubuntu-18.04:1.0.0
   variables:
     PYTHON: "3.8"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,25 +40,25 @@ check_python_flake8:
 
 build_wheel_linux_py35:
   <<: *build_linux
-  image: registry.gitlab.com/zach_nation/coremltools/build-image-ubuntu-20.04:1.0.2
+  image: registry.gitlab.com/zach_nation/coremltools/build-image-ubuntu-18.04:1.0.2
   variables:
     PYTHON: "3.5"
 
 build_wheel_linux_py36:
   <<: *build_linux
-  image: registry.gitlab.com/zach_nation/coremltools/build-image-ubuntu-20.04:1.0.2
+  image: registry.gitlab.com/zach_nation/coremltools/build-image-ubuntu-18.04:1.0.2
   variables:
     PYTHON: "3.6"
 
 build_wheel_linux_py37:
   <<: *build_linux
-  image: registry.gitlab.com/zach_nation/coremltools/build-image-ubuntu-20.04:1.0.2
+  image: registry.gitlab.com/zach_nation/coremltools/build-image-ubuntu-18.04:1.0.2
   variables:
     PYTHON: "3.7"
 
 build_wheel_linux_py38:
   <<: *build_linux
-  image: registry.gitlab.com/zach_nation/coremltools/build-image-ubuntu-20.04:1.0.2
+  image: registry.gitlab.com/zach_nation/coremltools/build-image-ubuntu-18.04:1.0.2
   variables:
     PYTHON: "3.8"
 
@@ -214,7 +214,7 @@ build_documentation:
   tags:
     - docker
   stage: test
-  image: registry.gitlab.com/zach_nation/coremltools/build-image-ubuntu-20.04:1.0.0
+  image: registry.gitlab.com/zach_nation/coremltools/build-image-ubuntu-18.04:1.0.0
   script:
     - export PATH=$PATH:/opt/anaconda/bin/
     - bash -e scripts/build_docs.sh --wheel-path=${WHEEL_PATH} --python=${PYTHON}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,8 +80,13 @@ target_compile_definitions(modelpackage
 target_link_libraries(modelpackage
   mlmodel
   libprotobuf
-  stdc++fs
   )
+
+if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.1)
+  target_link_libraries(modelpackage
+    stdc++fs
+    )
+endif()
 
 if (APPLE)
   # Allow Python to be found at runtime instead of compile/link time

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ target_compile_definitions(modelpackage
 target_link_libraries(modelpackage
   mlmodel
   libprotobuf
+  stdc++fs
   )
 
 if (APPLE)

--- a/docker/Dockerfile-coremltools-linux
+++ b/docker/Dockerfile-coremltools-linux
@@ -1,5 +1,5 @@
 # An Ubuntu based image that is used for gitlab based ci infrastructure
-FROM ubuntu:20.04
+FROM ubuntu:18.04
 
 # Install dependencies, particularly libraries that python or CMake need
 RUN  apt-get -y update \

--- a/modelpackage/src/ModelPackage.cpp
+++ b/modelpackage/src/ModelPackage.cpp
@@ -15,7 +15,17 @@
 #include <sstream>
 #include <istream>
 #include <string>
+
+#if __has_include(<filesystem>)
 #include <filesystem>
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem> 
+namespace std {
+  namespace filesystem = std::experimental::filesystem;
+}
+#else
+#error "missing required header <filesystem>"
+#endif
 #include <uuid/uuid.h>
 #include <vector>
 


### PR DESCRIPTION
Fixes compatibility with Ubuntu 18.04 by:

* Downgrading our build image from 20.04 to 18.04
* Fall back to using `<experimental/filesystem>` for compatibility with the libstdc++ on 18.04, with corresponding linking to `stdc++fs`