### PR TITLE
Adds torch op: empty

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -3587,9 +3587,10 @@ def zeros_like(context, node):
 
     context.add(zeros_like)
 
-@register_torch_op
+
+@register_torch_op(torch_alias=["empty"])
 def zeros(context, node):
-    inputs = _get_inputs(context, node, expected=5)
+    inputs = _get_inputs(context, node)
     size = inputs[0]
     dtype = inputs[1].val
     if isinstance(size, list):

--- a/coremltools/converters/mil/frontend/torch/torchir_passes.py
+++ b/coremltools/converters/mil/frontend/torch/torchir_passes.py
@@ -97,7 +97,7 @@ def generate_tensor_assignment_ops(graph):
             input_name = node.inputs[idx]
             node.inputs[idx] = _get_updated_name(input_name, updated_tensor_count)
 
-        if node.kind in ("select", "slice"):
+        if node.kind in ("empty", "select", "slice"):
             node_input = node.inputs[0]
             node_output = node.outputs[0]
             node_sequence = tensor_to_node_sequence_mapping.get(node_input, [])


### PR DESCRIPTION
Fixes two issues found by #1447:
* Output of `empty` op can be input to a `fill_` op (inplace fill).
* No support `empty` op
