### PR TITLE
Revise Conv and Pool Ops Docs

### DIFF
--- a/coremltools/converters/mil/mil/ops/defs/conv.py
+++ b/coremltools/converters/mil/mil/ops/defs/conv.py
@@ -22,8 +22,7 @@ from coremltools.converters.mil.mil.ops.defs._utils import spatial_dimensions_ou
 @register_op(doc_str="")
 class conv(Operation):
     """
-    Perform convolution over input. Currently supports only 1-D and 2-D
-    convolution.
+    Perform convolution over input. Supports 1-D, 2-D, and 3-D convolution.
 
     Parameters
     ----------
@@ -40,7 +39,7 @@ class conv(Operation):
         * Filter weights.
         * ``C_in`` is the number of input channels.
         * ``C_in`` must be divisible by ``groups``.
-        * ``K`` are kernel sizes. For example, ``K = [KH, KW]`` for 2-D conv.
+        * ``K`` are kernel sizes. For example, ``K = [KH, KW]`` for 2-D convolution.
         * When ``dilations`` is not all ``1``, ``weight`` has to be ``const``
           at compile time
 
@@ -57,14 +56,14 @@ class conv(Operation):
             * ``valid``: No padding. This is equivalent to custom pad with
               ``pad[2*i] == pad[2*i+1] == 0, for i=0,...,len(d_in)-1``.
             * ``custom``: Specify custom padding in the parameter ``pad``.
-            * ``same``: input is padded such that out spatial shapes are
+            * ``same``: Input is padded such that out spatial shapes are
               ``d_out[i] = ceil(d_in[i] / strides[i])``.
 
         Specifically, for ``i = 0,..,,len(d_in)-1``, the equivalent paddings are
         calculated as follows:
 
             * ``dilated_kernel = (K[i] - 1) * dilate[i] + 1``
-            * if ``dilated_kernel`` is odd,
+            * If ``dilated_kernel`` is odd,
               ``padding[2*i] = padding[2*i+1] = floor(dilated_kernel / 2)``
             * Otherwise:
               ``padding[2*i] = ceil((dilated_kernel - 1) / 2)``,
@@ -116,7 +115,7 @@ class conv(Operation):
         * Output activation has the same rank and spatial dimension as the input.
           That is, ``len(d_out) == len(d_in)``.
         * For ``i=0,..,len(d_in)-1, d_out[i] = floor [(D_in[i] + pad[2*i] +
-          pad[2*i+1] - (K[i]-1)*dilations[i] - 1) / strides[i] ] + 1``
+          pad[2*i+1] - (K[i]-1)*dilations[i] - 1) / strides[i] ] + 1``.
 
     Attributes
     ----------
@@ -256,7 +255,7 @@ class conv_transpose(Operation):
     """
     Perform transposed convolution (also known as deconvolution and fractionally
     stride convolution) over input. ``conv_transpose`` can also be used to compute
-    the gradient of conv. Currently supports only 1-D and 2-D.
+    the gradient of ``conv``. Supports 1-D, 2-D, and 3-D convolution.
 
     Parameters
     ----------
@@ -284,7 +283,9 @@ class conv_transpose(Operation):
     output_shape: const tensor<[P],i32> (Optional, default None)
         * Expected output shape. The first two dim must be ``[n, C_out]``.
         * The output shape of conv_transpose is underdetermined in general,
-        * because conv can map multiple input shape to a single output shape. For example, for 'same' padding mode, `conv_out = ceil(conv_in/stride)`. Hence we need `output_shape` when this occurs.
+        * because conv can map multiple input shape to a single output shape.
+          For example, for ``same`` padding mode, ``conv_out = ceil(conv_in/stride)``.
+          Hence we need ``output_shape`` when this occurs.
 
     pad_type: const tensor<[P],i32> (Optional, default valid)
         * One of ``same``, ``valid``, or ``custom``.

--- a/coremltools/converters/mil/mil/ops/defs/pool.py
+++ b/coremltools/converters/mil/mil/ops/defs/pool.py
@@ -77,8 +77,8 @@ class Pooling(Operation):
 @register_op(doc_str="")
 class avg_pool(Pooling):
     """
-    Perform average pooling. Currently defined only for spatial 1-D and
-    2-D cases. (Can be extended to the 3-D case easily.)
+    Perform average pooling. Supports spatial 1-D, 2-D, and 3-D
+    cases.
     
     Parameters
     ----------
@@ -103,48 +103,51 @@ class avg_pool(Pooling):
         * ``valid``: No padding. This is equivalent to custom pad with ``pad[i] = 0, for
           all i``.
         * ``same`` : This is equivalent to custom pad with ``pad[2*i] + pad[2*i+1] = kernel_size[i]``.
-        * ``custom``: Specify custom padding in the parameter pad. note that "same"
+        * ``custom``: Specify custom padding in the parameter pad. note that ``same``
           padding is equivalent to custom padding with
           ``pad[2*i] + pad[2*i+1] = kernel_size[i]``.
     
     pad: const<[P],i32> (Optional. Default to all 0s)
         * ``pad`` represents the number of elements to pad before and after each 
-          dimension: `pad[2*i], pad[2*i+1]` are the pad size before and after spatial
+          dimension: ``pad[2*i], pad[2*i+1]`` are the pad size before and after spatial
           dimension ``i``.
         * ``P = 2 * len(D_in)``.
         * ``pad`` should be specified if and only if ``pad_type == custom``
     
     exclude_padding_from_average: const tensor<[], bool> (Optional, default to False)
-        * If ''True'', padded values (0s) are excluded from the denominator count
+        * If ``True``, padded values (0s) are excluded from the denominator count
           when computing the average over the kernel window.
 
     ceil_mode: const<bool>
-        * same as PyTorch's ceil mode
-        * ceil is used instead of floor in calculating the output size
-        * only supported when its 1D or 2D pool
-        * optional, defaults to False
-        * only applicable when pad_type is ``valid`` or ``custom``
-        * when ceil_mode is True, padding must be symmetric, that is, if specified, ``pad[2*i] == pad[2*i+1]`` must hold
+        * Same as PyTorch's ``ceil`` mode.
+        * ``ceil`` is used instead of floor in calculating the output size.
+        * Only supported for a 1D or 2D pool.
+        * Optional, defaults to ``False``.
+        * Only applicable when ``pad_type`` is ``valid`` or ``custom``.
+        * When ``ceil_mode`` is True, padding must be symmetric; that is, if specified, 
+          ``pad[2*i] == pad[2*i+1]`` must hold.
     
     Returns
     -------
     tensor<[n, C_out,\*D_out],T>
         * Same rank as ``x``.
-        * when ceil_mode= False:
+        * When ``ceil_mode = False``:
             * ``D_out[i] = floor[(D_in[i] + pad[2*i] + pad[2*i+1] - kernel_sizes[i]) /
               strides[i]] +1, for i = 0, .., len(D_in) - 1`` is mathematically the same
               as (when all parameters involved are integers):
 
                   * ``D_out[i] = ceil [(D_in[i] + pad[2*i] + pad[2*i+1] - kernel_size[i] - 1) / stride[i]], for i = 0, .., len(D_in) - 1``.
-                  * ``*D_out`` is all 1s if ``global_pooling`` is ``true``.
+                  * ``*D_out`` is all ones if ``global_pooling`` is ``true``.
 
-        * when ceil_mode= True
-            * `D_out[i] = ceil[(D_in[i] + pad[2*i] + pad[2*i+1] - kernel_sizes[i]) / strides[i]] +1, for i = 0, .., len(D_in) - 1``
-                * if  `(D_out[i] - 1) * strides[i] >= D_in[i] + pad[2*i] and (pad[2*i] + pad[2*i+1] > 0)`:
-                        then `D_out[i] = D_out[i] - 1`
+        * When ``ceil_mode = True``:
+            * ``D_out[i] = ceil[(D_in[i] + pad[2*i] + pad[2*i+1] - kernel_sizes[i]) / strides[i]] +1, for i = 0, .., len(D_in) - 1``
 
-            * the first equation is same as :
-                * `D_out[i] = floor[(D_in[i] + pad[2*i] + pad[2*i+1] - kernel_sizes[i] + strides[i] - 1) / strides[i]] +1, for i = 0, .., len(D_in) - 1``
+                  * If  ``(D_out[i] - 1) * strides[i] >= D_in[i] + pad[2*i] and (pad[2*i] + pad[2*i+1] > 0)``
+                    then ``D_out[i] = D_out[i] - 1``.
+
+            * The first equation is same as:
+
+                * ``D_out[i] = floor[(D_in[i] + pad[2*i] + pad[2*i+1] - kernel_sizes[i] + strides[i] - 1) / strides[i]] +1, for i = 0, .., len(D_in) - 1``
     
     Attributes
     ----------
@@ -175,7 +178,7 @@ class avg_pool(Pooling):
 @register_op(doc_str="")
 class l2_pool(Pooling):
     """
-    Perform L2 pooling. Currently supports only 1-D and 2-D.
+    Perform L2 pooling. Supports 1-D, 2-D, and 3-D.
     
     Parameters
     ----------
@@ -215,7 +218,7 @@ class l2_pool(Pooling):
 @register_op(doc_str="")
 class max_pool(Pooling):
     """
-    Perform max pooling. Currently supports only 1-D and 2-D.
+    Perform max pooling. Supports 1-D, 2-D, and 3-D.
     
     Parameters
     ----------


### PR DESCRIPTION
This PR addresses the following doc problems:
- [rdar://91358500](https://rdar.apple.com/problem/91358500) (Update conv / pool ops MIL documentation to clearly mention that 3D conv/pool are also supported)

It includes the following files:

```
	modified:   coremltools/converters/mil/mil/ops/defs/conv.py
	modified:   coremltools/converters/mil/mil/ops/defs/pool.py
```

This PR does _not_ include the generated HTML. After these changes are
reviewed and merged, I will do a separate PR to merge the HTML.
