### PR TITLE
arm64 build: use same version of numpy as tensorflow-metal

### DIFF
--- a/reqs/build.pip
+++ b/reqs/build.pip
@@ -1,4 +1,4 @@
-numpy<1.20
+numpy<1.20; platform_machine != "arm64"
 protobuf
 pytest
 six

--- a/scripts/env_create.sh
+++ b/scripts/env_create.sh
@@ -91,6 +91,11 @@ fi
 echo "Installing basic build requirements."
 if [[ $include_build_deps == 1 ]]; then
     python -m pip install -r $COREMLTOOLS_HOME/reqs/build.pip
+
+    if [[ $(uname -m) == "arm64" ]]; then
+	# Install the earliest version of numpy, we can find, that support arm64
+	conda install -c apple numpy==1.19.5 -y
+    fi
 fi
 
 # Install test requirements (upgrades packages if required)


### PR DESCRIPTION
Fixes #1325