### PR TITLE
Fixed unbind for one split size

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -3179,8 +3179,11 @@ def unbind(context, node):
     x = inputs[0]
     dim = inputs[1].val
     split_sizes = [1]*x.shape[dim]
-    res = mb.split(x=x, split_sizes=split_sizes, axis=dim, name=node.name)
-    res = [mb.squeeze(x=x, axes=[dim]) for x in res]
+    if len(split_sizes) == 1:
+        res = [mb.squeeze(x=x, axes=[dim])]
+    else:
+        res = mb.split(x=x, split_sizes=split_sizes, axis=dim, name=node.name)
+        res = [mb.squeeze(x=x, axes=[dim]) for x in res]
     context.add(res, torch_name=node.name)
 
 @register_torch_op

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -2361,10 +2361,22 @@ class TestSplit(TorchBaseTest):
 
 class TestUnbind(TorchBaseTest):
     @pytest.mark.parametrize(
-        "backend, input_shape, dim",
-        itertools.product(backends, [(1), (3, 3, 4)], [0,1,2]),
+        "backend, dim",
+        itertools.product(backends, [0,1,2]),
     )
-    def test_unbind(self, backend, input_shape, dim):
+    def test_unbind(self, backend, dim):
+        input_shape = (3, 3, 4)
+        model = ModuleWrapper(function=torch.unbind,
+                              kwargs={"dim": dim})
+        self.run_compare_torch(input_shape, model, backend=backend)
+
+    @pytest.mark.parametrize(
+        "backend",
+        backends,
+    )
+    def test_unbind_one_dim_shape(self, backend):
+        input_shape = (1,)
+        dim = 0
         model = ModuleWrapper(function=torch.unbind,
                               kwargs={"dim": dim})
         self.run_compare_torch(input_shape, model, backend=backend)

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -2362,7 +2362,7 @@ class TestSplit(TorchBaseTest):
 class TestUnbind(TorchBaseTest):
     @pytest.mark.parametrize(
         "backend, input_shape, dim",
-        itertools.product(backends, [(0), (3, 3, 4)], [0,1,2]),
+        itertools.product(backends, [(1), (3, 3, 4)], [0,1,2]),
     )
     def test_unbind(self, backend, input_shape, dim):
         model = ModuleWrapper(function=torch.unbind,

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -2361,11 +2361,10 @@ class TestSplit(TorchBaseTest):
 
 class TestUnbind(TorchBaseTest):
     @pytest.mark.parametrize(
-        "backend, dim",
-        itertools.product(backends,[0,1,2]),
+        "backend, input_shape, dim",
+        itertools.product(backends, [(0), (3, 3, 4)], [0,1,2]),
     )
-    def test_unbind(self, backend, dim):
-        input_shape = (3, 3, 4)
+    def test_unbind(self, backend, input_shape, dim):
         model = ModuleWrapper(function=torch.unbind,
                               kwargs={"dim": dim})
         self.run_compare_torch(input_shape, model, backend=backend)


### PR DESCRIPTION
In some specific cases there's a possibility that unbind operation accepts only one split_size.

Here is the minimum artificial example that breaks current version and causes exception:
```
import coremltools as ct
import torch
import numpy as np


class UnbindModule(torch.nn.Module):
    def forward(self, x):
        axes = torch.tensor([0])
        dims = torch.Size(axes)
        for dim in sorted(dims):
            x = torch.unsqueeze(x, dim)
        return x

model = UnbindModule()

with torch.no_grad():
    tr_mod = torch.jit.trace(model, torch.tensor(1.))

batch_network_input = [
    ct.TensorType(
        name='input',
        shape=ct.Shape(
            shape=(0,), default=(0,)
        ),
        dtype=np.float32,
    ),
]

coreml_model = ct.convert(
    tr_mod,
    inputs=batch_network_input,
    minimum_deployment_target=ct.target.iOS14,
    compute_units=ct.ComputeUnit.CPU_ONLY
)
```

This PR fixes this issue.