### PR TITLE
Fix Sphinx warnings when generating HTML

### DIFF
--- a/coremltools/converters/_converters_entry.py
+++ b/coremltools/converters/_converters_entry.py
@@ -51,42 +51,50 @@ def convert(
     debug=False,
 ):
     """
-    Convert a TensorFlow or PyTorch model to the Core ML model format as either
-    a neural network or an ML program. To learn about the differences, see
+    Convert a TensorFlow or PyTorch model to the Core ML model format as either a neural network or an ML program. 
+    To learn about the differences, see
     `ML Programs <https://coremltools.readme.io/docs/ml-programs>`_.
+    This function is aliased as ``ct.convert`` in examples and guides.
+    Some parameters and requirements differ by TensorFlow and PyTorch frameworks.
 
-    This function is aliased as ``ct.convert`` in examples and guides. Some
-    parameters and requirements differ by TensorFlow and PyTorch frameworks.
 
     Parameters
     ----------
+    
     model :
         TensorFlow 1, TensorFlow 2, or PyTorch model in one of the following
-        formats:
+        formats.
 
-        For TensorFlow versions 1.x:
+        * TensorFlow versions 1.x
+        
             - Frozen `tf.Graph <https://www.tensorflow.org/api_docs/python/tf/Graph>`_
             - Frozen graph (``.pb``) file path
             - `tf.keras.Model <https://www.tensorflow.org/api_docs/python/tf/keras>`_
             -  `HDF5 <https://keras.io/api/models/model_saving_apis/>`_ file path (``.h5``)
             - `SavedModel <https://www.tensorflow.org/guide/saved_model>`_ directory path
-        For TensorFlow versions 2.x:
+
+        * TensorFlow versions 2.x
+        
             - `tf.keras.Model <https://www.tensorflow.org/api_docs/python/tf/keras>`_
             - `HDF5 file path <https://keras.io/api/models/model_saving_apis/>`_ (``.h5``)
             - `SavedModel <https://www.tensorflow.org/guide/saved_model>`_ directory path
             - A `concrete function <https://www.tensorflow.org/guide/concrete_function>`_
-        For PyTorch:
+
+        * PyTorch
+        
             - A `TorchScript <https://pytorch.org/docs/stable/jit.html>`_ object
             - Path to a ``.pt`` file
 
     source : str (optional)
+    
         One of [``auto``, ``tensorflow``, ``pytorch``, ``milinternal``]. ``auto``
         determines the framework automatically for most cases. Raises
         ``ValueError`` if it fails to determine the source framework.
 
     inputs : list of ``TensorType`` or ``ImageType``
 
-        TensorFlow 1 and 2:
+        * TensorFlow 1 and 2
+
             - The ``inputs`` parameter is optional. If not provided, the inputs
               are placeholder nodes in the model (if the model is frozen graph)
               or function inputs (if the model is a ``tf.function``).
@@ -96,7 +104,8 @@ def convert(
               specified. ``shape`` is optional.
             - If ``inputs`` is provided, it must be a flat list.
 
-        PyTorch:
+        * PyTorch
+
             - The ``inputs`` parameter is required.
             - ``inputs`` may be a nested list or tuple.
             - ``TensorType`` and ``ImageType`` in ``inputs`` must have the ``name``
@@ -104,7 +113,8 @@ def convert(
 
     outputs : list[str] (optional)
 
-        TensorFlow 1 and 2:
+        * TensorFlow 1 and 2
+
             - The ``outputs`` parameter is optional.
 
             - If specified, ``outputs`` is a list of string representing node
@@ -113,19 +123,22 @@ def convert(
             - If ``outputs`` is not specified, the converter infers outputs to
               all be terminal identity nodes.
 
-        PyTorch:
+        * PyTorch
+
             - ``outputs`` must not be specified.
 
     classifier_config : ClassifierConfig class (optional)
         The configuration if the MLModel is intended to be a classifier.
 
     minimum_deployment_target : coremltools.target enumeration (optional)
-        - One of the members of enum ``coremltools.target``.
-        - The value of this parameter determines the type of the model
-          reperesentation produced by the converter. Alternatively, you can use
-          the ``convert_to`` parameter to specify the model type (see the
-          ``convert_to`` parameter). To learn about the differences between
-          neural networks and ML programs, see `ML Programs <https://coremltools.readme.io/docs/ml-programs>`_.
+        One of the members of enum ``coremltools.target``.
+        The value of this parameter determines the type of the model
+        representation produced by the converter. Alternatively, you can use
+        the ``convert_to`` parameter to specify the model type (see the
+        ``convert_to`` parameter). To learn about the differences between
+        neural networks and ML programs, see
+        `ML Programs <https://coremltools.readme.io/docs/ml-programs>`_.
+
         - The converter produces a neural network (``neuralnetwork``) if:
           ::
              minimum_deployment_target <= coremltools.target.iOS14/
@@ -152,13 +165,14 @@ def convert(
             convert_to="mlprogram", minimum_deployment_target=coremltools.target.iOS14
 
     convert_to : str (optional)
-        - Must be one of [``'neuralnetwork'``, ``'mlprogram'``, ``'milinternal'``].
-        - The value of this parameter determines the type of the model
-          reperesentation produced by the converter. Alternatively, you can use
-          the ``minimum_deployment_target`` parameter to specify the model type
-          (see the ``minimum_deployment_target`` parameter). To learn about the
-          differences between neural networks and ML programs, see
-          `ML Programs <https://coremltools.readme.io/docs/ml-programs>`_.
+        Must be one of [``'neuralnetwork'``, ``'mlprogram'``, ``'milinternal'``].
+        The value of this parameter determines the type of the model
+        representation produced by the converter. Alternatively, you can use
+        the ``minimum_deployment_target`` parameter to specify the model type
+        (see the ``minimum_deployment_target`` parameter). To learn about the
+        differences between neural networks and ML programs, see
+        `ML Programs <https://coremltools.readme.io/docs/ml-programs>`_.
+        
         - ``'neuralnetwork'``: Returns an MLModel (``coremltools.models.MLModel``)
           containing a NeuralNetwork proto, which is the original Core ML format.
           The model saved from this returned object is executable either on
@@ -181,34 +195,35 @@ def convert(
           parameter is specified, the converter produces the neural network
           model type with as minimum of a deployment target as possible.
 
-    compute_precision :
-    coremltools.precision enumeration or ct.transform.FP16ComputePrecision() (optional)
-        - Must be one of the following:
-            - ``coremltools.precision.FLOAT16``
-                - The following transform is applied:
-                  ::
-                      coremltools.transform.FP16ComputePrecision(op_selector=
-                                                             lambda op:True)
+    compute_precision : coremltools.precision enumeration or ct.transform.FP16ComputePrecision() (optional)
 
-                  The above transform injects ``cast`` ops to convert the
-                  float32 dtypes of intermediate tensors to float16.
-            - ``coremltools.precision.FLOAT32``
-                - No transform is applied. The original float32 tensor dtype in
-                  the source model is preserved.
-            - ``coremltools.transform.FP16ComputePrecision(op_selector=...)``
-                - Use the above to control which tensors are cast to float16.
-                - For example:
-                  ::
-                      coremltools.transform.FP16ComputePrecision(op_selector=
-                                          lambda op: op.op_type != "linear")
+        Must be one of the following.
+        
+        - ``coremltools.precision.FLOAT16``
+            - The following transform is applied:
+              ::
+                 coremltools.transform.FP16ComputePrecision(op_selector=
+                                                         lambda op:True)
 
-                  The above casts all the float32 tensors to be float16, except
-                  the input/output tensors to any ``linear`` op.
-            - If ``None``,
-                - When ``convert_to="mlprogram"``, compute_precision parameter
-                  defaults to ``coremltools.precision.FLOAT16``.
-                - When ``convert_to="neuralnetwork"``, compute_precision parameter
-                  needs to be ``None`` and has no meaning.
+              The above transform injects ``cast`` ops to convert the
+              float32 dtypes of intermediate tensors to float16.
+        - ``coremltools.precision.FLOAT32``
+            - No transform is applied. The original float32 tensor dtype in
+              the source model is preserved.
+        - ``coremltools.transform.FP16ComputePrecision(op_selector=...)``
+            - Use the above to control which tensors are cast to float16.
+            - For example:
+              ::
+                 coremltools.transform.FP16ComputePrecision(op_selector=
+                                         lambda op: op.op_type != "linear")
+
+              The above casts all the float32 tensors to be float16, except
+              the input/output tensors to any ``linear`` op.
+        - ``None``
+            - When ``convert_to="mlprogram"``, compute_precision parameter
+              defaults to ``coremltools.precision.FLOAT16``.
+            - When ``convert_to="neuralnetwork"``, compute_precision parameter
+              needs to be ``None`` and has no meaning.
 
     skip_model_load : bool
         Set to True to prevent coremltools from calling into the Core ML framework
@@ -225,7 +240,9 @@ def convert(
         Defaults to False.
 
     compute_units: coremltools.ComputeUnit
-        An enum with three possible values:
+    
+        An enum with three possible values.
+        
             - ``coremltools.ComputeUnit.ALL``: Use all compute units available, including the
               neural engine.
             - ``coremltools.ComputeUnit.CPU_ONLY``: Limit the model to only use the CPU.
@@ -252,11 +269,13 @@ def convert(
 
     Returns
     -------
+    
     model : ``coremltools.models.MLModel`` or ``coremltools.converters.mil.Program``
         A Core ML MLModel object or MIL Program object (see ``convert_to``).
 
     Examples
     --------
+    
     TensorFlow 1, 2 (``model`` is a frozen graph):
 
         >>> with tf.Graph().as_default() as graph:

--- a/coremltools/converters/_converters_entry.py
+++ b/coremltools/converters/_converters_entry.py
@@ -54,7 +54,6 @@ def convert(
     Convert a TensorFlow or PyTorch model to the Core ML model format as either a neural network or an ML program. 
     To learn about the differences, see
     `ML Programs <https://coremltools.readme.io/docs/ml-programs>`_.
-    This function is aliased as ``ct.convert`` in examples and guides.
     Some parameters and requirements differ by TensorFlow and PyTorch frameworks.
 
 
@@ -131,11 +130,9 @@ def convert(
         The configuration if the MLModel is intended to be a classifier.
 
     minimum_deployment_target : coremltools.target enumeration (optional)
-        One of the members of enum ``coremltools.target``.
+        A member of the ``coremltools.target`` enum.
         The value of this parameter determines the type of the model
-        representation produced by the converter. Alternatively, you can use
-        the ``convert_to`` parameter to specify the model type (see the
-        ``convert_to`` parameter). To learn about the differences between
+        representation produced by the converter. To learn about the differences between
         neural networks and ML programs, see
         `ML Programs <https://coremltools.readme.io/docs/ml-programs>`_.
 
@@ -167,9 +164,7 @@ def convert(
     convert_to : str (optional)
         Must be one of [``'neuralnetwork'``, ``'mlprogram'``, ``'milinternal'``].
         The value of this parameter determines the type of the model
-        representation produced by the converter. Alternatively, you can use
-        the ``minimum_deployment_target`` parameter to specify the model type
-        (see the ``minimum_deployment_target`` parameter). To learn about the
+        representation produced by the converter. To learn about the
         differences between neural networks and ML programs, see
         `ML Programs <https://coremltools.readme.io/docs/ml-programs>`_.
         

--- a/coremltools/converters/mil/mil/ops/defs/tensor_operation.py
+++ b/coremltools/converters/mil/mil/ops/defs/tensor_operation.py
@@ -423,17 +423,19 @@ class pad(Operation):
 
     Parameters
     ----------
+    
     x: tensor<[\*D_in],T>  (Required)
 
     pad: tensor<[2\*N],i32> (Required)
-        * ``N <= D_in``: Last ``N`` dimensions of ``x`` are padded as follows: For
-          each dimension ``i`` of ``x`` if ``i >= D_in - N``:
+        ``N <= D_in``. Last ``N`` dimensions of ``x`` are padded as follows:
+        
+        * For each dimension ``i`` of ``x`` if ``i >= D_in - N``:
             * pad ``pad[2*i]`` elements before ``x[..,i,..]``
             * pad ``pad[2*i+1]`` elements after ``x[..,i,..]``
         * If mode is "reflect" then ``pad[2*i]`` and ``pad[2*i+1]`` can be at
-        most ``D[i]-1``.
+          most ``D[i]-1``.
         * If mode is "replicate" then ``pad[2*i]`` and ``pad[2*i+1]`` can be
-        at most ``D[i]``.
+          at most ``D[i]``.
 
     mode: const<str> (Optional)
         * Default to ``constant``.

--- a/coremltools/models/neural_network/builder.py
+++ b/coremltools/models/neural_network/builder.py
@@ -272,28 +272,29 @@ class NeuralNetworkBuilder(object):
 
         Parameters
         ----------
+
         input_features: [(str, datatypes.Array)] or None
             List of input feature of the network. 
             Each feature is a ``(name, array)`` tuple, where ``name`` is the 
             name of the feature, and ``array`` is a ``datatype.Array`` object 
             describing the feature type.
             
-            When ``spec`` is ``None`` (building from scratch), ``input_features`` must not be ``None``.
+            * When ``spec`` is ``None`` (building from scratch), ``input_features`` must not be ``None``.
 
-            When ``spec`` is not ``None``, ``input_features`` will be ignored; 
-            the input feature of the existing spec will be used instead.
+            * When ``spec`` is not ``None``, ``input_features`` will be ignored; 
+              the input feature of the existing spec will be used instead.
 
         output_features: [(str, datatypes.Array or None)] or None
             List of output feature of the network. Each feature is a 
             ``(name, array)`` tuple, where ``name`` is the name of the feature, 
             and ``array`` is a ``datatypes.Array`` object describing the feature type.
             
-            The ``array`` can be ``None`` if not known.
+            * The ``array`` can be ``None`` if not known.
             
-            When ``spec`` is ``None`` (building from scratch), ``output_features`` must not be ``None``.
+            * When ``spec`` is ``None`` (building from scratch), ``output_features`` must not be ``None``.
             
-            When ``spec`` is not ``None``, ``output_features`` will be ignored; 
-            the output feature of the existing spec will be used instead.
+            * When ``spec`` is not ``None``, ``output_features`` will be ignored; 
+              the output feature of the existing spec will be used instead.
 
         mode: str ('classifier', 'regressor' or None)
             Mode (one of ``'classifier'``, ``'regressor'``, or ``None``).
@@ -2285,35 +2286,45 @@ class NeuralNetworkBuilder(object):
 
         Parameters
         ----------
+        
         name: str
             The name of this layer.
+
         kernel_channels: int
             Number of channels for the convolution kernels.
+
         output_channels: int
             Number of filter kernels. This is equal to the number of channels in the output blob.
+
         height: int
             Height of each kernel.
+
         width: int
             Width of each kernel.
+
         stride_height: int
             Stride along the height direction.
+
         stride_width: int
             Stride along the height direction.
+
         border_mode: str
             Option for the padding type and output blob shape. Can be either 'valid' or 'same'.
+ 
         groups: int
             Number of kernel groups. Input is divided into groups along the channel axis. 
             Each kernel group share the same weights.
+ 
         W: numpy.array or bytes() or None
 
             Weight of the convolution kernels.
 
             * If ``is_deconv`` is False, ``W`` should have 
               shape ``(height, width, kernel_channels, output_channels)``, where:
-                 ``kernel_channel = input_channels / groups``.
+                 ``kernel_channel = input_channels / groups``
             * If ``is_deconv`` is True, ``W`` should have 
               shape ``(height, width, kernel_channels, output_channels / groups)``, where:
-                 ``kernel_channel = input_channels``.
+                 ``kernel_channel = input_channels``
 
             If ``W`` is of type ``bytes()`` (quantized), other quantization 
             related arguments must be provided as well (see below).
@@ -2324,6 +2335,7 @@ class NeuralNetworkBuilder(object):
 
         b: numpy.array
             Biases of the convolution kernels. ``b`` should have shape ``(outputChannels, )``.
+
         has_bias: boolean
             Whether bias is ignored.
 
@@ -2340,34 +2352,32 @@ class NeuralNetworkBuilder(object):
         output_shape: tuple or None
             Either ``None`` or a 2-tuple, specifying the output 
             shape ``(output_height, output_width)``. 
-            Used only when ``is_deconv == True``.
-            When ``is_deconv == False``, this parameter is ignored.
-            If it is ``None``, the output shape is calculated automatically using the ``border_mode``.
+            
+            - Used only when ``is_deconv == True``.
+            - When ``is_deconv == False``, this parameter is ignored.
+            - If it is ``None``, the output shape is calculated automatically using the ``border_mode``.
 
         input_name: str or list of str
             The input blob name(s) of this layer.
+
         output_name: str
             The output blob name of this layer.
+
         dilation_factors: list of int
             Dilation factors across height and width directions. Must be a list of two positive integers.
             Defaults to ``[1, 1]``.
+
         padding_top, padding_bottom, padding_left, padding_right: int
-            values of height (top, bottom) and width (left, right) padding 
+            Values of height (top, bottom) and width (left, right) padding 
             to be used if ``border_more`` is ``"valid"``.
+
         same_padding_asymmetry_mode: str
             Type of asymmetric padding to be used when  ``border_mode`` is ``'same'``.
             Can be either ``'BOTTOM_RIGHT_HEAVY'`` or  ``'TOP_LEFT_HEAVY'``.
-		Depthwise convolution
-			Depthwise convolution is a special case of convolution, in which:
-			
-            	* ``kernel_channels = 1 (== input_channels / groups)``
-            	* ``output_channels = channel_multiplier * input_channels``
-           	* ``groups = input_channels``
-            	* ``W``: ``[Kernel_height, Kernel_width, 1, channel_multiplier * input_channels]``
 
 		Quantization
 			Quantization arguments expected in ``kwargs``, when ``W`` is of type ``bytes()``.
-
+        
 				quantization_type: str
 					When weights are quantized (that is, ``W`` is of type ``bytes()``), 
 					this should be either ``"linear"`` or ``"lut"``.
@@ -2387,6 +2397,14 @@ class NeuralNetworkBuilder(object):
 				quant_lut: numpy.array(dtype=numpy.float32)
 					the LUT (look up table) to be used with LUT quantization. 
 					Must be of length 2^n bits.
+
+        Depthwise convolution
+        	Depthwise convolution is a special case of convolution, in which:
+        
+                  * ``kernel_channels = 1 (== input_channels / groups)``
+                  * ``output_channels = channel_multiplier * input_channels``
+                  * ``groups = input_channels``
+                  * ``W``: ``[Kernel_height, Kernel_width, 1, channel_multiplier * input_channels]``
 
         See Also
         --------
@@ -2553,21 +2571,28 @@ class NeuralNetworkBuilder(object):
 
         Parameters
         ----------
+
         name: str
             The name of this layer.
+
         input_channels: int
             Number of input channels.
+
         output_channels: int
             Number of filter kernels. This is equal to the number of channels in the output blob.
+
         depth: int
             Depth of each kernel.
+
         height: int
             Height of each kernel.
+
         width: int
             Width of each kernel.
+
         W: numpy.array or bytes()
-            Weight of the convolution kernels.
-            - ``W`` should have shape:
+            Weight of the convolution kernels. ``W`` should have shape:
+
             - If ``deconv`` is False:
             
                  ``(output_channels, kernel_channels, depth, height, width)``, where:
@@ -2582,34 +2607,44 @@ class NeuralNetworkBuilder(object):
               
         b: numpy.array
             Biases of the convolution kernels. ``b`` should have shape ``(outputChannels, )``.
+
         has_bias: boolean
             Whether bias is ignored.
             - If True, bias is not ignored.
             - If False, bias is ignored.
+
         groups: int
             Number of kernel groups. Input is divided into groups along the channel axis. Each
             kernel group share the same weights. Defaults to 1.
+
         stride_depth, stride_height, stride_width: int
             Stride along the depth, height, and width directions, respectively. Must all be positive
             integers. Defaults to 1.
+
         dilation_depth, dilation_width, dilation_height: int
             Dilation factors across depth, height, and width directions. Must all be positive
             integers. Defaults to 1 in each dimension.
+
         is_deconv: bool
             True if this is Convolution Transpose, otherwise False.
+
         output_shape: None or Tuple of int
             Applicable only for Deconvolution layer.
             ``None`` if Convolution.
             Tuple of length 3 if Convolution Transpose.
+
         padding_mode: str
             Option for the padding type and output blob shape. 
             Can be ``'custom'``, ``'valid'``, or ``'same'``.
             Defaults to ``'valid'``. Case-insensitive.
+
         padding_front, padding_back, padding_top, padding_bottom, padding_left, padding_right: int
             Values of depth (front, back), height (top, bottom), and width (left, right) padding to
             be used. Must all be positive integers. All default to 0.
+
         input_name: str or list of str
             The input blob name(s) of this layer.
+
         output_name: str
             The output blob name of this layer.
 
@@ -2733,39 +2768,54 @@ class NeuralNetworkBuilder(object):
 
         Parameters
         ----------
+
         name: str
             The name of this layer.
+
         height: int
             Height of pooling region.
+
         width: int
             Width of pooling region.
+
         stride_height: int
             Stride along the height direction.
+
         stride_width: int
             Stride along the width direction.
+
         layer_type: str
             Type of pooling performed. Can either be ``'MAX'``, ``'AVERAGE'``, or ``'L2'``.
+
         padding_type: str
             Option for the type of padding and output blob shape. Can be either 
             ``'VALID'``, ``'SAME'``, or ``'INCLUDE_LAST_PIXEL'``.
+
         input_name: str
             The input blob name of this layer.
+
         output_name: str
             The output blob name of this layer.
+
         exclude_pad_area: boolean
-            Whether to exclude padded area in the ``'AVERAGE'`` pooling operation, default: true.
+            Whether to exclude padded area in the ``'AVERAGE'`` pooling operation,
+            default: true. This flag is only used with average pooling.
+            
             - If True, the value of the padded area will be excluded.
             - If False, the padded area will be included.
-            This flag is only used with average pooling.
+
         is_global: boolean
             Whether the pooling operation is global. Defaults to False.
+            
             - If True, the pooling operation is global. The pooling region 
               is of the same size of the input blob.
               Parameters ``height``, ``width``, ``stride_height``, and ``stride_width`` will be ignored.
             - If False, the pooling operation is not global.
+
         padding_top, padding_bottom, padding_left, padding_right: int
-            values of height (top, bottom) and width (left, right) padding 
+            Values of height (top, bottom) and width (left, right) padding 
             to be used if padding type is ``"VALID"`` or ``"INCLUDE_LAST_PIXEL"``.
+
         same_padding_asymmetry_mode: str.
             Type of asymmetric padding to be used when ``padding_type = 'SAME'``.
             Can be either ``'BOTTOM_RIGHT_HEAVY'`` or ``'TOP_LEFT_HEAVY'``.
@@ -3558,7 +3608,7 @@ class NeuralNetworkBuilder(object):
             If ``True``, a vector of 1s is added to forget gate bias. Defaults to ``False``.
         coupled_input_forget_gate: boolean
             If ``True``, the input gate and forget gate is coupled. That is, the
-             forget gate is not used.
+            forget gate is not used.
             Defaults to ``False``.
         cell_clip_threshold: float
             The limit on the maximum and minimum values on the cell state.
@@ -4534,31 +4584,42 @@ class NeuralNetworkBuilder(object):
 
         Parameters
         ----------
+
         name: str
             The name of this layer.
+
         input_names: list of str
- 
-            Must be a list of two names: image feature map and crop indices/RoI input.
-               * First input corresponds to a blob with shape ``[1, Batch, C, H_in, W_in]``. This represents a batch of input image feature data with ``C`` channels.
-               * The second input shape must be ``[N, 1, 4, 1, 1]`` or ``[N, 1, 5, 1, 1]``. This represents the bounding box coordinates for ``N`` patches/RoIs.
-            *  ``N``: number of patches/RoIs to be extracted
-            * If RoI shape = ``[N, 1, 4, 1, 1]``, the channel axis corresponds to the four coordinates specifying the bounding box.
+            * Must be a list of two names: image feature map and crop indices/RoI input.
+               * First input corresponds to a blob with shape ``[1, Batch, C, H_in, W_in]``.
+                 This represents a batch of input image feature data with ``C`` channels.
+               * The second input shape must be ``[N, 1, 4, 1, 1]`` or ``[N, 1, 5, 1, 1]``.
+                 This represents the bounding box coordinates for ``N`` patches/RoIs.
+            * ``N``: number of patches/RoIs to be extracted.
+            * If RoI shape = ``[N, 1, 4, 1, 1]``, the channel axis corresponds
+              to the four coordinates specifying the bounding box.
               All the N~ RoIs are extracted from all the batches of the input.
-            * If RoI shape = ``[N, 1, 5, 1, 1]``, the first element of the channel axis specifies the input batch id from which to extract the RoI and
-              must be in the interval ``[0, Batch - 1]``. That is, ``n`` -th RoI is extracted from the ``RoI[n,0,0,0]`` -th input batch id.
-              The last four elements of the channel axis specify the bounding box coordinates.
+            * If RoI shape = ``[N, 1, 5, 1, 1]``, the first element of the
+              channel axis specifies the input batch id from which to extract the RoI and
+              must be in the interval ``[0, Batch - 1]``. That is, ``n`` -th RoI is 
+              extracted from the ``RoI[n,0,0,0]`` -th input batch id.
+              The last four elements of the channel axis specify the
+              bounding box coordinates.
 
         output_name: str
             The output blob name of this layer.
+
         target_height: int
             Output height dimension.
+
         target_width: int
             Output width dimension.
+
         mode: str
             * The following values are supported: 
               ``'STRICT_ALIGN_ENDPOINTS_MODE'``, ``'ALIGN_ENDPOINTS_MODE'``, 
               ``'UPSAMPLE_MODE'``, ``'ROI_ALIGN_MODE'``.
             * This parameter determines the sampling grid used for bilinear interpolation.
+
         normalized_roi: bool
             * If true the bounding box coordinates must be in the interval ``[0, 1]``.
               They are scaled by ``(input_height - 1)``, ``(input_width - 1)``; 
@@ -4566,6 +4627,7 @@ class NeuralNetworkBuilder(object):
             * If false the bounding box coordinates must be in the interval
               ``[0, input_height - 1]`` and ``[0, input_width - 1]``, 
               respectively for height and width dimensions.
+
         box_indices_mode: str
             * The following values are supported: 
               ``'CORNERS_HEIGHT_FIRST'``, ``'CORNERS_WIDTH_FIRST'``, 
@@ -4575,6 +4637,7 @@ class NeuralNetworkBuilder(object):
                 * ``'CORNERS_WIDTH_FIRST'``: ``[w_start, h_start, w_end, h_end]``
                 * ``'CENTER_SIZE_HEIGHT_FIRST'``: ``[h_center, w_center, box_height, box_width]``
                 * ``'CENTER_SIZE_WIDTH_FIRST'``: ``[w_center, h_center, box_width, box_height]``
+
         spatial_scale: float
             Additional spatial scale that multiplies the bounding box coordinates.
             Generally used while implementing the RoI Align layer,

--- a/docs/source/coremltools.converters.mil.mil.ops.defs.rst
+++ b/docs/source/coremltools.converters.mil.mil.ops.defs.rst
@@ -230,7 +230,6 @@ tensor\_operation
    .. autoclass:: split
    .. autoclass:: stack
    .. autoclass:: identity
-   .. autoclass:: isfinite
 
 
 tensor\_transformation

--- a/docs/source/coremltools.converters.mil.rst
+++ b/docs/source/coremltools.converters.mil.rst
@@ -6,4 +6,3 @@ MIL Builder
    .. autoclass:: Builder
       :members:
       
-      .. method:: program


### PR DESCRIPTION
This PR includes the following documentation changes based on warnings from Sphinx while generating the API.

The formatting errors in these files are fixed:

```
	modified:   coremltools/converters/_converters_entry.py
	modified:   coremltools/converters/mil/mil/ops/defs/tensor_operation.py
	modified:   coremltools/models/neural_network/builder.py
```

The `autodoc: failed to import class 'isfinite'` error is fixed by editing this file:

```
	modified:   docs/source/coremltools.converters.mil.mil.ops.defs.rst
```

The `WARNING: duplicate object description of coremltools.converters.mil.mil.Builder.program, other instance in source/coremltools.converters.mil` error is fixed by editing this file:

```
	modified:   docs/source/coremltools.converters.mil.rst
```

This PR does _not_ include the generated HTML. After these changes are
reviewed and merged, I will do a separate PR to merge the HTML.

The following attached screenshots demonstrate some of the formatting changes (see "before" and "after" for each type of screenshot).

### Compute Precision Before

![compute_precision_before](https://user-images.githubusercontent.com/70229264/140432980-47e664bb-5bcf-4cf8-995b-860bbe1fc444.png)

### Compute Precision After

![compute_precision_after](https://user-images.githubusercontent.com/70229264/140432974-64ad651d-f387-4420-9159-e11034132245.png)

### Add Pooling Before 
![add_pooling_before](https://user-images.githubusercontent.com/70229264/140433007-822d0658-dc7d-4bd0-96e7-86e15d2841a6.png)

### Add Pooling After
![add_pooling_after](https://user-images.githubusercontent.com/70229264/140433000-5a3b92f4-c967-4c72-b624-1ed7fe8ae2f9.png)


