### PR TITLE
Fix bug: support various type of batch_norm

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -1194,8 +1194,6 @@ def batch_norm(context, node):
     # helper functions for different type of batch norm
     def _add_batch_norm_dynamic():
         x = _input
-        shape = [1] * x.rank
-        shape[1] = -1 if any_symbolic(running_mean.shape) else running_mean.shape[0]
 
         if training:
             axes = [axis for axis in range(x.rank) if axis != 1]
@@ -1204,6 +1202,8 @@ def batch_norm(context, node):
             square = mb.mul(x=num, y=num)
             variance = mb.reduce_mean(x=square, axes=axes, keep_dims=True)
         else:
+            shape = [1] * x.rank
+            shape[1] = -1 if any_symbolic(running_mean.shape) else running_mean.shape[0]
             mean = mb.reshape(x=running_mean, shape=shape)
             num = mb.sub(x=x, y=mean)
             variance = mb.reshape(x=running_var, shape=shape)

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -246,26 +246,36 @@ class TestBatchNorm(TorchBaseTest):
             )
 
     @pytest.mark.parametrize(
-        "rank, num_features, eps, training, backend",
-        itertools.product([3, 4, 5], [5, 1], [0.1, 1e-05], [True, False], backends),
+        "rank, num_features, eps, running_vars_exist, training, backend",
+        itertools.product([3, 4, 5], [5, 1], [0.1, 1e-05], [True, False], [True, False], backends),
     )
-    def test_batchnorm_dynamic(self, rank, num_features, eps, training, backend):
+    def test_batchnorm_dynamic(self, rank, num_features, eps, running_vars_exist, training, backend):
         if backend != "neuralnetwork" and rank == 5 and num_features == 5:
             pytest.xfail("rdar://75770475 ([ActivateMIL] Failure in "
                          "test_ops_public_torch.py::TestBatchNorm::test_batchnorm_3d "
                          "[elementwise_kernel_cpu: Cannot broadcast])")
 
-        model = ModuleWrapper(
-            nn.functional.batch_norm,
-            {"training": training, "eps": eps,},
-        )
         input_shape = [6, num_features, 3, 4, 5]
         input_shape = input_shape[:rank]
         _input = torch.randn(*input_shape)
-        _mean = torch.randn(num_features)
-        _var = torch.randn(num_features)
 
-        inputs = (_input, _mean, _var)
+        if training == True and running_vars_exist == True:
+            _mean = None
+            _var = None
+            inputs = [_input]
+            model = ModuleWrapper(
+                nn.functional.batch_norm,
+                {"training": training, "eps": eps, "running_mean": _mean, "running_var": _var},
+            )
+        else:
+            _mean = torch.randn(num_features)
+            _var = torch.randn(num_features)
+            inputs = (_input, _mean, _var)
+            model = ModuleWrapper(
+                nn.functional.batch_norm,
+                {"training": training, "eps": eps,},
+            )
+
         expected_results = model(*inputs)
 
         self.run_compare_torch(

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -259,7 +259,7 @@ class TestBatchNorm(TorchBaseTest):
         input_shape = input_shape[:rank]
         _input = torch.randn(*input_shape)
 
-        if training == True and running_vars_exist == True:
+        if training and running_vars_exist:
             _mean = None
             _var = None
             inputs = [_input]


### PR DESCRIPTION
This fixes a bug when converting various types of batch_norm like from [StdConv2d](https://github.com/rwightman/pytorch-image-models/blob/766b4d32627fc4d1d9d188de81736504215127a0/timm/models/layers/std_conv.py#L26). Those batch norms doesn't have have `running_mean` or `running_var` and uses `training=True` so we can simply move two lines and can resolve the error.