### PR TITLE
edit docs for v5.0b3 and regenerate API Reference

### DIFF
--- a/coremltools/converters/_converters_entry.py
+++ b/coremltools/converters/_converters_entry.py
@@ -78,11 +78,11 @@ def convert(
             - Path to a ``.pt`` file
 
     source : str (optional)
-        One of [``auto``, ``tensorflow``, ``pytorch``, ``milinternal``]. `auto`
+        One of [``auto``, ``tensorflow``, ``pytorch``, ``milinternal``]. ``auto``
         determines the framework automatically for most cases. Raises
         ``ValueError`` if it fails to determine the source framework.
 
-    inputs : list of `TensorType` or `ImageType`
+    inputs : list of ``TensorType`` or ``ImageType``
 
         TensorFlow 1 and 2:
             - The ``inputs`` parameter is optional. If not provided, the inputs
@@ -188,13 +188,13 @@ def convert(
                       coremltools.transform.FP16ComputePrecision(op_selector=
                                                              lambda op:True)
 
-                  The above transfomr injects ``cast`` ops to convert the
+                  The above transform injects ``cast`` ops to convert the
                   float32 dtypes of intermediate tensors to float16.
             - ``coremltools.precision.FLOAT32``
                 - No transform is applied. The original float32 tensor dtype in
                   the source model is preserved.
             - ``coremltools.transform.FP16ComputePrecision(op_selector=...)``
-                - Use the above to control which tensors get cast to float16.
+                - Use the above to control which tensors are cast to float16.
                 - For example:
                   ::
                       coremltools.transform.FP16ComputePrecision(op_selector=
@@ -203,14 +203,16 @@ def convert(
                   The above casts all the float32 tensors to be float16, except
                   the input/output tensors to any ``linear`` op.
             - If ``None``,
-                - when convert_to="mlprogram", compute_precision parameter defaults to ``coremltools.precision.FLOAT16``.
-                - when convert_to="neuralnetwork", compute_precision parameter needs to be None and has no meaning.
+                - When ``convert_to="mlprogram"``, compute_precision parameter
+                  defaults to ``coremltools.precision.FLOAT16``.
+                - When ``convert_to="neuralnetwork"``, compute_precision parameter
+                  needs to be ``None`` and has no meaning.
 
     skip_model_load : bool
         Set to True to prevent coremltools from calling into the Core ML framework
         to compile and load the model, post-conversion. In that case, the returned
         model object cannot be used to make a prediction, but can be used to save
-        via "model.save()". This flag may be used to convert to a newer model type
+        via ``"model.save()"``. This flag may be used to convert to a newer model type
         on an older Mac, which if done without turning this flag on, may raise a
         runtime warning.
         Example: Use this flag to suppress runtime warning when converting to
@@ -219,12 +221,12 @@ def convert(
         Defaults to False.
 
     compute_units: coremltools.ComputeUnit
-        A enum with three possible values:
-            - coremltools.ComputeUnit.ALL - use all compute units available, including the
-                  neural engine.
-            - coremltools.ComputeUnit.CPU_ONLY - limit the model to only use the CPU.
-            - coremltools.ComputeUnit.CPU_AND_GPU - use both the CPU and GPU, but not the
-                  neural engine.
+        An enum with three possible values:
+            - `coremltools.ComputeUnit.ALL`: Use all compute units available, including the
+              neural engine.
+            - `coremltools.ComputeUnit.CPU_ONLY`: Limit the model to only use the CPU.
+            - `coremltools.ComputeUnit.CPU_AND_GPU`: Use both the CPU and GPU, but not the
+              neural engine.
 
     Returns
     -------

--- a/coremltools/converters/_converters_entry.py
+++ b/coremltools/converters/_converters_entry.py
@@ -215,9 +215,11 @@ def convert(
         via ``"model.save()"``. This flag may be used to convert to a newer model type
         on an older Mac, which if done without turning this flag on, may raise a
         runtime warning.
+        
         Example: Use this flag to suppress runtime warning when converting to
         ML program model type on a macOS 11, since ML program
         can only be compiled and loaded from macOS12+.
+        
         Defaults to False.
 
     compute_units: coremltools.ComputeUnit

--- a/coremltools/converters/_converters_entry.py
+++ b/coremltools/converters/_converters_entry.py
@@ -222,10 +222,10 @@ def convert(
 
     compute_units: coremltools.ComputeUnit
         An enum with three possible values:
-            - `coremltools.ComputeUnit.ALL`: Use all compute units available, including the
+            - ``coremltools.ComputeUnit.ALL``: Use all compute units available, including the
               neural engine.
-            - `coremltools.ComputeUnit.CPU_ONLY`: Limit the model to only use the CPU.
-            - `coremltools.ComputeUnit.CPU_AND_GPU`: Use both the CPU and GPU, but not the
+            - ``coremltools.ComputeUnit.CPU_ONLY``: Limit the model to only use the CPU.
+            - ``coremltools.ComputeUnit.CPU_AND_GPU``: Use both the CPU and GPU, but not the
               neural engine.
 
     Returns

--- a/coremltools/models/model.py
+++ b/coremltools/models/model.py
@@ -227,21 +227,21 @@ class MLModel(object):
 
         compute_units: coremltools.ComputeUnit
             An enum with three possible values:
-                - `coremltools.ComputeUnit.ALL`: Use all compute units available, including the
-                      neural engine.
-                - `coremltools.ComputeUnit.CPU_ONLY`: Limit the model to only use the CPU.
-                - `coremltools.ComputeUnit.CPU_AND_GPU`: Use both the CPU and GPU,
+                - ``coremltools.ComputeUnit.ALL``: Use all compute units available, including the
+                  neural engine.
+                - ``coremltools.ComputeUnit.CPU_ONLY``: Limit the model to only use the CPU.
+                - ``coremltools.ComputeUnit.CPU_AND_GPU``: Use both the CPU and GPU,
                   but not the neural engine.
 
         Notes
         -----
         Internally this maintains the following:
 
-        - `_MLModelProxy`: A pybind wrapper around
+        - ``_MLModelProxy``: A pybind wrapper around
           CoreML::Python::Model (see
-          [`coremltools/coremlpython/CoreMLPython.mm`](https://github.com/apple/coremltools/blob/main/coremlpython/CoreMLPython.mm))
+          `coremltools/coremlpython/CoreMLPython.mm <https://github.com/apple/coremltools/blob/main/coremlpython/CoreMLPython.mm`_)
 
-        - `bundle_path` (MIL only): Directory containing all artifacts (`.mlmodel`,
+        - ``bundle_path`` (MIL only): Directory containing all artifacts (`.mlmodel`,
           weights etc).
 
         Examples
@@ -403,8 +403,8 @@ class MLModel(object):
         useCPUOnly: bool
             This parameter is deprecated and will be removed in 6.0. Instead use the `compute_units`
             parameter at load time or conversion time (that is, in
-            [`coremltools.models.MLModel()`](https://apple.github.io/coremltools/source/coremltools.models.html#module-coremltools.models.model) or
-            [`coremltools.convert()`](https://apple.github.io/coremltools/source/coremltools.converters.mil.html#module-coremltools.converters._converters_entry)).
+            `coremltools.models.MLModel() <https://apple.github.io/coremltools/source/coremltools.models.html#module-coremltools.models.model>`_ or
+            `coremltools.convert() <(https://apple.github.io/coremltools/source/coremltools.converters.mil.html#module-coremltools.converters._converters_entry>`).
 
             Set to True to restrict computation to use only the CPU. Defaults to False.
 

--- a/coremltools/models/model.py
+++ b/coremltools/models/model.py
@@ -188,16 +188,16 @@ class MLModel(object):
                  skip_model_load=False,
                  compute_units=_ComputeUnit.ALL):
         """
-        Construct an MLModel from an .mlmodel
+        Construct an MLModel from an ``.mlmodel``.
 
         Parameters
         ----------
         model: str or Model_pb2
 
-            For MIL, model must be path string to directory containing bundle
-            artifacts (e.g. ``weights.bin``).
+            For MIL, the model must be a path string to the directory containing bundle
+            artifacts (such as ``weights.bin``).
 
-            For NeuralNetwork, model can be path string (``.mlmodel``) or ``Model_pb2``.
+            For NeuralNetwork, the model can be a path string (``.mlmodel``) or ``Model_pb2``.
 
         useCPUOnly: bool
             This parameter is deprecated and will be removed in 6.0. Use the ``compute_units``
@@ -205,15 +205,15 @@ class MLModel(object):
 
             The ``compute_units`` parameter overrides any usages of this parameter.
 
-            Set to true to restrict loading of model on CPU Only. Defaults to False.
+            Set to True to restrict loading of the model to only the CPU. Defaults to False.
 
         is_temp_package: bool
             Set to true if the input model package dir is temporary and can be
             deleted upon destruction of this class.
 
         mil_program: coremltools.converters.mil.Program
-            Set to the ``mil`` program object, if available.
-            It is avaiable whenever an MLModel object is constructed using
+            Set to the MIL program object, if available.
+            It is available whenever an MLModel object is constructed using
             the unified converter API `coremltools.convert() <https://apple.github.io/coremltools/source/coremltools.converters.mil.html#module-coremltools.converters._converters_entry>`_.
 
         skip_model_load: bool
@@ -222,8 +222,8 @@ class MLModel(object):
             be used to make a prediction. This flag may be used to load a newer model
             type on an older Mac, to inspect or load/save the spec.
             
-            Example: Loading ML Program model type on a macOS 11, since ML Program can only be
-            compiled and loaded from macOS12+.
+            Example: Loading an ML Program model type on a macOS 11, since an ML Program can be
+            compiled and loaded only from macOS12+.
             
             Defaults to False.
 
@@ -244,7 +244,7 @@ class MLModel(object):
           `coremltools/coremlpython/CoreMLPython.mm <https://github.com/apple/coremltools/blob/main/coremlpython/CoreMLPython.mm>`_)
 
         - ``bundle_path`` (MIL only): Directory containing all artifacts (``.mlmodel``,
-          ``weights``, etc).
+          weights, and so on).
 
         Examples
         --------
@@ -349,14 +349,14 @@ class MLModel(object):
 
     def save(self, filename):
         """
-        Save the model to a `.mlmodel` format. For MIL program filename is
-        package directory containing the mlmodel and weights
+        Save the model to a ``.mlmodel`` format. For an MIL program, the filename is
+        a package directory containing the ``mlmodel`` and weights.
 
         Parameters
         ----------
         filename: str
             Target filename / bundle directory for the model. Must have the
-            `.mlmodel` extension
+            ``.mlmodel`` extension
 
         Examples
         --------
@@ -403,7 +403,7 @@ class MLModel(object):
             the names of the input features.
 
         useCPUOnly: bool
-            This parameter is deprecated and will be removed in 6.0. Instead use the `compute_units`
+            This parameter is deprecated and will be removed in 6.0. Instead, use the ``compute_units``
             parameter at load time or conversion time (that is, in
             `coremltools.models.MLModel() <https://apple.github.io/coremltools/source/coremltools.models.html#module-coremltools.models.model>`_ or
             `coremltools.convert() <https://apple.github.io/coremltools/source/coremltools.converters.mil.html#module-coremltools.converters._converters_entry>`_).
@@ -478,7 +478,7 @@ class MLModel(object):
 
     def _get_mil_internal(self):
         """
-        Get a deep copy of the `mil` program object, if available.
+        Get a deep copy of the MIL program object, if available.
         It's available whenever an MLModel object is constructed using
         the unified converter API [`coremltools.convert()`](https://apple.github.io/coremltools/source/coremltools.converters.mil.html#coremltools.converters._converters_entry.convert).
 

--- a/coremltools/models/model.py
+++ b/coremltools/models/model.py
@@ -188,7 +188,7 @@ class MLModel(object):
                  skip_model_load=False,
                  compute_units=_ComputeUnit.ALL):
         """
-        Construct an MLModel from a .mlmodel
+        Construct an MLModel from an .mlmodel
 
         Parameters
         ----------
@@ -197,7 +197,7 @@ class MLModel(object):
             For MIL, model must be path string to directory containing bundle
             artifacts (e.g. weights.bin).
 
-            For NeuralNetwork, model can be path string (.mlmodel) or Model_pb2.
+            For NeuralNetwork, model can be path string (`.mlmodel`) or Model_pb2.
 
         useCPUOnly: bool
             This parameter is deprecated and will be removed in 6.0. Use the `compute_units`
@@ -226,22 +226,22 @@ class MLModel(object):
             Defaults to False.
 
         compute_units: coremltools.ComputeUnit
-            A enum with three possible values:
-                - coremltools.ComputeUnit.ALL - use all compute units available, including the
+            An enum with three possible values:
+                - `coremltools.ComputeUnit.ALL`: Use all compute units available, including the
                       neural engine.
-                - coremltools.ComputeUnit.CPU_ONLY - limit the model to only use the CPU.
-                - coremltools.ComputeUnit.CPU_AND_GPU - use both the CPU and GPU, but not the
-                      neural engine.
+                - `coremltools.ComputeUnit.CPU_ONLY`: Limit the model to only use the CPU.
+                - `coremltools.ComputeUnit.CPU_AND_GPU`: Use both the CPU and GPU,
+                  but not the neural engine.
 
         Notes
         -----
         Internally this maintains the following:
 
-        - `_MLModelProxy`: a pybind wrapper around
+        - `_MLModelProxy`: A pybind wrapper around
           CoreML::Python::Model (see
-          `coremltools/coremlpython/CoreMLPython.mm`)
+          [`coremltools/coremlpython/CoreMLPython.mm`](https://github.com/apple/coremltools/blob/main/coremlpython/CoreMLPython.mm))
 
-        - `bundle_path` (MIL only): directory containing all artifacts (.mlmodel,
+        - `bundle_path` (MIL only): Directory containing all artifacts (`.mlmodel`,
           weights etc).
 
         Examples
@@ -347,18 +347,14 @@ class MLModel(object):
 
     def save(self, filename):
         """
-        Save the model to a .mlmodel format. For MIL program filename is
+        Save the model to a `.mlmodel` format. For MIL program filename is
         package directory containing the mlmodel and weights
 
         Parameters
         ----------
         filename: str
-            Target filename / bundle directory for the model. Must have
+            Target filename / bundle directory for the model. Must have the
             `.mlmodel` extension
-
-        See Also
-        --------
-        coremltools.utils.load_model
 
         Examples
         --------
@@ -395,7 +391,7 @@ class MLModel(object):
 
     def predict(self, data, useCPUOnly=False, **kwargs):
         """
-        Return predictions for the model. The kwargs gets passed into the
+        Return predictions for the model. The kwargs are passed into the
         model as a dictionary.
 
         Parameters
@@ -406,8 +402,9 @@ class MLModel(object):
 
         useCPUOnly: bool
             This parameter is deprecated and will be removed in 6.0. Instead use the `compute_units`
-            parameter at load time or conversion time, i.e. in `coremltools.models.MLModel()` or
-            `coremltools.convert()`.
+            parameter at load time or conversion time (that is, in
+            [`coremltools.models.MLModel()`](https://apple.github.io/coremltools/source/coremltools.models.html#module-coremltools.models.model) or
+            [`coremltools.convert()`](https://apple.github.io/coremltools/source/coremltools.converters.mil.html#module-coremltools.converters._converters_entry)).
 
             Set to True to restrict computation to use only the CPU. Defaults to False.
 
@@ -479,9 +476,9 @@ class MLModel(object):
 
     def _get_mil_internal(self):
         """
-        Get a deep copy of the mil program object, if avaiable.
-        Its avaiable whenever an MLModel object is constructed using
-        the unified converter API coremltools.convert()
+        Get a deep copy of the `mil` program object, if available.
+        It's available whenever an MLModel object is constructed using
+        the unified converter API [`coremltools.convert()`](https://apple.github.io/coremltools/source/coremltools.converters.mil.html#coremltools.converters._converters_entry.convert).
 
         Returns
         -------

--- a/coremltools/models/model.py
+++ b/coremltools/models/model.py
@@ -195,15 +195,15 @@ class MLModel(object):
         model: str or Model_pb2
 
             For MIL, model must be path string to directory containing bundle
-            artifacts (e.g. weights.bin).
+            artifacts (e.g. ``weights.bin``).
 
-            For NeuralNetwork, model can be path string (`.mlmodel`) or Model_pb2.
+            For NeuralNetwork, model can be path string (``.mlmodel``) or ``Model_pb2``.
 
         useCPUOnly: bool
-            This parameter is deprecated and will be removed in 6.0. Use the `compute_units`
+            This parameter is deprecated and will be removed in 6.0. Use the ``compute_units``
             parameter instead.
 
-            The `compute_units` parameter overrides any usages of this parameter.
+            The ``compute_units`` parameter overrides any usages of this parameter.
 
             Set to true to restrict loading of model on CPU Only. Defaults to False.
 
@@ -212,17 +212,19 @@ class MLModel(object):
             deleted upon destruction of this class.
 
         mil_program: coremltools.converters.mil.Program
-            Set to the mil program object, if available.
+            Set to the ``mil`` program object, if available.
             It is avaiable whenever an MLModel object is constructed using
-            the unified converter API coremltools.convert()
+            the unified converter API `coremltools.convert() <https://apple.github.io/coremltools/source/coremltools.converters.mil.html#module-coremltools.converters._converters_entry>`_.
 
         skip_model_load: bool
             Set to True to prevent coremltools from calling into the Core ML framework
             to compile and load the model. In that case, the returned model object cannot
             be used to make a prediction. This flag may be used to load a newer model
             type on an older Mac, to inspect or load/save the spec.
+            
             Example: Loading ML Program model type on a macOS 11, since ML Program can only be
             compiled and loaded from macOS12+.
+            
             Defaults to False.
 
         compute_units: coremltools.ComputeUnit
@@ -239,10 +241,10 @@ class MLModel(object):
 
         - ``_MLModelProxy``: A pybind wrapper around
           CoreML::Python::Model (see
-          `coremltools/coremlpython/CoreMLPython.mm <https://github.com/apple/coremltools/blob/main/coremlpython/CoreMLPython.mm`_)
+          `coremltools/coremlpython/CoreMLPython.mm <https://github.com/apple/coremltools/blob/main/coremlpython/CoreMLPython.mm>`_)
 
-        - ``bundle_path`` (MIL only): Directory containing all artifacts (`.mlmodel`,
-          weights etc).
+        - ``bundle_path`` (MIL only): Directory containing all artifacts (``.mlmodel``,
+          ``weights``, etc).
 
         Examples
         --------
@@ -404,7 +406,7 @@ class MLModel(object):
             This parameter is deprecated and will be removed in 6.0. Instead use the `compute_units`
             parameter at load time or conversion time (that is, in
             `coremltools.models.MLModel() <https://apple.github.io/coremltools/source/coremltools.models.html#module-coremltools.models.model>`_ or
-            `coremltools.convert() <(https://apple.github.io/coremltools/source/coremltools.converters.mil.html#module-coremltools.converters._converters_entry>`).
+            `coremltools.convert() <https://apple.github.io/coremltools/source/coremltools.converters.mil.html#module-coremltools.converters._converters_entry>`_).
 
             Set to True to restrict computation to use only the CPU. Defaults to False.
 

--- a/coremltools/models/tree_ensemble.py
+++ b/coremltools/models/tree_ensemble.py
@@ -258,6 +258,9 @@ class TreeEnsembleRegressor(TreeEnsembleBase):
 
     Examples
     --------
+    
+    In the following example, the code saves the model to disk, which is a
+    recommended practice but not required.
 
     .. sourcecode:: python
 
@@ -343,6 +346,9 @@ class TreeEnsembleClassifier(TreeEnsembleBase):
 
     Examples
     --------
+
+    In the following example, the code saves the model to disk, which is a
+    recommended practice but not required.
 
     .. sourcecode:: python
 


### PR DESCRIPTION
This PR includes the following documentation changes:

* `coremltools/converters/_converters_entry.py`: Minor editing around 5.0b3 changes.
* `coremltools/models/model.py`: Minor editing around 5.0b3 changes.
* `coremltools/models/tree_ensemble.py`: Clarification for example 
(Radar: fix: rdar://81798525 (Coremltools documentation | Example in tutorial))

Note: 2 fix-up commits added to fix some formatting errors.

This PR does _not_ include the generated HTML. After these changes are
reviewed and merged, I will do a separate PR to merge the HTML.

Preview: https://tonybove-apple.github.io/coremltools/index.html
