### PR TITLE
Refactor deprecated unittest aliases for Python 3.11 compatibility.

### DIFF
--- a/coremltools/test/neural_network/test_custom_neural_nets.py
+++ b/coremltools/test/neural_network/test_custom_neural_nets.py
@@ -82,7 +82,7 @@ class SimpleTest(unittest.TestCase):
         coreml_input = {"data": X}
         if _is_macos() and _macos_version() >= (10, 13):
             coreml_preds = coreml_model.predict(coreml_input)["output"]
-            self.assertEquals(len(coreml_preds.flatten()), 2)
+            self.assertEqual(len(coreml_preds.flatten()), 2)
 
         if os.path.exists(model_dir):
             shutil.rmtree(model_dir)

--- a/coremltools/test/neural_network/test_keras.py
+++ b/coremltools/test/neural_network/test_keras.py
@@ -48,11 +48,11 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
         self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
-        self.assertEquals(len(spec.description.output), len(output_names))
+        self.assertEqual(len(spec.description.output), len(output_names))
         self.assertCountEqual(
             self, output_names, [x.name for x in spec.description.output]
         )
@@ -104,11 +104,11 @@ class KerasSingleLayerTest(unittest.TestCase):
             self.assertTrue(spec.HasField("neuralNetwork"))
 
             # Test the inputs and outputs
-            self.assertEquals(len(spec.description.input), len(input_names))
+            self.assertEqual(len(spec.description.input), len(input_names))
             self.assertCountEqual(
                 self, input_names, [x.name for x in spec.description.input]
             )
-            self.assertEquals(len(spec.description.output), len(output_names))
+            self.assertEqual(len(spec.description.output), len(output_names))
             self.assertCountEqual(
                 self, output_names, [x.name for x in spec.description.output]
             )
@@ -140,11 +140,11 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
         self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
-        self.assertEquals(len(spec.description.output), len(output_names))
+        self.assertEqual(len(spec.description.output), len(output_names))
         self.assertCountEqual(
             self, output_names, [x.name for x in spec.description.output]
         )
@@ -178,11 +178,11 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
         self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
-        self.assertEquals(len(spec.description.output), len(output_names))
+        self.assertEqual(len(spec.description.output), len(output_names))
         self.assertCountEqual(
             self, output_names, [x.name for x in spec.description.output]
         )
@@ -191,7 +191,7 @@ class KerasSingleLayerTest(unittest.TestCase):
         layers = spec.neuralNetwork.layers
         layer_0 = layers[0]
         self.assertIsNotNone(layer_0.innerProduct)
-        self.assertEquals(len(layers), 2)
+        self.assertEqual(len(layers), 2)
 
     def test_convolution(self):
         """
@@ -225,11 +225,11 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
         self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
-        self.assertEquals(len(spec.description.output), len(output_names))
+        self.assertEqual(len(spec.description.output), len(output_names))
         self.assertCountEqual(
             self, output_names, [x.name for x in spec.description.output]
         )
@@ -261,11 +261,11 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
         self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
-        self.assertEquals(len(spec.description.output), len(output_names))
+        self.assertEqual(len(spec.description.output), len(output_names))
         self.assertCountEqual(
             self, output_names, [x.name for x in spec.description.output]
         )
@@ -311,11 +311,11 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
         self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
-        self.assertEquals(len(spec.description.output), len(output_names))
+        self.assertEqual(len(spec.description.output), len(output_names))
         self.assertCountEqual(
             self, output_names, [x.name for x in spec.description.output]
         )
@@ -345,11 +345,11 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
         self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
-        self.assertEquals(len(spec.description.output), len(output_names))
+        self.assertEqual(len(spec.description.output), len(output_names))
         self.assertCountEqual(
             self, output_names, [x.name for x in spec.description.output]
         )
@@ -382,24 +382,24 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names) + 2)
+        self.assertEqual(len(spec.description.input), len(input_names) + 2)
 
-        self.assertEquals(32, spec.description.input[1].type.multiArrayType.shape[0])
-        self.assertEquals(32, spec.description.input[2].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.input[1].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.input[2].type.multiArrayType.shape[0])
 
-        self.assertEquals(len(spec.description.output), len(output_names) + 2)
-        self.assertEquals(output_names[0], spec.description.output[0].name)
-        self.assertEquals(32, spec.description.output[0].type.multiArrayType.shape[0])
+        self.assertEqual(len(spec.description.output), len(output_names) + 2)
+        self.assertEqual(output_names[0], spec.description.output[0].name)
+        self.assertEqual(32, spec.description.output[0].type.multiArrayType.shape[0])
 
-        self.assertEquals(32, spec.description.output[1].type.multiArrayType.shape[0])
-        self.assertEquals(32, spec.description.output[2].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.output[1].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.output[2].type.multiArrayType.shape[0])
 
         # Test the layer parameters.
         layers = spec.neuralNetwork.layers
         layer_0 = layers[0]
         self.assertIsNotNone(layer_0.uniDirectionalLSTM)
-        self.assertEquals(len(layer_0.input), 3)
-        self.assertEquals(len(layer_0.output), 3)
+        self.assertEqual(len(layer_0.input), 3)
+        self.assertEqual(len(layer_0.output), 3)
 
     def test_simple_rnn(self):
         """
@@ -421,22 +421,22 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names) + 1)
-        self.assertEquals(input_names[0], spec.description.input[0].name)
+        self.assertEqual(len(spec.description.input), len(input_names) + 1)
+        self.assertEqual(input_names[0], spec.description.input[0].name)
 
-        self.assertEquals(32, spec.description.input[1].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.input[1].type.multiArrayType.shape[0])
 
-        self.assertEquals(len(spec.description.output), len(output_names) + 1)
-        self.assertEquals(output_names[0], spec.description.output[0].name)
-        self.assertEquals(32, spec.description.output[0].type.multiArrayType.shape[0])
-        self.assertEquals(32, spec.description.output[1].type.multiArrayType.shape[0])
+        self.assertEqual(len(spec.description.output), len(output_names) + 1)
+        self.assertEqual(output_names[0], spec.description.output[0].name)
+        self.assertEqual(32, spec.description.output[0].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.output[1].type.multiArrayType.shape[0])
 
         # Test the layer parameters.
         layers = spec.neuralNetwork.layers
         layer_0 = layers[0]
         self.assertIsNotNone(layer_0.simpleRecurrent)
-        self.assertEquals(len(layer_0.input), 2)
-        self.assertEquals(len(layer_0.output), 2)
+        self.assertEqual(len(layer_0.input), 2)
+        self.assertEqual(len(layer_0.output), 2)
 
     def test_gru(self):
         """
@@ -458,22 +458,22 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names) + 1)
-        self.assertEquals(input_names[0], spec.description.input[0].name)
+        self.assertEqual(len(spec.description.input), len(input_names) + 1)
+        self.assertEqual(input_names[0], spec.description.input[0].name)
 
-        self.assertEquals(32, spec.description.input[1].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.input[1].type.multiArrayType.shape[0])
 
-        self.assertEquals(len(spec.description.output), len(output_names) + 1)
-        self.assertEquals(output_names[0], spec.description.output[0].name)
-        self.assertEquals(32, spec.description.output[0].type.multiArrayType.shape[0])
-        self.assertEquals(32, spec.description.output[1].type.multiArrayType.shape[0])
+        self.assertEqual(len(spec.description.output), len(output_names) + 1)
+        self.assertEqual(output_names[0], spec.description.output[0].name)
+        self.assertEqual(32, spec.description.output[0].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.output[1].type.multiArrayType.shape[0])
 
         # Test the layer parameters.
         layers = spec.neuralNetwork.layers
         layer_0 = layers[0]
         self.assertIsNotNone(layer_0.gru)
-        self.assertEquals(len(layer_0.input), 2)
-        self.assertEquals(len(layer_0.output), 2)
+        self.assertEqual(len(layer_0.input), 2)
+        self.assertEqual(len(layer_0.output), 2)
 
     def test_bidir(self):
         """
@@ -498,29 +498,29 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names) + 4)
-        self.assertEquals(input_names[0], spec.description.input[0].name)
+        self.assertEqual(len(spec.description.input), len(input_names) + 4)
+        self.assertEqual(input_names[0], spec.description.input[0].name)
 
-        self.assertEquals(32, spec.description.input[1].type.multiArrayType.shape[0])
-        self.assertEquals(32, spec.description.input[2].type.multiArrayType.shape[0])
-        self.assertEquals(32, spec.description.input[3].type.multiArrayType.shape[0])
-        self.assertEquals(32, spec.description.input[4].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.input[1].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.input[2].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.input[3].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.input[4].type.multiArrayType.shape[0])
 
-        self.assertEquals(len(spec.description.output), len(output_names) + 4)
-        self.assertEquals(output_names[0], spec.description.output[0].name)
-        self.assertEquals(64, spec.description.output[0].type.multiArrayType.shape[0])
+        self.assertEqual(len(spec.description.output), len(output_names) + 4)
+        self.assertEqual(output_names[0], spec.description.output[0].name)
+        self.assertEqual(64, spec.description.output[0].type.multiArrayType.shape[0])
 
-        self.assertEquals(32, spec.description.output[1].type.multiArrayType.shape[0])
-        self.assertEquals(32, spec.description.output[2].type.multiArrayType.shape[0])
-        self.assertEquals(32, spec.description.output[3].type.multiArrayType.shape[0])
-        self.assertEquals(32, spec.description.output[4].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.output[1].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.output[2].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.output[3].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.output[4].type.multiArrayType.shape[0])
 
         # Test the layer parameters.
         layers = spec.neuralNetwork.layers
         layer_0 = layers[0]
         self.assertIsNotNone(layer_0.biDirectionalLSTM)
-        self.assertEquals(len(layer_0.input), 5)
-        self.assertEquals(len(layer_0.output), 5)
+        self.assertEqual(len(layer_0.input), 5)
+        self.assertEqual(len(layer_0.output), 5)
 
     def test_embedding(self):
         from keras.layers import Embedding
@@ -542,17 +542,17 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
 
         # Test the layer parameters.
         layers = spec.neuralNetwork.layers
         layer_0 = layers[0]
         self.assertIsNotNone(layer_0.embedding)
 
-        self.assertEquals(layer_0.embedding.inputDim, num_inputs)
-        self.assertEquals(layer_0.embedding.outputChannels, num_outputs)
+        self.assertEqual(layer_0.embedding.inputDim, num_inputs)
+        self.assertEqual(layer_0.embedding.outputChannels, num_outputs)
 
-        self.assertEquals(
+        self.assertEqual(
             len(layer_0.embedding.weights.floatValue), num_inputs * num_outputs
         )
 
@@ -589,11 +589,11 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
         self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
-        self.assertEquals(len(spec.description.output), len(output_names))
+        self.assertEqual(len(spec.description.output), len(output_names))
         self.assertCountEqual(
             self, output_names, [x.name for x in spec.description.output]
         )
@@ -624,11 +624,11 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
         self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
-        self.assertEquals(len(spec.description.output), len(output_names))
+        self.assertEqual(len(spec.description.output), len(output_names))
         self.assertCountEqual(
             self, output_names, [x.name for x in spec.description.output]
         )
@@ -674,11 +674,11 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
         self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
-        self.assertEquals(len(spec.description.output), len(output_names))
+        self.assertEqual(len(spec.description.output), len(output_names))
         self.assertCountEqual(
             self, output_names, [x.name for x in spec.description.output]
         )
@@ -702,11 +702,11 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertIsNotNone(spec.description)
         self.assertTrue(spec.HasField("neuralNetwork"))
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
         self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
-        self.assertEquals(len(spec.description.output), len(output_names))
+        self.assertEqual(len(spec.description.output), len(output_names))
         self.assertCountEqual(
             self, output_names, [x.name for x in spec.description.output]
         )
@@ -772,10 +772,10 @@ class KerasSingleLayerTest(unittest.TestCase):
         # Test the model class
         self.assertIsNotNone(spec.description)
         self.assertTrue(spec.HasField("neuralNetwork"))
-        self.assertEquals(
+        self.assertEqual(
             spec.description.input[0].type.WhichOneof("Type"), "imageType"
         )
-        self.assertEquals(
+        self.assertEqual(
             spec.description.input[0].type.imageType.colorSpace,
             FeatureTypes_pb2.ImageFeatureType.ColorSpace.Value("BGR"),
         )
@@ -814,10 +814,10 @@ class KerasSingleLayerTest(unittest.TestCase):
         # Test the model class
         self.assertIsNotNone(spec.description)
         self.assertTrue(spec.HasField("neuralNetwork"))
-        self.assertEquals(
+        self.assertEqual(
             spec.description.input[0].type.WhichOneof("Type"), "imageType"
         )
-        self.assertEquals(
+        self.assertEqual(
             spec.description.input[0].type.imageType.colorSpace,
             FeatureTypes_pb2.ImageFeatureType.ColorSpace.Value("RGB"),
         )
@@ -849,10 +849,10 @@ class KerasSingleLayerTest(unittest.TestCase):
         # Test the model class
         self.assertIsNotNone(spec.description)
         self.assertTrue(spec.HasField("neuralNetwork"))
-        self.assertEquals(
+        self.assertEqual(
             spec.description.input[0].type.WhichOneof("Type"), "imageType"
         )
-        self.assertEquals(
+        self.assertEqual(
             spec.description.input[0].type.imageType.colorSpace,
             FeatureTypes_pb2.ImageFeatureType.ColorSpace.Value("RGB"),
         )
@@ -894,24 +894,24 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertFalse(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
         self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
-        self.assertEquals(len(spec.description.output), len(expected_output_names))
-        self.assertEquals(
+        self.assertEqual(len(spec.description.output), len(expected_output_names))
+        self.assertEqual(
             expected_output_names, [x.name for x in spec.description.output]
         )
 
         # Check the types
-        self.assertEquals(
+        self.assertEqual(
             spec.description.output[0].type.WhichOneof("Type"), "dictionaryType"
         )
-        self.assertEquals(
+        self.assertEqual(
             spec.description.output[0].type.dictionaryType.WhichOneof("KeyType"),
             "stringKeyType",
         )
-        self.assertEquals(
+        self.assertEqual(
             spec.description.output[1].type.WhichOneof("Type"), "stringType"
         )
         self.assertTrue(spec.description.predictedFeatureName, "classLabel")
@@ -958,24 +958,24 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertFalse(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
         self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
-        self.assertEquals(len(spec.description.output), len(expected_output_names))
-        self.assertEquals(
+        self.assertEqual(len(spec.description.output), len(expected_output_names))
+        self.assertEqual(
             expected_output_names, [x.name for x in spec.description.output]
         )
 
         # Check the types
-        self.assertEquals(
+        self.assertEqual(
             spec.description.output[0].type.WhichOneof("Type"), "dictionaryType"
         )
-        self.assertEquals(
+        self.assertEqual(
             spec.description.output[0].type.dictionaryType.WhichOneof("KeyType"),
             "stringKeyType",
         )
-        self.assertEquals(
+        self.assertEqual(
             spec.description.output[1].type.WhichOneof("Type"), "stringType"
         )
         self.assertTrue(spec.description.predictedFeatureName, "classLabel")
@@ -1008,24 +1008,24 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertFalse(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
         self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
-        self.assertEquals(len(spec.description.output), len(expected_output_names))
-        self.assertEquals(
+        self.assertEqual(len(spec.description.output), len(expected_output_names))
+        self.assertEqual(
             expected_output_names, [x.name for x in spec.description.output]
         )
 
         # Check the types
-        self.assertEquals(
+        self.assertEqual(
             spec.description.output[0].type.WhichOneof("Type"), "dictionaryType"
         )
-        self.assertEquals(
+        self.assertEqual(
             spec.description.output[0].type.dictionaryType.WhichOneof("KeyType"),
             "int64KeyType",
         )
-        self.assertEquals(
+        self.assertEqual(
             spec.description.output[1].type.WhichOneof("Type"), "int64Type"
         )
         self.assertTrue(spec.description.predictedFeatureName, "classLabel")
@@ -1071,24 +1071,24 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertFalse(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
         self.assertCountEqual(
             self, input_names, [x.name for x in spec.description.input]
         )
-        self.assertEquals(len(spec.description.output), len(expected_output_names))
-        self.assertEquals(
+        self.assertEqual(len(spec.description.output), len(expected_output_names))
+        self.assertEqual(
             expected_output_names, [x.name for x in spec.description.output]
         )
 
         # Check the types
-        self.assertEquals(
+        self.assertEqual(
             spec.description.output[0].type.WhichOneof("Type"), "dictionaryType"
         )
-        self.assertEquals(
+        self.assertEqual(
             spec.description.output[0].type.dictionaryType.WhichOneof("KeyType"),
             "stringKeyType",
         )
-        self.assertEquals(
+        self.assertEqual(
             spec.description.output[1].type.WhichOneof("Type"), "stringType"
         )
         self.assertTrue(
@@ -1127,11 +1127,11 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(expected_input_names))
+        self.assertEqual(len(spec.description.input), len(expected_input_names))
         self.assertCountEqual(
             self, expected_input_names, [x.name for x in spec.description.input]
         )
-        self.assertEquals(len(spec.description.output), len(expected_output_names))
-        self.assertEquals(
+        self.assertEqual(len(spec.description.output), len(expected_output_names))
+        self.assertEqual(
             expected_output_names, [x.name for x in spec.description.output]
         )

--- a/coremltools/test/neural_network/test_keras2.py
+++ b/coremltools/test/neural_network/test_keras2.py
@@ -45,11 +45,11 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
         self.assertEqual(
             sorted(input_names), sorted(map(lambda x: x.name, spec.description.input))
         )
-        self.assertEquals(len(spec.description.output), len(output_names))
+        self.assertEqual(len(spec.description.output), len(output_names))
         self.assertEqual(
             sorted(output_names), sorted(map(lambda x: x.name, spec.description.output))
         )
@@ -103,12 +103,12 @@ class KerasSingleLayerTest(unittest.TestCase):
             self.assertTrue(spec.HasField("neuralNetwork"))
 
             # Test the inputs and outputs
-            self.assertEquals(len(spec.description.input), len(input_names))
+            self.assertEqual(len(spec.description.input), len(input_names))
             self.assertEqual(
                 sorted(input_names),
                 sorted(map(lambda x: x.name, spec.description.input)),
             )
-            self.assertEquals(len(spec.description.output), len(output_names))
+            self.assertEqual(len(spec.description.output), len(output_names))
             self.assertEqual(
                 sorted(output_names),
                 sorted(map(lambda x: x.name, spec.description.output)),
@@ -141,11 +141,11 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
         self.assertEqual(
             sorted(input_names), sorted(map(lambda x: x.name, spec.description.input))
         )
-        self.assertEquals(len(spec.description.output), len(output_names))
+        self.assertEqual(len(spec.description.output), len(output_names))
         self.assertEqual(
             sorted(output_names), sorted(map(lambda x: x.name, spec.description.output))
         )
@@ -179,11 +179,11 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
         self.assertEqual(
             sorted(input_names), sorted(map(lambda x: x.name, spec.description.input))
         )
-        self.assertEquals(len(spec.description.output), len(output_names))
+        self.assertEqual(len(spec.description.output), len(output_names))
         self.assertEqual(
             sorted(output_names), sorted(map(lambda x: x.name, spec.description.output))
         )
@@ -192,7 +192,7 @@ class KerasSingleLayerTest(unittest.TestCase):
         layers = spec.neuralNetwork.layers
         layer_0 = layers[0]
         self.assertIsNotNone(layer_0.innerProduct)
-        self.assertEquals(len(layers), 2)
+        self.assertEqual(len(layers), 2)
 
     def test_convolution(self, with_dilations=False):
         """
@@ -229,11 +229,11 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
         self.assertEqual(
             sorted(input_names), sorted(map(lambda x: x.name, spec.description.input))
         )
-        self.assertEquals(len(spec.description.output), len(output_names))
+        self.assertEqual(len(spec.description.output), len(output_names))
         self.assertEqual(
             sorted(output_names), sorted(map(lambda x: x.name, spec.description.output))
         )
@@ -285,11 +285,11 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
         self.assertEqual(
             sorted(input_names), sorted(map(lambda x: x.name, spec.description.input))
         )
-        self.assertEquals(len(spec.description.output), len(output_names))
+        self.assertEqual(len(spec.description.output), len(output_names))
         self.assertEqual(
             sorted(output_names), sorted(map(lambda x: x.name, spec.description.output))
         )
@@ -337,11 +337,11 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
         self.assertEqual(
             sorted(input_names), sorted(map(lambda x: x.name, spec.description.input))
         )
-        self.assertEquals(len(spec.description.output), len(output_names))
+        self.assertEqual(len(spec.description.output), len(output_names))
         self.assertEqual(
             sorted(output_names), sorted(map(lambda x: x.name, spec.description.output))
         )
@@ -352,7 +352,7 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertIsNotNone(layer_0.convolution)
         layer_1 = layers[1]
         self.assertIsNotNone(layer_1.upsample)
-        self.assertEquals(
+        self.assertEqual(
             layer_1.upsample.mode,
             NeuralNetwork_pb2.UpsampleLayerParams.InterpolationMode.Value("NN"),
         )
@@ -370,7 +370,7 @@ class KerasSingleLayerTest(unittest.TestCase):
         layers = spec.neuralNetwork.layers
         layer_1 = layers[1]
         self.assertIsNotNone(layer_1.upsample)
-        self.assertEquals(
+        self.assertEqual(
             layer_1.upsample.mode,
             NeuralNetwork_pb2.UpsampleLayerParams.InterpolationMode.Value("BILINEAR"),
         )
@@ -406,11 +406,11 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
         self.assertEqual(
             sorted(input_names), sorted(map(lambda x: x.name, spec.description.input))
         )
-        self.assertEquals(len(spec.description.output), len(output_names))
+        self.assertEqual(len(spec.description.output), len(output_names))
         self.assertEqual(
             sorted(output_names), sorted(map(lambda x: x.name, spec.description.output))
         )
@@ -439,11 +439,11 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
         self.assertEqual(
             sorted(input_names), sorted(map(lambda x: x.name, spec.description.input))
         )
-        self.assertEquals(len(spec.description.output), len(output_names))
+        self.assertEqual(len(spec.description.output), len(output_names))
         self.assertEqual(
             sorted(output_names), sorted(map(lambda x: x.name, spec.description.output))
         )
@@ -476,24 +476,24 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names) + 2)
+        self.assertEqual(len(spec.description.input), len(input_names) + 2)
 
-        self.assertEquals(32, spec.description.input[1].type.multiArrayType.shape[0])
-        self.assertEquals(32, spec.description.input[2].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.input[1].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.input[2].type.multiArrayType.shape[0])
 
-        self.assertEquals(len(spec.description.output), len(output_names) + 2)
-        self.assertEquals(output_names[0], spec.description.output[0].name)
-        self.assertEquals(32, spec.description.output[0].type.multiArrayType.shape[0])
+        self.assertEqual(len(spec.description.output), len(output_names) + 2)
+        self.assertEqual(output_names[0], spec.description.output[0].name)
+        self.assertEqual(32, spec.description.output[0].type.multiArrayType.shape[0])
 
-        self.assertEquals(32, spec.description.output[1].type.multiArrayType.shape[0])
-        self.assertEquals(32, spec.description.output[2].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.output[1].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.output[2].type.multiArrayType.shape[0])
 
         # Test the layer parameters.
         layers = spec.neuralNetwork.layers
         layer_0 = layers[0]
         self.assertIsNotNone(layer_0.uniDirectionalLSTM)
-        self.assertEquals(len(layer_0.input), 3)
-        self.assertEquals(len(layer_0.output), 3)
+        self.assertEqual(len(layer_0.input), 3)
+        self.assertEqual(len(layer_0.output), 3)
 
     def test_simple_rnn(self):
         """
@@ -515,22 +515,22 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names) + 1)
-        self.assertEquals(input_names[0], spec.description.input[0].name)
+        self.assertEqual(len(spec.description.input), len(input_names) + 1)
+        self.assertEqual(input_names[0], spec.description.input[0].name)
 
-        self.assertEquals(32, spec.description.input[1].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.input[1].type.multiArrayType.shape[0])
 
-        self.assertEquals(len(spec.description.output), len(output_names) + 1)
-        self.assertEquals(output_names[0], spec.description.output[0].name)
-        self.assertEquals(32, spec.description.output[0].type.multiArrayType.shape[0])
-        self.assertEquals(32, spec.description.output[1].type.multiArrayType.shape[0])
+        self.assertEqual(len(spec.description.output), len(output_names) + 1)
+        self.assertEqual(output_names[0], spec.description.output[0].name)
+        self.assertEqual(32, spec.description.output[0].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.output[1].type.multiArrayType.shape[0])
 
         # Test the layer parameters.
         layers = spec.neuralNetwork.layers
         layer_0 = layers[0]
         self.assertIsNotNone(layer_0.simpleRecurrent)
-        self.assertEquals(len(layer_0.input), 2)
-        self.assertEquals(len(layer_0.output), 2)
+        self.assertEqual(len(layer_0.input), 2)
+        self.assertEqual(len(layer_0.output), 2)
 
     def test_gru(self):
         """
@@ -552,22 +552,22 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names) + 1)
-        self.assertEquals(input_names[0], spec.description.input[0].name)
+        self.assertEqual(len(spec.description.input), len(input_names) + 1)
+        self.assertEqual(input_names[0], spec.description.input[0].name)
 
-        self.assertEquals(32, spec.description.input[1].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.input[1].type.multiArrayType.shape[0])
 
-        self.assertEquals(len(spec.description.output), len(output_names) + 1)
-        self.assertEquals(output_names[0], spec.description.output[0].name)
-        self.assertEquals(32, spec.description.output[0].type.multiArrayType.shape[0])
-        self.assertEquals(32, spec.description.output[1].type.multiArrayType.shape[0])
+        self.assertEqual(len(spec.description.output), len(output_names) + 1)
+        self.assertEqual(output_names[0], spec.description.output[0].name)
+        self.assertEqual(32, spec.description.output[0].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.output[1].type.multiArrayType.shape[0])
 
         # Test the layer parameters.
         layers = spec.neuralNetwork.layers
         layer_0 = layers[0]
         self.assertIsNotNone(layer_0.gru)
-        self.assertEquals(len(layer_0.input), 2)
-        self.assertEquals(len(layer_0.output), 2)
+        self.assertEqual(len(layer_0.input), 2)
+        self.assertEqual(len(layer_0.output), 2)
 
     def test_bidir(self):
         """
@@ -590,29 +590,29 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names) + 4)
-        self.assertEquals(input_names[0], spec.description.input[0].name)
+        self.assertEqual(len(spec.description.input), len(input_names) + 4)
+        self.assertEqual(input_names[0], spec.description.input[0].name)
 
-        self.assertEquals(32, spec.description.input[1].type.multiArrayType.shape[0])
-        self.assertEquals(32, spec.description.input[2].type.multiArrayType.shape[0])
-        self.assertEquals(32, spec.description.input[3].type.multiArrayType.shape[0])
-        self.assertEquals(32, spec.description.input[4].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.input[1].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.input[2].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.input[3].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.input[4].type.multiArrayType.shape[0])
 
-        self.assertEquals(len(spec.description.output), len(output_names) + 4)
-        self.assertEquals(output_names[0], spec.description.output[0].name)
-        self.assertEquals(64, spec.description.output[0].type.multiArrayType.shape[0])
+        self.assertEqual(len(spec.description.output), len(output_names) + 4)
+        self.assertEqual(output_names[0], spec.description.output[0].name)
+        self.assertEqual(64, spec.description.output[0].type.multiArrayType.shape[0])
 
-        self.assertEquals(32, spec.description.output[1].type.multiArrayType.shape[0])
-        self.assertEquals(32, spec.description.output[2].type.multiArrayType.shape[0])
-        self.assertEquals(32, spec.description.output[3].type.multiArrayType.shape[0])
-        self.assertEquals(32, spec.description.output[4].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.output[1].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.output[2].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.output[3].type.multiArrayType.shape[0])
+        self.assertEqual(32, spec.description.output[4].type.multiArrayType.shape[0])
 
         # Test the layer parameters.
         layers = spec.neuralNetwork.layers
         layer_0 = layers[0]
         self.assertIsNotNone(layer_0.biDirectionalLSTM)
-        self.assertEquals(len(layer_0.input), 5)
-        self.assertEquals(len(layer_0.output), 5)
+        self.assertEqual(len(layer_0.input), 5)
+        self.assertEqual(len(layer_0.output), 5)
 
     def test_embedding(self):
         from keras.layers import Embedding
@@ -634,17 +634,17 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
 
         # Test the layer parameters.
         layers = spec.neuralNetwork.layers
         layer_0 = layers[0]
         self.assertIsNotNone(layer_0.embedding)
 
-        self.assertEquals(layer_0.embedding.inputDim, num_inputs)
-        self.assertEquals(layer_0.embedding.outputChannels, num_outputs)
+        self.assertEqual(layer_0.embedding.inputDim, num_inputs)
+        self.assertEqual(layer_0.embedding.outputChannels, num_outputs)
 
-        self.assertEquals(
+        self.assertEqual(
             len(layer_0.embedding.weights.floatValue), num_inputs * num_outputs
         )
 
@@ -681,8 +681,8 @@ class KerasSingleLayerTest(unittest.TestCase):
 
         # Test the inputs and outputs
         # We're giving state input and output so expect description to differ.
-        self.assertEquals(len(spec.description.input), len(input_names) + 2)
-        self.assertEquals(len(spec.description.output), len(output_names) + 2)
+        self.assertEqual(len(spec.description.input), len(input_names) + 2)
+        self.assertEqual(len(spec.description.output), len(output_names) + 2)
 
         # Test the layer parameters.
         layers = spec.neuralNetwork.layers
@@ -708,8 +708,8 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names) + 2)
-        self.assertEquals(len(spec.description.output), len(output_names) + 2)
+        self.assertEqual(len(spec.description.input), len(input_names) + 2)
+        self.assertEqual(len(spec.description.output), len(output_names) + 2)
 
         # Test the layer parameters.
         layers = spec.neuralNetwork.layers
@@ -749,11 +749,11 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
         self.assertEqual(
             sorted(input_names), sorted(map(lambda x: x.name, spec.description.input))
         )
-        self.assertEquals(len(spec.description.output), len(output_names))
+        self.assertEqual(len(spec.description.output), len(output_names))
         self.assertEqual(
             sorted(output_names), sorted(map(lambda x: x.name, spec.description.output))
         )
@@ -777,11 +777,11 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertIsNotNone(spec.description)
         self.assertTrue(spec.HasField("neuralNetwork"))
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
         self.assertEqual(
             sorted(input_names), sorted(map(lambda x: x.name, spec.description.input))
         )
-        self.assertEquals(len(spec.description.output), len(output_names))
+        self.assertEqual(len(spec.description.output), len(output_names))
         self.assertEqual(
             sorted(output_names), sorted(map(lambda x: x.name, spec.description.output))
         )
@@ -844,10 +844,10 @@ class KerasSingleLayerTest(unittest.TestCase):
         # Test the model class
         self.assertIsNotNone(spec.description)
         self.assertTrue(spec.HasField("neuralNetwork"))
-        self.assertEquals(
+        self.assertEqual(
             spec.description.input[0].type.WhichOneof("Type"), "imageType"
         )
-        self.assertEquals(
+        self.assertEqual(
             spec.description.input[0].type.imageType.colorSpace,
             FeatureTypes_pb2.ImageFeatureType.ColorSpace.Value("BGR"),
         )
@@ -886,10 +886,10 @@ class KerasSingleLayerTest(unittest.TestCase):
         # Test the model class
         self.assertIsNotNone(spec.description)
         self.assertTrue(spec.HasField("neuralNetwork"))
-        self.assertEquals(
+        self.assertEqual(
             spec.description.input[0].type.WhichOneof("Type"), "imageType"
         )
-        self.assertEquals(
+        self.assertEqual(
             spec.description.input[0].type.imageType.colorSpace,
             FeatureTypes_pb2.ImageFeatureType.ColorSpace.Value("RGB"),
         )
@@ -921,10 +921,10 @@ class KerasSingleLayerTest(unittest.TestCase):
         # Test the model class
         self.assertIsNotNone(spec.description)
         self.assertTrue(spec.HasField("neuralNetwork"))
-        self.assertEquals(
+        self.assertEqual(
             spec.description.input[0].type.WhichOneof("Type"), "imageType"
         )
-        self.assertEquals(
+        self.assertEqual(
             spec.description.input[0].type.imageType.colorSpace,
             FeatureTypes_pb2.ImageFeatureType.ColorSpace.Value("RGB"),
         )
@@ -966,24 +966,24 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertFalse(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
         self.assertEqual(
             sorted(input_names), sorted(map(lambda x: x.name, spec.description.input))
         )
-        self.assertEquals(len(spec.description.output), len(expected_output_names))
-        self.assertEquals(
+        self.assertEqual(len(spec.description.output), len(expected_output_names))
+        self.assertEqual(
             expected_output_names, list(map(lambda x: x.name, spec.description.output))
         )
 
         # Check the types
-        self.assertEquals(
+        self.assertEqual(
             spec.description.output[0].type.WhichOneof("Type"), "dictionaryType"
         )
-        self.assertEquals(
+        self.assertEqual(
             spec.description.output[0].type.dictionaryType.WhichOneof("KeyType"),
             "stringKeyType",
         )
-        self.assertEquals(
+        self.assertEqual(
             spec.description.output[1].type.WhichOneof("Type"), "stringType"
         )
         self.assertTrue(spec.description.predictedFeatureName, "classLabel")
@@ -1030,24 +1030,24 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertFalse(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
         self.assertEqual(
             sorted(input_names), sorted(map(lambda x: x.name, spec.description.input))
         )
-        self.assertEquals(len(spec.description.output), len(expected_output_names))
-        self.assertEquals(
+        self.assertEqual(len(spec.description.output), len(expected_output_names))
+        self.assertEqual(
             expected_output_names, list(map(lambda x: x.name, spec.description.output))
         )
 
         # Check the types
-        self.assertEquals(
+        self.assertEqual(
             spec.description.output[0].type.WhichOneof("Type"), "dictionaryType"
         )
-        self.assertEquals(
+        self.assertEqual(
             spec.description.output[0].type.dictionaryType.WhichOneof("KeyType"),
             "stringKeyType",
         )
-        self.assertEquals(
+        self.assertEqual(
             spec.description.output[1].type.WhichOneof("Type"), "stringType"
         )
         self.assertTrue(spec.description.predictedFeatureName, "classLabel")
@@ -1080,24 +1080,24 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertFalse(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
         self.assertEqual(
             sorted(input_names), sorted(map(lambda x: x.name, spec.description.input))
         )
-        self.assertEquals(len(spec.description.output), len(expected_output_names))
-        self.assertEquals(
+        self.assertEqual(len(spec.description.output), len(expected_output_names))
+        self.assertEqual(
             expected_output_names, list(map(lambda x: x.name, spec.description.output))
         )
 
         # Check the types
-        self.assertEquals(
+        self.assertEqual(
             spec.description.output[0].type.WhichOneof("Type"), "dictionaryType"
         )
-        self.assertEquals(
+        self.assertEqual(
             spec.description.output[0].type.dictionaryType.WhichOneof("KeyType"),
             "int64KeyType",
         )
-        self.assertEquals(
+        self.assertEqual(
             spec.description.output[1].type.WhichOneof("Type"), "int64Type"
         )
         self.assertTrue(spec.description.predictedFeatureName, "classLabel")
@@ -1143,24 +1143,24 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertFalse(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(input_names))
+        self.assertEqual(len(spec.description.input), len(input_names))
         self.assertEqual(
             sorted(input_names), sorted(map(lambda x: x.name, spec.description.input))
         )
-        self.assertEquals(len(spec.description.output), len(expected_output_names))
-        self.assertEquals(
+        self.assertEqual(len(spec.description.output), len(expected_output_names))
+        self.assertEqual(
             expected_output_names, list(map(lambda x: x.name, spec.description.output))
         )
 
         # Check the types
-        self.assertEquals(
+        self.assertEqual(
             spec.description.output[0].type.WhichOneof("Type"), "dictionaryType"
         )
-        self.assertEquals(
+        self.assertEqual(
             spec.description.output[0].type.dictionaryType.WhichOneof("KeyType"),
             "stringKeyType",
         )
-        self.assertEquals(
+        self.assertEqual(
             spec.description.output[1].type.WhichOneof("Type"), "stringType"
         )
         self.assertTrue(
@@ -1199,13 +1199,13 @@ class KerasSingleLayerTest(unittest.TestCase):
         self.assertTrue(spec.HasField("neuralNetwork"))
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.input), len(expected_input_names))
+        self.assertEqual(len(spec.description.input), len(expected_input_names))
         self.assertEqual(
             sorted(expected_input_names),
             sorted(map(lambda x: x.name, spec.description.input)),
         )
-        self.assertEquals(len(spec.description.output), len(expected_output_names))
-        self.assertEquals(
+        self.assertEqual(len(spec.description.output), len(expected_output_names))
+        self.assertEqual(
             sorted(expected_output_names),
             sorted(map(lambda x: x.name, spec.description.output)),
         )

--- a/coremltools/test/neural_network/test_keras2_numeric.py
+++ b/coremltools/test/neural_network/test_keras2_numeric.py
@@ -2903,7 +2903,7 @@ class KerasNumericCorrectnessStressTest(KerasNumericCorrectnessTest):
 
             if use_tmp_folder:
                 shutil.rmtree(model_dir)
-            self.assertEquals(
+            self.assertEqual(
                 len(coreml_preds),
                 len(keras_preds),
                 msg="Failed test case %s. Lengths wrong (%s vs %s)"
@@ -2911,7 +2911,7 @@ class KerasNumericCorrectnessStressTest(KerasNumericCorrectnessTest):
             )
             for i in range(len(keras_preds)):
                 max_den = max(1.0, keras_preds[i], coreml_preds[i])
-                self.assertAlmostEquals(
+                self.assertAlmostEqual(
                     keras_preds[i] / max_den,
                     coreml_preds[i] / max_den,
                     delta=delta,

--- a/coremltools/test/neural_network/test_keras_numeric.py
+++ b/coremltools/test/neural_network/test_keras_numeric.py
@@ -219,10 +219,10 @@ class KerasNumericCorrectnessTest(unittest.TestCase):
                     kp = k_pred.flatten()
                 cp = c_preds[idx].flatten()
                 # Compare predictions
-                self.assertEquals(len(kp), len(cp))
+                self.assertEqual(len(kp), len(cp))
                 for i in range(len(kp)):
                     max_den = max(1.0, kp[i], cp[i])
-                    self.assertAlmostEquals(
+                    self.assertAlmostEqual(
                         kp[i] / max_den, cp[i] / max_den, delta=delta
                     )
 
@@ -2653,7 +2653,7 @@ class KerasNumericCorrectnessStressTest(KerasNumericCorrectnessTest):
 
             if use_tmp_folder:
                 shutil.rmtree(model_dir)
-            self.assertEquals(
+            self.assertEqual(
                 len(coreml_preds),
                 len(keras_preds),
                 msg="Failed test case %s. Lengths wrong (%s vs %s)"
@@ -2661,7 +2661,7 @@ class KerasNumericCorrectnessStressTest(KerasNumericCorrectnessTest):
             )
             for i in range(len(keras_preds)):
                 max_den = max(1.0, keras_preds[i], coreml_preds[i])
-                self.assertAlmostEquals(
+                self.assertAlmostEqual(
                     keras_preds[i] / max_den,
                     coreml_preds[i] / max_den,
                     delta=delta,

--- a/coremltools/test/neural_network/test_multiple_images_preprocessing.py
+++ b/coremltools/test/neural_network/test_multiple_images_preprocessing.py
@@ -107,9 +107,9 @@ class ManyImagesKeras(unittest.TestCase):
             coreml_input_dict["data"] = PIL.Image.fromarray(data.astype(np.uint8))
             coreml_preds = coreml_model.predict(coreml_input_dict)["output"].flatten()
 
-            self.assertEquals(len(keras_preds), len(coreml_preds))
+            self.assertEqual(len(keras_preds), len(coreml_preds))
             max_relative_error = compare_models(keras_preds, coreml_preds)
-            self.assertAlmostEquals(max(max_relative_error, 0.001), 0.001, delta=1e-6)
+            self.assertAlmostEqual(max(max_relative_error, 0.001), 0.001, delta=1e-6)
 
         if os.path.exists(model_dir):
             shutil.rmtree(model_dir)
@@ -183,9 +183,9 @@ class ManyImagesKeras(unittest.TestCase):
             coreml_preds = coreml_model.predict(coreml_input_dict)["output"].flatten()
 
             # compare
-            self.assertEquals(len(keras_preds), len(coreml_preds))
+            self.assertEqual(len(keras_preds), len(coreml_preds))
             max_relative_error = compare_models(keras_preds, coreml_preds)
-            self.assertAlmostEquals(max(max_relative_error, 0.001), 0.001, delta=1e-6)
+            self.assertAlmostEqual(max(max_relative_error, 0.001), 0.001, delta=1e-6)
 
         if os.path.exists(model_dir):
             shutil.rmtree(model_dir)

--- a/coremltools/test/neural_network/test_neural_networks.py
+++ b/coremltools/test/neural_network/test_neural_networks.py
@@ -73,7 +73,7 @@ class KerasBasicNumericCorrectnessTest(unittest.TestCase):
             inputs = np.random.rand(input_dim)
             outputs = coremlmodel.predict({"input": inputs})
             # this checks that the dictionary got the right name and type
-            self.assertEquals(type(outputs[output_names[0]]), type({"a": 0.5}))
+            self.assertEqual(type(outputs[output_names[0]]), type({"a": 0.5}))
 
     def test_classifier_no_name(self):
         np.random.seed(1988)
@@ -112,7 +112,7 @@ class KerasBasicNumericCorrectnessTest(unittest.TestCase):
             inputs = np.random.rand(input_dim)
             outputs = coremlmodel.predict({"input": inputs})
             # this checks that the dictionary got the right name and type
-            self.assertEquals(type(outputs[output_names[0]]), type({"a": 0.5}))
+            self.assertEqual(type(outputs[output_names[0]]), type({"a": 0.5}))
 
     def test_internal_layer(self):
 
@@ -171,7 +171,7 @@ class KerasBasicNumericCorrectnessTest(unittest.TestCase):
             partialOutput = coreml2.predict({"input": inputs})
 
             for i in range(0, num_channels2):
-                self.assertAlmostEquals(
+                self.assertAlmostEqual(
                     fullOutputs["middle_layer_output"][i],
                     partialOutput["output2"][i],
                     2,

--- a/coremltools/test/neural_network/test_nn_builder.py
+++ b/coremltools/test/neural_network/test_nn_builder.py
@@ -500,10 +500,10 @@ class BasicNumericCorrectnessTest(unittest.TestCase):
         builder = self._build_nn_with_one_ip_layer()
         builder.set_input(input_names=["data_renamed"], input_dims=[(2,)])
 
-        self.assertEquals(
+        self.assertEqual(
             builder.spec.description.input[0].type.multiArrayType.shape[0], 2
         )
-        self.assertEquals(builder.spec.description.input[0].name, "data_renamed")
+        self.assertEqual(builder.spec.description.input[0].name, "data_renamed")
 
     def test_set_input_fail(self):
         builder = self._build_nn_with_one_ip_layer()
@@ -516,10 +516,10 @@ class BasicNumericCorrectnessTest(unittest.TestCase):
         builder = self._build_nn_with_one_ip_layer()
         builder.set_output(output_names=["out_renamed"], output_dims=[(2,)])
 
-        self.assertEquals(
+        self.assertEqual(
             builder.spec.description.output[0].type.multiArrayType.shape[0], 2
         )
-        self.assertEquals(builder.spec.description.output[0].name, "out_renamed")
+        self.assertEqual(builder.spec.description.output[0].name, "out_renamed")
 
     def test_set_output_fail(self):
         builder = self._build_nn_with_one_ip_layer()
@@ -598,9 +598,9 @@ class UseFloatArraytypeTest(unittest.TestCase):
             else coremltools.proto.FeatureTypes_pb2.ArrayFeatureType.DOUBLE
         )
         for input in spec.description.input:
-            self.assertEquals(input.type.multiArrayType.dataType, array_feature_type)
+            self.assertEqual(input.type.multiArrayType.dataType, array_feature_type)
         for output in spec.description.input:
-            self.assertEquals(output.type.multiArrayType.dataType, array_feature_type)
+            self.assertEqual(output.type.multiArrayType.dataType, array_feature_type)
 
         # Assert that the generated spec is functional
         mlmodel = MLModel(spec)

--- a/coremltools/test/neural_network/test_numpy_nn_layers.py
+++ b/coremltools/test/neural_network/test_numpy_nn_layers.py
@@ -239,7 +239,7 @@ class SimpleTest(CorrectnessTest):
         }
 
         self._test_model(builder.spec, input, expected)
-        self.assertEquals(len(input_dim), builder._get_rank("output"))
+        self.assertEqual(len(input_dim), builder._get_rank("output"))
 
     def test_LRN(self):
         input_dim = (1, 3, 3)
@@ -6713,7 +6713,7 @@ class IOS14SingleLayerTests(CorrectnessTest):
         expected = {"output": pytorch_output.numpy()}
 
         self._test_model(builder.spec, input, expected, useCPUOnly=cpu_only)
-        self.assertEquals(len(input_dim), builder._get_rank("output"))
+        self.assertEqual(len(input_dim), builder._get_rank("output"))
 
     def test_slice_by_size_cpu(self, cpu_only=True):
 

--- a/coremltools/test/neural_network/test_recurrent_stress_tests.py
+++ b/coremltools/test/neural_network/test_recurrent_stress_tests.py
@@ -736,7 +736,7 @@ class RNNLayer(RecurrentLayerTest):
                     "output"
                 ].flatten()
                 try:
-                    self.assertEquals(coreml_preds.shape, keras_preds.shape)
+                    self.assertEqual(coreml_preds.shape, keras_preds.shape)
                 except AssertionError:
                     print(
                         "Shape error:\nbase_params: {}\nkeras_preds.shape: {}\ncoreml_preds.shape: {}".format(
@@ -765,10 +765,10 @@ class RNNLayer(RecurrentLayerTest):
                     numerical_err_models.append(base_params)
             i += 1
 
-        self.assertEquals(
+        self.assertEqual(
             shape_err_models, [], msg="Shape error models {}".format(shape_err_models)
         )
-        self.assertEquals(
+        self.assertEqual(
             numerical_err_models,
             [],
             msg="Numerical error models {}\n"
@@ -922,7 +922,7 @@ class LSTMLayer(RecurrentLayerTest):
                     K.tensorflow_backend._SESSION = None
 
                 try:
-                    self.assertEquals(coreml_preds.shape, keras_preds.shape)
+                    self.assertEqual(coreml_preds.shape, keras_preds.shape)
                 except AssertionError:
                     print(
                         "Shape error:\n param: {}\n\n keras_preds.shape: {}\n\n coreml_preds.shape: {}".format(
@@ -971,10 +971,10 @@ class LSTMLayer(RecurrentLayerTest):
 
             i += 1
 
-        self.assertEquals(
+        self.assertEqual(
             shape_err_models, [], msg="Shape error models {}".format(shape_err_models)
         )
-        self.assertEquals(
+        self.assertEqual(
             numerical_err_models,
             [],
             msg="Numerical error models {}".format(numerical_err_models),
@@ -1057,7 +1057,7 @@ class LSTMLayer(RecurrentLayerTest):
                     K.tensorflow_backend._SESSION = None
 
                 try:
-                    self.assertEquals(coreml_preds.shape, keras_preds.shape)
+                    self.assertEqual(coreml_preds.shape, keras_preds.shape)
                 except AssertionError:
                     print(
                         "Shape error:\n param: {}\n\n keras_preds.shape: {}\n\n coreml_preds.shape: {}".format(
@@ -1107,10 +1107,10 @@ class LSTMLayer(RecurrentLayerTest):
 
             i += 1
 
-        self.assertEquals(
+        self.assertEqual(
             shape_err_models, [], msg="Shape error models {}".format(shape_err_models)
         )
-        self.assertEquals(
+        self.assertEqual(
             numerical_err_models,
             [],
             msg="Numerical error models {}".format(numerical_err_models),
@@ -1242,7 +1242,7 @@ class LSTMLayer(RecurrentLayerTest):
                     K.tensorflow_backend._SESSION = None
 
                 try:
-                    self.assertEquals(coreml_preds.shape, keras_preds.shape)
+                    self.assertEqual(coreml_preds.shape, keras_preds.shape)
                 except AssertionError:
                     print(
                         "Shape error:\n base_params: {}\n\n lstm_params: {}\n\n keras_preds.shape: {}\n\n coreml_preds.shape: {}".format(
@@ -1278,10 +1278,10 @@ class LSTMLayer(RecurrentLayerTest):
                     numerical_failiure += 1
                     numerical_err_models.append(base_params)
 
-        self.assertEquals(
+        self.assertEqual(
             shape_err_models, [], msg="Shape error models {}".format(shape_err_models)
         )
-        self.assertEquals(
+        self.assertEqual(
             numerical_err_models,
             [],
             msg="Numerical error models {}".format(numerical_err_models),
@@ -1416,7 +1416,7 @@ class GRULayer(RecurrentLayerTest):
                     K.tensorflow_backend._SESSION.close()
                     K.tensorflow_backend._SESSION = None
                 try:
-                    self.assertEquals(coreml_preds.shape, keras_preds.shape)
+                    self.assertEqual(coreml_preds.shape, keras_preds.shape)
                 except AssertionError:
                     print(
                         "Shape error:\nbase_params: {}\n gru_params: {}\nkeras_preds.shape: {}\ncoreml_preds.shape: {}".format(
@@ -1454,10 +1454,10 @@ class GRULayer(RecurrentLayerTest):
                     numerical_err_models.append(base_params)
             i += 1
 
-        self.assertEquals(
+        self.assertEqual(
             shape_err_models, [], msg="Shape error models {}".format(shape_err_models)
         )
-        self.assertEquals(
+        self.assertEqual(
             numerical_err_models,
             [],
             msg="Numerical error models {}".format(numerical_err_models),
@@ -1607,7 +1607,7 @@ class LSTMStacked(unittest.TestCase):
                 K.tensorflow_backend._SESSION.close()
                 K.tensorflow_backend._SESSION = None
                 try:
-                    self.assertEquals(coreml_preds.shape, keras_preds.shape)
+                    self.assertEqual(coreml_preds.shape, keras_preds.shape)
                 except AssertionError:
                     print(
                         "Shape error:\nbase_params: {}\nkeras_preds.shape: {}\ncoreml_preds.shape: {}".format(
@@ -1635,10 +1635,10 @@ class LSTMStacked(unittest.TestCase):
                     numerical_failiure += 1
                     numerical_err_models.append(base_params)
             i += 1
-        self.assertEquals(
+        self.assertEqual(
             shape_err_models, [], msg="Shape error models {}".format(shape_err_models)
         )
-        self.assertEquals(
+        self.assertEqual(
             numerical_err_models,
             [],
             msg="Numerical error models {}".format(numerical_err_models),

--- a/coremltools/test/neural_network/test_simple_recurrent_single_layer.py
+++ b/coremltools/test/neural_network/test_simple_recurrent_single_layer.py
@@ -143,7 +143,7 @@ class SimpleRNNLayer(RecurrentLayerTest):
                     "output"
                 ].flatten()
                 try:
-                    self.assertEquals(coreml_preds.shape, keras_preds.shape)
+                    self.assertEqual(coreml_preds.shape, keras_preds.shape)
                 except AssertionError:
                     print(
                         "Shape error:\nbase_params: {}\nkeras_preds.shape: {}\ncoreml_preds.shape: {}".format(
@@ -170,10 +170,10 @@ class SimpleRNNLayer(RecurrentLayerTest):
             shutil.rmtree(model_dir)
             i += 1
 
-        self.assertEquals(
+        self.assertEqual(
             shape_err_models, [], msg="Shape error models {}".format(shape_err_models)
         )
-        self.assertEquals(
+        self.assertEqual(
             numerical_err_models,
             [],
             msg="Numerical error models {}".format(numerical_err_models),
@@ -286,7 +286,7 @@ class LSTMLayer(RecurrentLayerTest):
                     "output"
                 ].flatten()
                 try:
-                    self.assertEquals(coreml_preds.shape, keras_preds.shape)
+                    self.assertEqual(coreml_preds.shape, keras_preds.shape)
                 except AssertionError:
                     print(
                         "Shape error:\nbase_params: {}\nkeras_preds.shape: {}\ncoreml_preds.shape: {}".format(
@@ -313,10 +313,10 @@ class LSTMLayer(RecurrentLayerTest):
             shutil.rmtree(model_dir)
             i += 1
 
-        self.assertEquals(
+        self.assertEqual(
             shape_err_models, [], msg="Shape error models {}".format(shape_err_models)
         )
-        self.assertEquals(
+        self.assertEqual(
             numerical_err_models,
             [],
             msg="Numerical error models {}".format(numerical_err_models),
@@ -427,7 +427,7 @@ class GRULayer(RecurrentLayerTest):
                     "output"
                 ].flatten()
                 try:
-                    self.assertEquals(coreml_preds.shape, keras_preds.shape)
+                    self.assertEqual(coreml_preds.shape, keras_preds.shape)
                 except AssertionError:
                     print(
                         "Shape error:\nbase_params: {}\nkeras_preds.shape: {}\ncoreml_preds.shape: {}".format(
@@ -454,10 +454,10 @@ class GRULayer(RecurrentLayerTest):
             shutil.rmtree(model_dir)
             i += 1
 
-        self.assertEquals(
+        self.assertEqual(
             shape_err_models, [], msg="Shape error models {}".format(shape_err_models)
         )
-        self.assertEquals(
+        self.assertEqual(
             numerical_err_models,
             [],
             msg="Numerical error models {}".format(numerical_err_models),

--- a/coremltools/test/neural_network/test_tf_numeric.py
+++ b/coremltools/test/neural_network/test_tf_numeric.py
@@ -61,7 +61,7 @@ class CorrectnessTest(unittest.TestCase):
         for out_ in list(ref_output_dict.keys()):
             ref_out = ref_output_dict[out_].flatten()
             coreml_out = coreml_out_dict[out_].flatten()
-            self.assertEquals(len(coreml_out), len(ref_out))
+            self.assertEqual(len(coreml_out), len(ref_out))
             self._compare_predictions_numerical(
                 ref_out, coreml_out, snr_thresh=snr_thresh, psnr_thresh=psnr_thresh
             )

--- a/coremltools/test/sklearn_tests/test_NuSVC.py
+++ b/coremltools/test/sklearn_tests/test_NuSVC.py
@@ -107,14 +107,14 @@ class NuSvcScikitTest(unittest.TestCase):
                         metrics = evaluate_classifier_with_probabilities(
                             spec, df, probabilities="classProbability"
                         )
-                        self.assertEquals(metrics["num_key_mismatch"], 0)
+                        self.assertEqual(metrics["num_key_mismatch"], 0)
                         self.assertLess(
                             metrics["max_probability_error"], allowed_prob_delta
                         )
                     else:
                         df["prediction"] = cur_model.predict(x)
                         metrics = evaluate_classifier(spec, df, verbose=False)
-                        self.assertEquals(metrics["num_errors"], 0)
+                        self.assertEqual(metrics["num_errors"], 0)
 
                 if not allow_slow:
                     break
@@ -249,7 +249,7 @@ class NuSVCLibSVMTest(unittest.TestCase):
 
         if _is_macos() and _macos_version() >= (10, 13):
             metrics = evaluate_classifier_with_probabilities(spec, df, verbose=False)
-            self.assertEquals(metrics["num_key_mismatch"], 0)
+            self.assertEqual(metrics["num_key_mismatch"], 0)
             self.assertLess(metrics["max_probability_error"], 0.00001)
 
     @pytest.mark.slow
@@ -295,7 +295,7 @@ class NuSVCLibSVMTest(unittest.TestCase):
                 spec = libsvm.convert(model, column_names, "target")
 
                 metrics = evaluate_classifier(spec, df, verbose=False)
-                self.assertEquals(metrics["num_errors"], 0)
+                self.assertEqual(metrics["num_errors"], 0)
 
     def test_conversion_from_filesystem(self):
         libsvm_model_path = tempfile.mktemp(suffix="model.libsvm")

--- a/coremltools/test/sklearn_tests/test_NuSVR.py
+++ b/coremltools/test/sklearn_tests/test_NuSVR.py
@@ -115,7 +115,7 @@ class NuSVRScikitTest(unittest.TestCase):
 
                 if _is_macos() and _macos_version() >= (10, 13):
                     metrics = evaluate_regressor(spec, df)
-                    self.assertAlmostEquals(metrics["max_error"], 0)
+                    self.assertAlmostEqual(metrics["max_error"], 0)
 
                 if not allow_slow:
                     break
@@ -218,7 +218,7 @@ class NuSVRLibSVMTest(unittest.TestCase):
 
                 if _is_macos() and _macos_version() >= (10, 13):
                     metrics = evaluate_regressor(spec, df)
-                    self.assertAlmostEquals(metrics["max_error"], 0)
+                    self.assertAlmostEqual(metrics["max_error"], 0)
 
                 if not allow_slow:
                     break

--- a/coremltools/test/sklearn_tests/test_SVC.py
+++ b/coremltools/test/sklearn_tests/test_SVC.py
@@ -102,14 +102,14 @@ class SvcScikitTest(unittest.TestCase):
                         metrics = evaluate_classifier_with_probabilities(
                             spec, df, probabilities="classProbability", verbose=True
                         )
-                        self.assertEquals(metrics["num_key_mismatch"], 0)
+                        self.assertEqual(metrics["num_key_mismatch"], 0)
                         self.assertLess(
                             metrics["max_probability_error"], allowed_prob_delta
                         )
                     else:
                         df["prediction"] = cur_model.predict(x)
                         metrics = evaluate_classifier(spec, df, verbose=False)
-                        self.assertEquals(metrics["num_errors"], 0)
+                        self.assertEqual(metrics["num_errors"], 0)
 
                 if not allow_slow:
                     break
@@ -249,7 +249,7 @@ class CSVCLibSVMTest(unittest.TestCase):
                 self.y, self.x, no_probability_model, " -q"
             )
             metrics = evaluate_classifier(spec, df, verbose=False)
-            self.assertEquals(metrics["num_errors"], 0)
+            self.assertEqual(metrics["num_errors"], 0)
 
     # LibSVM only supports string labels
     @pytest.mark.slow
@@ -317,7 +317,7 @@ class CSVCLibSVMTest(unittest.TestCase):
                     metrics = evaluate_classifier_with_probabilities(
                         spec, df, verbose=False
                     )
-                    self.assertEquals(metrics["num_key_mismatch"], 0)
+                    self.assertEqual(metrics["num_key_mismatch"], 0)
                     self.assertLess(metrics["max_probability_error"], 0.00001)
 
                 if not allow_slow:
@@ -359,7 +359,7 @@ class CSVCLibSVMTest(unittest.TestCase):
 
                 if _is_macos() and _macos_version() >= (10, 13):
                     metrics = evaluate_classifier(spec, df, verbose=False)
-                    self.assertEquals(metrics["num_errors"], 0)
+                    self.assertEqual(metrics["num_errors"], 0)
 
                 if not allow_slow:
                     break

--- a/coremltools/test/sklearn_tests/test_SVR.py
+++ b/coremltools/test/sklearn_tests/test_SVR.py
@@ -121,7 +121,7 @@ class SvrScikitTest(unittest.TestCase):
 
                 if _is_macos() and _macos_version() >= (10, 13):
                     metrics = evaluate_regressor(spec, df)
-                    self.assertAlmostEquals(metrics["max_error"], 0)
+                    self.assertAlmostEqual(metrics["max_error"], 0)
 
                 if not allow_slow:
                     break
@@ -168,7 +168,7 @@ class EpsilonSVRLibSVMTest(unittest.TestCase):
                 data["target"], data["data"].tolist(), self.libsvm_model
             )
             metrics = evaluate_regressor(spec, df)
-            self.assertAlmostEquals(metrics["max_error"], 0)
+            self.assertAlmostEqual(metrics["max_error"], 0)
 
         # One extra parameters. This is legal/possible.
         num_inputs = len(data["data"][0])
@@ -251,7 +251,7 @@ class EpsilonSVRLibSVMTest(unittest.TestCase):
 
                 if _is_macos() and _macos_version() >= (10, 13):
                     metrics = evaluate_regressor(spec, df)
-                    self.assertAlmostEquals(metrics["max_error"], 0)
+                    self.assertAlmostEqual(metrics["max_error"], 0)
 
                 if not allow_slow:
                     break

--- a/coremltools/test/sklearn_tests/test_dict_vectorizer.py
+++ b/coremltools/test/sklearn_tests/test_dict_vectorizer.py
@@ -98,4 +98,4 @@ class DictVectorizerScikitTest(unittest.TestCase):
             )
 
             cur_eval_metics = evaluate_classifier(model, x)
-            self.assertEquals(cur_eval_metics["num_errors"], 0)
+            self.assertEqual(cur_eval_metics["num_errors"], 0)

--- a/coremltools/test/sklearn_tests/test_feature_names.py
+++ b/coremltools/test/sklearn_tests/test_feature_names.py
@@ -19,11 +19,11 @@ class FeatureManagementTests(unittest.TestCase):
             ("c", dt.Double()),
         ]
         out = fm.process_or_validate_features(features)
-        self.assertEquals(out, processed_features)
+        self.assertEqual(out, processed_features)
         self.assertTrue(fm.is_valid_feature_list(out))
 
     def test_single_array(self):
-        self.assertEquals(
+        self.assertEqual(
             fm.process_or_validate_features("a", num_dimensions=10),
             [("a", dt.Array(10))],
         )

--- a/coremltools/test/sklearn_tests/test_glm_classifier.py
+++ b/coremltools/test/sklearn_tests/test_glm_classifier.py
@@ -78,7 +78,7 @@ class GlmCassifierTest(unittest.TestCase):
                 metrics = evaluate_classifier_with_probabilities(
                     spec, df, probabilities="classProbability", verbose=False
                 )
-                self.assertEquals(metrics["num_key_mismatch"], 0)
+                self.assertEqual(metrics["num_key_mismatch"], 0)
                 self.assertLess(metrics["max_probability_error"], 0.00001)
 
     def test_linear_svc_binary_classification_with_string_labels(self):
@@ -113,4 +113,4 @@ class GlmCassifierTest(unittest.TestCase):
                 df["prediction"] = cur_model.predict(x)
 
                 cur_eval_metics = evaluate_classifier(spec, df, verbose=False)
-                self.assertEquals(cur_eval_metics["num_errors"], 0)
+                self.assertEqual(cur_eval_metics["num_errors"], 0)

--- a/coremltools/test/sklearn_tests/test_linear_regression.py
+++ b/coremltools/test/sklearn_tests/test_linear_regression.py
@@ -46,16 +46,16 @@ class LinearRegressionScikitTest(unittest.TestCase):
         self.assertIsNotNone(spec.description)
 
         # Test the interface class
-        self.assertEquals(spec.description.predictedFeatureName, "target")
+        self.assertEqual(spec.description.predictedFeatureName, "target")
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.output), 1)
-        self.assertEquals(spec.description.output[0].name, "target")
-        self.assertEquals(
+        self.assertEqual(len(spec.description.output), 1)
+        self.assertEqual(spec.description.output[0].name, "target")
+        self.assertEqual(
             spec.description.output[0].type.WhichOneof("Type"), "doubleType"
         )
         for input_type in spec.description.input:
-            self.assertEquals(input_type.type.WhichOneof("Type"), "doubleType")
+            self.assertEqual(input_type.type.WhichOneof("Type"), "doubleType")
         self.assertEqual(
             sorted(input_names), sorted(map(lambda x: x.name, spec.description.input))
         )
@@ -65,9 +65,9 @@ class LinearRegressionScikitTest(unittest.TestCase):
             spec.pipelineRegressor.pipeline.models[-1].HasField("glmRegressor")
         )
         lr = spec.pipelineRegressor.pipeline.models[-1].glmRegressor
-        self.assertEquals(lr.offset, self.scikit_model.intercept_)
-        self.assertEquals(len(lr.weights), 1)
-        self.assertEquals(len(lr.weights[0].value), 13)
+        self.assertEqual(lr.offset, self.scikit_model.intercept_)
+        self.assertEqual(len(lr.weights), 1)
+        self.assertEqual(len(lr.weights[0].value), 13)
         i = 0
         for w in lr.weights[0].value:
             self.assertAlmostEqual(w, self.scikit_model.coef_[i])
@@ -104,7 +104,7 @@ class LinearRegressionScikitTest(unittest.TestCase):
             df["prediction"] = cur_model.predict(self.scikit_data.data)
 
             metrics = evaluate_regressor(spec, df)
-            self.assertAlmostEquals(metrics["max_error"], 0)
+            self.assertAlmostEqual(metrics["max_error"], 0)
 
     @unittest.skipUnless(
         _is_macos() and _macos_version() >= (10, 13), "Only supported on macOS 10.13+"
@@ -134,4 +134,4 @@ class LinearRegressionScikitTest(unittest.TestCase):
             df["prediction"] = cur_model.predict(self.scikit_data.data)
 
             metrics = evaluate_regressor(spec, df)
-            self.assertAlmostEquals(metrics["max_error"], 0)
+            self.assertAlmostEqual(metrics["max_error"], 0)

--- a/coremltools/test/sklearn_tests/test_one_hot_encoder.py
+++ b/coremltools/test/sklearn_tests/test_one_hot_encoder.py
@@ -59,7 +59,7 @@ class OneHotEncoderScikitTest(unittest.TestCase):
 
         self.assertIsNotNone(spec)
         self.assertIsNotNone(spec.description)
-        self.assertEquals(metrics["num_errors"], 0)
+        self.assertEqual(metrics["num_errors"], 0)
 
     @unittest.skipUnless(
         _is_macos() and _macos_version() >= (10, 13), "Only supported on macOS 10.13+"
@@ -83,7 +83,7 @@ class OneHotEncoderScikitTest(unittest.TestCase):
 
         self.assertIsNotNone(spec)
         self.assertIsNotNone(spec.description)
-        self.assertEquals(metrics["num_errors"], 0)
+        self.assertEqual(metrics["num_errors"], 0)
 
     @unittest.skipUnless(
         _is_macos() and _macos_version() >= (10, 13), "Only supported on macOS 10.13+"
@@ -107,7 +107,7 @@ class OneHotEncoderScikitTest(unittest.TestCase):
 
         self.assertIsNotNone(spec)
         self.assertIsNotNone(spec.description)
-        self.assertEquals(metrics["num_errors"], 0)
+        self.assertEqual(metrics["num_errors"], 0)
 
     @unittest.skipUnless(
         _is_macos() and _macos_version() >= (10, 13), "Only supported on macOS 10.13+"

--- a/coremltools/test/sklearn_tests/test_random_forest_classifier.py
+++ b/coremltools/test/sklearn_tests/test_random_forest_classifier.py
@@ -48,26 +48,26 @@ class RandomForestBinaryClassifierScikitTest(unittest.TestCase):
         self.assertIsNotNone(spec.description)
 
         # Test the interface class
-        self.assertEquals(spec.description.predictedFeatureName, "target")
+        self.assertEqual(spec.description.predictedFeatureName, "target")
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.output), 2)
-        self.assertEquals(spec.description.output[0].name, "target")
-        self.assertEquals(
+        self.assertEqual(len(spec.description.output), 2)
+        self.assertEqual(spec.description.output[0].name, "target")
+        self.assertEqual(
             spec.description.output[0].type.WhichOneof("Type"), "int64Type"
         )
         for input_type in spec.description.input:
-            self.assertEquals(input_type.type.WhichOneof("Type"), "doubleType")
+            self.assertEqual(input_type.type.WhichOneof("Type"), "doubleType")
         self.assertEqual(
             sorted(input_names), sorted(map(lambda x: x.name, spec.description.input))
         )
 
-        self.assertEquals(len(spec.pipelineClassifier.pipeline.models), 2)
+        self.assertEqual(len(spec.pipelineClassifier.pipeline.models), 2)
         tr = spec.pipelineClassifier.pipeline.models[
             -1
         ].treeEnsembleClassifier.treeEnsemble
         self.assertIsNotNone(tr)
-        self.assertEquals(len(tr.nodes), 1048)
+        self.assertEqual(len(tr.nodes), 1048)
 
     def test_conversion_bad_inputs(self):
         # Error on converting an untrained model
@@ -122,27 +122,27 @@ class RandomForestMultiClassClassifierScikitTest(unittest.TestCase):
         self.assertIsNotNone(spec.treeEnsembleClassifier)
 
         # Test the interface class
-        self.assertEquals(spec.description.predictedFeatureName, "target")
+        self.assertEqual(spec.description.predictedFeatureName, "target")
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.output), 2)
-        self.assertEquals(spec.description.output[0].name, "target")
-        self.assertEquals(
+        self.assertEqual(len(spec.description.output), 2)
+        self.assertEqual(spec.description.output[0].name, "target")
+        self.assertEqual(
             spec.description.output[0].type.WhichOneof("Type"), "int64Type"
         )
 
         for input_type in spec.description.input:
-            self.assertEquals(input_type.type.WhichOneof("Type"), "doubleType")
+            self.assertEqual(input_type.type.WhichOneof("Type"), "doubleType")
         self.assertEqual(
             sorted(input_names), sorted(map(lambda x: x.name, spec.description.input))
         )
 
-        self.assertEquals(len(spec.pipelineClassifier.pipeline.models), 2)
+        self.assertEqual(len(spec.pipelineClassifier.pipeline.models), 2)
         tr = spec.pipelineClassifier.pipeline.models[
             -1
         ].treeEnsembleClassifier.treeEnsemble
         self.assertIsNotNone(tr)
-        self.assertEquals(len(tr.nodes), 2970)
+        self.assertEqual(len(tr.nodes), 2970)
 
     def test_conversion_bad_inputs(self):
         # Error on converting an untrained model

--- a/coremltools/test/sklearn_tests/test_random_forest_classifier_numeric.py
+++ b/coremltools/test/sklearn_tests/test_random_forest_classifier_numeric.py
@@ -21,7 +21,7 @@ if _HAS_SKLEARN:
 @unittest.skipIf(not _HAS_SKLEARN, "Missing sklearn. Skipping tests.")
 class RandomForestClassificationBostonHousingScikitNumericTest(unittest.TestCase):
     def _check_metrics(self, metrics, params={}):
-        self.assertEquals(
+        self.assertEqual(
             metrics["num_errors"],
             0,
             msg="Failed case %s. Results %s" % (params, metrics),

--- a/coremltools/test/sklearn_tests/test_random_forest_regression.py
+++ b/coremltools/test/sklearn_tests/test_random_forest_regression.py
@@ -48,27 +48,27 @@ class RandomForestRegressorScikitTest(unittest.TestCase):
         self.assertIsNotNone(spec.description)
 
         # Test the interface class
-        self.assertEquals(spec.description.predictedFeatureName, "target")
+        self.assertEqual(spec.description.predictedFeatureName, "target")
 
         # Test the inputs and outputs
-        self.assertEquals(len(spec.description.output), 1)
-        self.assertEquals(spec.description.output[0].name, "target")
-        self.assertEquals(
+        self.assertEqual(len(spec.description.output), 1)
+        self.assertEqual(spec.description.output[0].name, "target")
+        self.assertEqual(
             spec.description.output[0].type.WhichOneof("Type"), "doubleType"
         )
         for input_type in spec.description.input:
-            self.assertEquals(input_type.type.WhichOneof("Type"), "doubleType")
+            self.assertEqual(input_type.type.WhichOneof("Type"), "doubleType")
         self.assertEqual(
             sorted(input_names), sorted(map(lambda x: x.name, spec.description.input))
         )
 
         # Test the linear regression parameters.
-        self.assertEquals(len(spec.pipelineRegressor.pipeline.models), 2)
+        self.assertEqual(len(spec.pipelineRegressor.pipeline.models), 2)
         tr = spec.pipelineRegressor.pipeline.models[
             -1
         ].treeEnsembleRegressor.treeEnsemble
         self.assertIsNotNone(tr)
-        self.assertEquals(len(tr.nodes), 5996)
+        self.assertEqual(len(tr.nodes), 5996)
 
     def test_conversion_bad_inputs(self):
         # Error on converting an untrained model

--- a/coremltools/test/sklearn_tests/test_random_forest_regression_numeric.py
+++ b/coremltools/test/sklearn_tests/test_random_forest_regression_numeric.py
@@ -43,13 +43,13 @@ class RandomForestRegressorBostonHousingScikitNumericTest(unittest.TestCase):
         """
         Check the metrics
         """
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             metrics["rmse"],
             0.0,
             delta=1e-5,
             msg="Failed case %s. Results %s" % (params, metrics),
         )
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             metrics["max_error"],
             0.0,
             delta=1e-5,

--- a/coremltools/test/xgboost_tests/test_boosted_trees_classifier_numeric.py
+++ b/coremltools/test/xgboost_tests/test_boosted_trees_classifier_numeric.py
@@ -49,7 +49,7 @@ class BoostedTreeClassificationBostonHousingScikitNumericTest(unittest.TestCase)
         self.output_name = "target"
 
     def _check_metrics(self, metrics, params={}):
-        self.assertEquals(
+        self.assertEqual(
             metrics["num_errors"],
             0,
             msg="Failed case %s. Results %s" % (params, metrics),
@@ -166,7 +166,7 @@ class BoostedTreeClassificationBostonHousingXGboostNumericTest(unittest.TestCase
     """
 
     def _check_metrics(self, metrics, params={}):
-        self.assertEquals(
+        self.assertEqual(
             metrics["num_errors"],
             0,
             msg="Failed case %s. Results %s" % (params, metrics),
@@ -194,7 +194,7 @@ class BoostedTreeClassificationBostonHousingXGboostNumericTest(unittest.TestCase
             metrics = evaluate_classifier_with_probabilities(
                 spec, df, probabilities="classProbability", verbose=False
             )
-            self.assertEquals(metrics["num_key_mismatch"], 0)
+            self.assertEqual(metrics["num_key_mismatch"], 0)
             self.assertLess(metrics["max_probability_error"], 1e-3)
 
     def _classifier_stress_test(self):

--- a/coremltools/test/xgboost_tests/test_boosted_trees_regression_numeric.py
+++ b/coremltools/test/xgboost_tests/test_boosted_trees_regression_numeric.py
@@ -35,13 +35,13 @@ class GradientBoostingRegressorBostonHousingScikitNumericTest(unittest.TestCase)
         self.output_name = "target"
 
     def _check_metrics(self, metrics, params={}):
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             metrics["rmse"],
             0,
             delta=1e-5,
             msg="Failed case %s. Results %s" % (params, metrics),
         )
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             metrics["max_error"],
             0,
             delta=1e-5,
@@ -114,13 +114,13 @@ class XgboostBoosterBostonHousingNumericTest(unittest.TestCase):
         """
         Check the metrics
         """
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             metrics["rmse"],
             allowed_error.get("rmse", 0),
             delta=1e-2,
             msg="Failed case %s. Results %s" % (params, metrics),
         )
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             metrics["max_error"],
             allowed_error.get("max_error", 0),
             delta=1e-2,
@@ -219,13 +219,13 @@ class XGboostRegressorBostonHousingNumericTest(unittest.TestCase):
         self.output_name = "target"
 
     def _check_metrics(self, metrics, params={}, allowed_error={}):
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             metrics["rmse"],
             allowed_error.get("rmse", 0),
             delta=1e-2,
             msg="Failed case %s. Results %s" % (params, metrics),
         )
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             metrics["max_error"],
             allowed_error.get("max_error", 0),
             delta=1e-2,

--- a/coremltools/test/xgboost_tests/test_decision_tree_classifier_numeric.py
+++ b/coremltools/test/xgboost_tests/test_decision_tree_classifier_numeric.py
@@ -19,7 +19,7 @@ if _HAS_SKLEARN:
 @unittest.skipIf(not _HAS_SKLEARN, "Missing sklearn. Skipping tests.")
 class DecisionTreeClassificationBostonHousingScikitNumericTest(unittest.TestCase):
     def _check_metrics(self, metrics, params={}):
-        self.assertEquals(
+        self.assertEqual(
             metrics["num_errors"],
             0,
             msg="Failed case %s. Results %s" % (params, metrics),

--- a/coremltools/test/xgboost_tests/test_decision_tree_regression_numeric.py
+++ b/coremltools/test/xgboost_tests/test_decision_tree_regression_numeric.py
@@ -36,13 +36,13 @@ class DecisionTreeRegressorBostonHousingScikitNumericTest(unittest.TestCase):
         """
         Check the metrics
         """
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             metrics["rmse"],
             0,
             delta=1e-5,
             msg="Failed case %s. Results %s" % (params, metrics),
         )
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             metrics["max_error"],
             0,
             delta=1e-5,


### PR DESCRIPTION
The deprecated unittest aliases have been removed in https://github.com/python/cpython/pull/28268.

assertEquals -> assertEqual
assertAlmostEquals -> assertAlmostEqual