### PR TITLE
Add einsum to linear and fix xgboost convert code

### DIFF
--- a/coremltools/converters/mil/mil/ops/defs/linear.py
+++ b/coremltools/converters/mil/mil/ops/defs/linear.py
@@ -235,35 +235,35 @@ class einsum(Operation):
     dimensions -1 and -3, treating all the other dimensions as batch. Broadcasting is supported along batch dimensions.
     In particular, the inputs must be of the following shapes:
 
-    * rank 4 input case
-        * input 1: [B, C, H, W1]
-        * input 2: [B, W1, H, W2]
-        * output: [B, C, H, W2]
-        * if , for one of the inputs, the dimensions "B" or "H" is 1, they are broadcast to match the other input
+    * Rank 4 input case
+        * Input 1: ``[B, C, H, W1]``
+        * Input 2: ``[B, W1, H, W2]``
+        * Output: ``[B, C, H, W2]``
+        * If, for one of the inputs, the dimensions ``"B"`` or ``"H"`` is 1, they are broadcast to match the other input.
 
-    * rank 3 input case
-        * input 1: [C, H, W1]
-        * input 2: [W1, H, W2]
-        * output: [C, H, W2]
-        * if , for one of the inputs, the dimension "H" is 1, it is broadcast to match the other input
+    * Rank 3 input case
+        * Input 1: ``[C, H, W1]``
+        * Input 2: ``[W1, H, W2]``
+        * Output: ``[C, H, W2]``
+        * If, for one of the inputs, the dimension ``"H"`` is 1, it is broadcast to match the other input.
 
     Parameters
     ----------
     values : Tuple(tensor_1, tensor_2)
-        * where
-            * tensor_1: tensor<[*D, C, H, W1], T>
-            * must be of rank 3 or 4
-            * tensor_2: tensor<[*D, W1, H, W2], T>
-            * must be of rank 3 or 4
+        * Where:
+            * ``tensor_1``: ``tensor<[*D, C, H, W1], T>``
+            * Must be of rank 3 or 4.
+            * ``tensor_2``: ``tensor<[*D, W1, H, W2], T>``
+            * Must be of rank 3 or 4.
     equation: const<str>
-        * supported equations are:
-            * "nchw,nwhu->nchu" and its equivalent equation strings
-            * "chw,whr->chr" and its equivalent equation strings
+        * Supported equations are:
+            * ``"nchw,nwhu->nchu"`` and its equivalent equation strings
+            * ``"chw,whr->chr"`` and its equivalent equation strings
 
     Returns
     -------
     tensor<[*D, C, H, W2], T>
-        * same ranks as the inputs
+        * Same ranks as the inputs.
 
     Attributes
     ----------

--- a/coremltools/converters/xgboost/_tree.py
+++ b/coremltools/converters/xgboost/_tree.py
@@ -68,7 +68,7 @@ def convert(
 		>>> coreml_model = coremltools.converters.xgboost.convert(model)
 
 		# Saving the Core ML model to a file.
-		>>> coremltools.save('my_model.mlmodel')
+		>>> coreml_model.save('my_model.mlmodel')
     """
     model = _MLModel(
         _convert_tree_ensemble(

--- a/docs/source/coremltools.converters.mil.mil.ops.defs.rst
+++ b/docs/source/coremltools.converters.mil.mil.ops.defs.rst
@@ -130,6 +130,7 @@ linear
 
    .. autoclass:: linear
    .. autoclass:: matmul
+   .. autoclass:: einsum
 
 
 normalization


### PR DESCRIPTION
This PR addresses the following doc problems:
* [rdar://88775719](rdar://88775719) (CoreML Tools Docs Bug)
* [rdar://90672903](rdar://90672903) (Coremltools documentation page lacks einsum op definition)

It includes the following files:
```
	modified:   coremltools/converters/mil/mil/ops/defs/linear.py
	modified:   coremltools/converters/xgboost/_tree.py
	modified:   docs/source/coremltools.converters.mil.mil.ops.defs.rst

```

This PR does _not_ include the generated HTML. After these changes are
reviewed and merged, I will do a separate PR to merge the HTML.

