### PR TITLE
Add unit tests for flexible input shapes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -174,7 +174,7 @@ test_macos11_py37_mil:
     - build_wheel_macos_py37
   variables:
     PYTHON: "3.7"
-    TEST_PACKAGE: coremltools.converters.mil.mil
+    TEST_PACKAGE: coremltools.converters.mil
     WHEEL_PATH: build/dist/*cp37*10_16*
 
 #########################################################################

--- a/coremltools/converters/mil/backend/mil/passes/test_passes.py
+++ b/coremltools/converters/mil/backend/mil/passes/test_passes.py
@@ -724,6 +724,7 @@ class TestPassFuseActivationSiLU:
     input --> silu --> output
     """
 
+    @pytest.mark.skipif(ct.utils._macos_version() < (12, 0), reason="mlprogram predict available only on macOS12+")
     @pytest.mark.parametrize(
         "reverse_order", itertools.product([True, False]),
     )

--- a/coremltools/converters/mil/test_flexible_shape_inputs.py
+++ b/coremltools/converters/mil/test_flexible_shape_inputs.py
@@ -102,12 +102,9 @@ class TestFlexibleInputShapes:
         assert len(spec.description.input[0].type.multiArrayType.enumeratedShapes.shapes) == 3
         _assert_torch_coreml_output_shapes(model, spec, traced_model, example_input)
 
-    @pytest.mark.skipif(ct.utils._macos_version() < (12, 0), reason=MSG_TORCH_NOT_FOUND)
+    @pytest.mark.skipif(ct.utils._macos_version() < (12, 0), reason="Image input with RangeDim works correctly on macOS12+")
     @pytest.mark.parametrize("convert_to", ['neuralnetwork', 'mlprogram'])
     def test_image_input_rangedim(self, convert_to):
-        if convert_to == "mlprogram" and ct.utils._macos_version() < (12, 0):
-            return
-
         example_input = torch.rand(1, 3, 50, 50) * 255
         traced_model = torch.jit.trace(TestConvModule().eval(), example_input)
 

--- a/coremltools/coremltools/converters/mil/test_flexible_shape_inputs.py
+++ b/coremltools/coremltools/converters/mil/test_flexible_shape_inputs.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2021, Apple Inc. All rights reserved.
+#
+# Use of this source code is governed by a BSD-3-clause license that can be
+# found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+
+import coremltools as ct
+from coremltools._deps import _HAS_TORCH, MSG_TORCH_NOT_FOUND
+import numpy as np
+import PIL.Image
+import pytest
+
+if _HAS_TORCH:
+    import torch
+
+    class TestConvModule(torch.nn.Module):
+        def __init__(self, in_channels=3, out_channels=10, kernel_size=3):
+            super(TestConvModule, self).__init__()
+            self.conv = torch.nn.Conv2d(in_channels, out_channels,
+                                        kernel_size)
+        def forward(self, x):
+            return self.conv(x)
+
+def _numpy_array_to_pil_image(x):
+    """
+    convert x of shape (1, 3, H, W) to PIL image
+    """
+    assert len(x.shape) == 4
+    assert list(x.shape[:2]) == [1, 3]
+    x = x[0, :, :, :] # (3, H, W)
+    x = np.transpose(x, [1, 2, 0]) # (H, W, 3)
+    x = x.astype(np.uint8)
+    return PIL.Image.fromarray(x)
+
+def _assert_torch_coreml_output_shapes(coreml_model, spec, torch_model, torch_example_input, is_image_input=False):
+    torch_out = torch_model(torch_example_input)
+    input_name = spec.description.input[0].name
+    output_name = spec.description.output[0].name
+    input_dict = {}
+    if is_image_input:
+        input_dict[input_name] = _numpy_array_to_pil_image(torch_example_input.numpy())
+    else:
+        input_dict[input_name] = torch_example_input.numpy()
+    coreml_out = coreml_model.predict(input_dict)[output_name]
+    assert torch_out.shape == coreml_out.shape
+
+
+@pytest.mark.skipif(not _HAS_TORCH or not ct.utils._is_macos(), reason=MSG_TORCH_NOT_FOUND)
+class TestFlexibleInputShapes:
+
+    @pytest.mark.parametrize("convert_to", ['neuralnetwork', 'mlprogram'])
+    def test_multiarray_input_rangedim(self, convert_to):
+        if convert_to == "mlprogram" and ct.utils._macos_version() < (12, 0):
+            return
+
+        example_input = torch.rand(1, 3, 50, 50)
+        traced_model = torch.jit.trace(TestConvModule().eval(), example_input)
+
+        input_shape = ct.Shape(shape=(1, 3, ct.RangeDim(25, 100, default=45), ct.RangeDim(25, 100, default=45)))
+        model = ct.convert(traced_model,
+                           inputs=[ct.TensorType(shape=input_shape)],
+                           convert_to=convert_to)
+
+        spec = model.get_spec()
+        assert list(spec.description.input[0].type.multiArrayType.shape) == [1, 3, 45, 45]
+        assert spec.description.input[0].type.multiArrayType.shapeRange.sizeRanges[2].lowerBound == 25
+        assert spec.description.input[0].type.multiArrayType.shapeRange.sizeRanges[2].upperBound == 100
+        _assert_torch_coreml_output_shapes(model, spec, traced_model, example_input)
+
+    @pytest.mark.parametrize("convert_to", ['neuralnetwork', 'mlprogram'])
+    def test_multiarray_input_enumerated(self, convert_to):
+        if convert_to == "mlprogram" and ct.utils._macos_version() < (12, 0):
+            return
+
+        example_input = torch.rand(1, 3, 50, 50)
+        traced_model = torch.jit.trace(TestConvModule().eval(), example_input)
+
+        input_shape = ct.EnumeratedShapes(shapes=[[1, 3, 25, 25], [1, 3, 50, 50], [1, 3, 67, 67]],
+                                          default=[1, 3, 67, 67])
+        model = ct.convert(traced_model,
+                           inputs=[ct.TensorType(shape=input_shape)],
+                           convert_to=convert_to)
+
+        spec = model.get_spec()
+        assert list(spec.description.input[0].type.multiArrayType.shape) == [1, 3, 67, 67]
+        assert list(spec.description.input[0].type.multiArrayType.enumeratedShapes.shapes[0].shape) == [1, 3, 67, 67]
+        assert len(spec.description.input[0].type.multiArrayType.enumeratedShapes.shapes) == 3
+        _assert_torch_coreml_output_shapes(model, spec, traced_model, example_input)
+
+    @pytest.mark.skipif(ct.utils._macos_version() < (12, 0), reason=MSG_TORCH_NOT_FOUND)
+    @pytest.mark.parametrize("convert_to", ['neuralnetwork', 'mlprogram'])
+    def test_image_input_rangedim(self, convert_to):
+        if convert_to == "mlprogram" and ct.utils._macos_version() < (12, 0):
+            return
+
+        example_input = torch.rand(1, 3, 50, 50) * 255
+        traced_model = torch.jit.trace(TestConvModule().eval(), example_input)
+
+        input_shape = ct.Shape(shape=(1, 3, ct.RangeDim(25, 100, default=45), ct.RangeDim(25, 100, default=45)))
+        model = ct.convert(traced_model,
+                           inputs=[ct.ImageType(shape=input_shape)],
+                           convert_to=convert_to)
+
+        spec = model.get_spec()
+        assert spec.description.input[0].type.imageType.width == 45
+        assert spec.description.input[0].type.imageType.height == 45
+        assert spec.description.input[0].type.imageType.imageSizeRange.widthRange.lowerBound == 25
+        assert spec.description.input[0].type.imageType.imageSizeRange.widthRange.upperBound == 100
+        _assert_torch_coreml_output_shapes(model, spec, traced_model, example_input, is_image_input=True)
+
+    @pytest.mark.parametrize("convert_to", ['neuralnetwork', 'mlprogram'])
+    def test_image_input_enumerated(self, convert_to):
+        if convert_to == "mlprogram" and ct.utils._macos_version() < (12, 0):
+            return
+
+        example_input = torch.rand(1, 3, 50, 50) * 255
+        traced_model = torch.jit.trace(TestConvModule().eval(), example_input)
+
+        input_shape = ct.EnumeratedShapes(shapes=[[1, 3, 25, 25], [1, 3, 50, 50], [1, 3, 67, 67]],
+                                          default=[1, 3, 67, 67])
+        model = ct.convert(traced_model,
+                           inputs=[ct.ImageType(shape=input_shape)],
+                           convert_to=convert_to)
+
+        spec = model.get_spec()
+        assert spec.description.input[0].type.imageType.width == 67
+        assert spec.description.input[0].type.imageType.height == 67
+        assert len(spec.description.input[0].type.imageType.enumeratedSizes.sizes) == 3
+        assert spec.description.input[0].type.imageType.enumeratedSizes.sizes[0].width == 25
+        assert spec.description.input[0].type.imageType.enumeratedSizes.sizes[0].height == 25
+        _assert_torch_coreml_output_shapes(model, spec, traced_model, example_input, is_image_input=True)
+
+
+
+
+

--- a/coremltools/models/neural_network/flexible_shape_utils.py
+++ b/coremltools/models/neural_network/flexible_shape_utils.py
@@ -436,10 +436,13 @@ def add_enumerated_image_sizes(spec, feature_name, sizes):
         fixed_width = feature.type.imageType.width
         sizes.append(NeuralNetworkImageSize(fixed_height, fixed_width))
 
+    shapes_added_so_far = []
     for size in sizes:
-        s = feature.type.imageType.enumeratedSizes.sizes.add()
-        s.height = size.height
-        s.width = size.width
+        if [size.height, size.width] not in shapes_added_so_far:
+            s = feature.type.imageType.enumeratedSizes.sizes.add()
+            s.height = size.height
+            s.width = size.width
+            shapes_added_so_far.append([s.height, s.width])
 
     # Bump up specification version
     spec.specificationVersion = max(
@@ -712,18 +715,23 @@ def add_multiarray_ndshape_enumeration(spec, feature_name, enumerated_shapes):
 
     eshape_len = len(feature.type.multiArrayType.enumeratedShapes.shapes)
 
+    shapes_added_so_far = []
+
     # Add default array shape to list of enumerated shapes if enumerated shapes
     # field is currently empty
     if eshape_len == 0:
         fixed_shape = feature.type.multiArrayType.shape
         s = feature.type.multiArrayType.enumeratedShapes.shapes.add()
         s.shape.extend(fixed_shape)
+        shapes_added_so_far.append(list(fixed_shape))
 
     for shape in enumerated_shapes:
         if not isinstance(shape, tuple):
             raise Exception("An element in 'enumerated_shapes' is not a tuple")
-        s = feature.type.multiArrayType.enumeratedShapes.shapes.add()
-        s.shape.extend(list(shape))
+        if list(shape) not in shapes_added_so_far:
+            s = feature.type.multiArrayType.enumeratedShapes.shapes.add()
+            s.shape.extend(list(shape))
+            shapes_added_so_far.append(list(shape))
 
     # Bump up specification version
     spec.specificationVersion = max(


### PR DESCRIPTION
Add tests for 4 combinations, of using flexible shapes with unified converter API: 
(https://coremltools.readme.io/docs/flexible-inputs)
- multiarray input + rangeDim
- multiarray input + enumerated shapes 
- image input + rangeDim
- image input + enumerated shapes

All the 4 tests pass on mac OS Monterey. 
The "image input + rangeDim" combination had a bug in Core ML Framework in mac OS Big Sur, which has been fixed in mac OS Monterey. 


In addition to the unit tests, there is a change in the flexible shape utils file, to make sure that the same shape does not get added twice to the enumerated set. This however has no effect on the correctness of the models with enumerated shapes, even if they repeat the model performs correctly. 

Related issues: #992 , #1249 