### PR TITLE
Fix links to the Core ML Model Format Specification

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -54,6 +54,6 @@ For more information, see the following:
 * [Release Notes](https://github.com/apple/coremltools/releases/) for the current release and previous releases
 * [Guides and examples](https://coremltools.readme.io/) with installation and troubleshooting
 * [API Reference](https://apple.github.io/coremltools/index.html)
-* [Core ML Specification](https://mlmodel.readme.io/)
+* [Core ML Specification](https://apple.github.io/coremltools/mlmodel/index.html)
 * [Contribution Guidelines](CONTRIBUTING.md) for reporting issues and making requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,6 @@ For more information, see the following:
 * [Release Notes](https://github.com/apple/coremltools/releases/) for the current release and previous releases
 * [Guides and examples](https://coremltools.readme.io/) with installation and troubleshooting
 * [API Reference](https://apple.github.io/coremltools/index.html)
-* [Core ML Specification](https://mlmodel.readme.io/)
+* [Core ML Specification](https://apple.github.io/coremltools/mlmodel/index.html)
 * [Building from Source](BUILDING.md)
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To install coremltools, see the [“Installation“ page](https://coremltools.re
 * [Release Notes](https://github.com/apple/coremltools/releases/) 
 * [Guides and examples](https://coremltools.readme.io/) 
 * [API Reference](https://apple.github.io/coremltools/index.html)
-* [Core ML Specification](https://mlmodel.readme.io/)
+* [Core ML Specification](https://apple.github.io/coremltools/mlmodel/index.html)
 * [Building from Source](BUILDING.md)
 * [Contribution Guidelines](CONTRIBUTING.md) 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,5 +25,5 @@ This the API Reference for coremltools. For guides, installation instructions, a
    :caption: Resources
    
    Guides and examples <https://coremltools.readme.io/docs>
-   Core ML Format Specification <https://mlmodel.readme.io/reference>
+   Core ML Format Specification <https://apple.github.io/coremltools/mlmodel/index.html>
    GitHub <https://github.com/apple/coremltools>


### PR DESCRIPTION
This PR fixes links in documentation files to point to the new version of the [Core ML Model Format Specification](https://apple.github.io/coremltools/mlmodel/index.html). This includes:

```
README.md
BUILDING.md
CONTRIBUTING.md
docs/index.rst
```

See [preview](https://tonybove-apple.github.io/coremltools/index.html) on my fork.
