### PR TITLE
Edit Attributes in MIL Ops Docs

### DIFF
--- a/coremltools/converters/mil/mil/ops/defs/activation.py
+++ b/coremltools/converters/mil/mil/ops/defs/activation.py
@@ -40,7 +40,7 @@ class clamped_relu(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(
@@ -80,7 +80,7 @@ class elu(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(
@@ -145,7 +145,7 @@ class gelu(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(
@@ -199,7 +199,7 @@ class leaky_relu(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(
@@ -244,7 +244,7 @@ class linear_activation(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(
@@ -286,7 +286,7 @@ class prelu(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(
@@ -334,7 +334,7 @@ class relu(elementwise_unary):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     def __init__(self, **kwargs):
@@ -361,7 +361,7 @@ class relu6(elementwise_unary):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     def __init__(self, **kwargs):
@@ -393,7 +393,7 @@ class scaled_tanh(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(
@@ -435,7 +435,7 @@ class sigmoid(elementwise_unary):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     def __init__(self, **kwargs):
@@ -466,7 +466,7 @@ class sigmoid_hard(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(
@@ -508,7 +508,7 @@ class silu(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(x=TensorInputType(),)
@@ -535,7 +535,7 @@ class softplus(elementwise_unary):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     def __init__(self, **kwargs):
@@ -564,7 +564,7 @@ class softplus_parametric(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(
@@ -623,7 +623,7 @@ class softmax(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(
@@ -663,6 +663,10 @@ class softsign(elementwise_unary):
     -------
     tensor<\*?, T>
         * A tensor of the same shape and type as ``x``.
+
+    Attributes
+    ----------
+    T: fp16, fp32
     """
 
     def __init__(self, **kwargs):
@@ -688,6 +692,10 @@ class thresholded_relu(Operation):
     -------
     tensor<\*, T>
         * A tensor of the same shape and type as ``x``.
+
+    Attributes
+    ----------
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(

--- a/coremltools/converters/mil/mil/ops/defs/control_flow.py
+++ b/coremltools/converters/mil/mil/ops/defs/control_flow.py
@@ -145,7 +145,7 @@ class Const(Operation):
 
     Attributes
     ----------
-    T: fp32, i32, str
+    T: fp16, fp32, i32, str, bool
     """
 
     input_spec = InputSpec(
@@ -266,7 +266,7 @@ class select(Operation):
     Attributes
     ----------
     B: bool
-    T: fp32
+    T: fp16, fp32, i32
     """
 
     input_spec = InputSpec(
@@ -601,6 +601,10 @@ class list_length(Operation):
     -------
     <i32>
         * Length of ``ls``.
+
+    Attributes
+    ----------
+    T: fp16, fp32, i32, bool
     """
 
     input_spec = InputSpec(ls=ListInputType(),)
@@ -640,7 +644,7 @@ class list_write(Operation):
 
     Attributes
     ----------
-    T: fp32, i32, bool
+    T: fp16, fp32, i32, bool
     """
 
     input_spec = InputSpec(
@@ -695,7 +699,7 @@ class list_read(Operation):
 
     Attributes
     ----------
-    T: fp32, i32, bool
+    T: fp16, fp32, i32, bool
     """
 
     input_spec = InputSpec(
@@ -737,7 +741,7 @@ class list_gather(Operation):
 
     Attributes
     ----------
-    T: fp32, i32, bool
+    T: fp16, fp32, i32, bool
     """
 
     input_spec = InputSpec(
@@ -788,7 +792,7 @@ class list_scatter(Operation):
 
     Attributes
     ----------
-    T: fp32, i32, bool
+    T: fp16, fp32, i32, bool
     """
 
     input_spec = InputSpec(

--- a/coremltools/converters/mil/mil/ops/defs/conv.py
+++ b/coremltools/converters/mil/mil/ops/defs/conv.py
@@ -22,7 +22,8 @@ from coremltools.converters.mil.mil.ops.defs._utils import spatial_dimensions_ou
 @register_op(doc_str="")
 class conv(Operation):
     """
-    Perform convolution over input. Supports 1-D, 2-D, and 3-D convolution.
+    Perform convolution over input. Currently supports only 1-D and 2-D
+    convolution.
 
     Parameters
     ----------
@@ -30,7 +31,7 @@ class conv(Operation):
 
         * ``d_in`` are (possibly runtime-determined) spatial dimensions. For example,
           ``d_in = [224, 224]`` for 2D convolution.
-        * ``1 <= len(d_in) <= 3``.
+        * ``1 <= len(d_in) <= 2``: Only 1-D and 2-D convolution.
         * ``C_in`` is the number of input channels or depth dimensions.
         * ``n``  is the batch dimension.
 
@@ -39,7 +40,7 @@ class conv(Operation):
         * Filter weights.
         * ``C_in`` is the number of input channels.
         * ``C_in`` must be divisible by ``groups``.
-        * ``K`` are kernel sizes. For example, ``K = [KH, KW]`` for 2-D convolution.
+        * ``K`` are kernel sizes. For example, ``K = [KH, KW]`` for 2-D conv.
         * When ``dilations`` is not all ``1``, ``weight`` has to be ``const``
           at compile time
 
@@ -56,14 +57,14 @@ class conv(Operation):
             * ``valid``: No padding. This is equivalent to custom pad with
               ``pad[2*i] == pad[2*i+1] == 0, for i=0,...,len(d_in)-1``.
             * ``custom``: Specify custom padding in the parameter ``pad``.
-            * ``same``: Input is padded such that out spatial shapes are
+            * ``same``: input is padded such that out spatial shapes are
               ``d_out[i] = ceil(d_in[i] / strides[i])``.
 
         Specifically, for ``i = 0,..,,len(d_in)-1``, the equivalent paddings are
         calculated as follows:
 
             * ``dilated_kernel = (K[i] - 1) * dilate[i] + 1``
-            * If ``dilated_kernel`` is odd,
+            * if ``dilated_kernel`` is odd,
               ``padding[2*i] = padding[2*i+1] = floor(dilated_kernel / 2)``
             * Otherwise:
               ``padding[2*i] = ceil((dilated_kernel - 1) / 2)``,
@@ -115,11 +116,11 @@ class conv(Operation):
         * Output activation has the same rank and spatial dimension as the input.
           That is, ``len(d_out) == len(d_in)``.
         * For ``i=0,..,len(d_in)-1, d_out[i] = floor [(D_in[i] + pad[2*i] +
-          pad[2*i+1] - (K[i]-1)*dilations[i] - 1) / strides[i] ] + 1``.
+          pad[2*i+1] - (K[i]-1)*dilations[i] - 1) / strides[i] ] + 1``
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
 
     See Also
     --------
@@ -223,7 +224,7 @@ class conv_quantized(conv):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
     input_spec = InputSpec(
         x=TensorInputType(),
@@ -255,7 +256,7 @@ class conv_transpose(Operation):
     """
     Perform transposed convolution (also known as deconvolution and fractionally
     stride convolution) over input. ``conv_transpose`` can also be used to compute
-    the gradient of ``conv``. Supports 1-D, 2-D, and 3-D convolution.
+    the gradient of conv. Currently supports only 1-D and 2-D.
 
     Parameters
     ----------
@@ -263,7 +264,7 @@ class conv_transpose(Operation):
     x: tensor<[n,C_in,*D_in],T> (Required)
         * Input data.
         * ``D_in`` are spatial dimensions.
-        * ``1 <= len(D_in) <= 3``.
+        * ``1 <= len(D_in) <= 2``.
         * ``C_in`` is the number of input channels.
 
     weight: const tensor<[C_in,C_out/groups,*D_in], T> (Required)
@@ -283,9 +284,7 @@ class conv_transpose(Operation):
     output_shape: const tensor<[P],i32> (Optional, default None)
         * Expected output shape. The first two dim must be ``[n, C_out]``.
         * The output shape of conv_transpose is underdetermined in general,
-        * because conv can map multiple input shape to a single output shape.
-          For example, for ``same`` padding mode, ``conv_out = ceil(conv_in/stride)``.
-          Hence we need ``output_shape`` when this occurs.
+        * because conv can map multiple input shape to a single output shape. For example, for 'same' padding mode, `conv_out = ceil(conv_in/stride)`. Hence we need `output_shape` when this occurs.
 
     pad_type: const tensor<[P],i32> (Optional, default valid)
         * One of ``same``, ``valid``, or ``custom``.
@@ -311,7 +310,7 @@ class conv_transpose(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
 
     See Also
     --------

--- a/coremltools/converters/mil/mil/ops/defs/conv.py
+++ b/coremltools/converters/mil/mil/ops/defs/conv.py
@@ -22,8 +22,7 @@ from coremltools.converters.mil.mil.ops.defs._utils import spatial_dimensions_ou
 @register_op(doc_str="")
 class conv(Operation):
     """
-    Perform convolution over input. Currently supports only 1-D and 2-D
-    convolution.
+    Perform convolution over input. Supports 1-D, 2-D, and 3-D convolution.
 
     Parameters
     ----------
@@ -31,7 +30,7 @@ class conv(Operation):
 
         * ``d_in`` are (possibly runtime-determined) spatial dimensions. For example,
           ``d_in = [224, 224]`` for 2D convolution.
-        * ``1 <= len(d_in) <= 2``: Only 1-D and 2-D convolution.
+        * ``1 <= len(d_in) <= 3``.
         * ``C_in`` is the number of input channels or depth dimensions.
         * ``n``  is the batch dimension.
 
@@ -40,7 +39,7 @@ class conv(Operation):
         * Filter weights.
         * ``C_in`` is the number of input channels.
         * ``C_in`` must be divisible by ``groups``.
-        * ``K`` are kernel sizes. For example, ``K = [KH, KW]`` for 2-D conv.
+        * ``K`` are kernel sizes. For example, ``K = [KH, KW]`` for 2-D convolution.
         * When ``dilations`` is not all ``1``, ``weight`` has to be ``const``
           at compile time
 
@@ -57,14 +56,14 @@ class conv(Operation):
             * ``valid``: No padding. This is equivalent to custom pad with
               ``pad[2*i] == pad[2*i+1] == 0, for i=0,...,len(d_in)-1``.
             * ``custom``: Specify custom padding in the parameter ``pad``.
-            * ``same``: input is padded such that out spatial shapes are
+            * ``same``: Input is padded such that out spatial shapes are
               ``d_out[i] = ceil(d_in[i] / strides[i])``.
 
         Specifically, for ``i = 0,..,,len(d_in)-1``, the equivalent paddings are
         calculated as follows:
 
             * ``dilated_kernel = (K[i] - 1) * dilate[i] + 1``
-            * if ``dilated_kernel`` is odd,
+            * If ``dilated_kernel`` is odd,
               ``padding[2*i] = padding[2*i+1] = floor(dilated_kernel / 2)``
             * Otherwise:
               ``padding[2*i] = ceil((dilated_kernel - 1) / 2)``,
@@ -116,7 +115,7 @@ class conv(Operation):
         * Output activation has the same rank and spatial dimension as the input.
           That is, ``len(d_out) == len(d_in)``.
         * For ``i=0,..,len(d_in)-1, d_out[i] = floor [(D_in[i] + pad[2*i] +
-          pad[2*i+1] - (K[i]-1)*dilations[i] - 1) / strides[i] ] + 1``
+          pad[2*i+1] - (K[i]-1)*dilations[i] - 1) / strides[i] ] + 1``.
 
     Attributes
     ----------
@@ -256,7 +255,7 @@ class conv_transpose(Operation):
     """
     Perform transposed convolution (also known as deconvolution and fractionally
     stride convolution) over input. ``conv_transpose`` can also be used to compute
-    the gradient of conv. Currently supports only 1-D and 2-D.
+    the gradient of conv. Supports 1-D, 2-D, and 3-D convolution.
 
     Parameters
     ----------
@@ -264,7 +263,7 @@ class conv_transpose(Operation):
     x: tensor<[n,C_in,*D_in],T> (Required)
         * Input data.
         * ``D_in`` are spatial dimensions.
-        * ``1 <= len(D_in) <= 2``.
+        * ``1 <= len(D_in) <= 3``.
         * ``C_in`` is the number of input channels.
 
     weight: const tensor<[C_in,C_out/groups,*D_in], T> (Required)
@@ -284,7 +283,9 @@ class conv_transpose(Operation):
     output_shape: const tensor<[P],i32> (Optional, default None)
         * Expected output shape. The first two dim must be ``[n, C_out]``.
         * The output shape of conv_transpose is underdetermined in general,
-        * because conv can map multiple input shape to a single output shape. For example, for 'same' padding mode, `conv_out = ceil(conv_in/stride)`. Hence we need `output_shape` when this occurs.
+        * Because conv can map multiple input shape to a single output shape.
+          For example, for ``same`` padding mode, ``conv_out = ceil(conv_in/stride)``.
+          Hence we need ``output_shape`` when this occurs.
 
     pad_type: const tensor<[P],i32> (Optional, default valid)
         * One of ``same``, ``valid``, or ``custom``.

--- a/coremltools/converters/mil/mil/ops/defs/elementwise_binary.py
+++ b/coremltools/converters/mil/mil/ops/defs/elementwise_binary.py
@@ -342,7 +342,7 @@ class logical_and(elementwise_binary):
     
     Attributes
     ----------
-    T: fp16, fp32, i32
+    T: bool
     
     """
     
@@ -379,7 +379,7 @@ class logical_or(elementwise_binary):
     
     Attributes
     ----------
-    T: fp16, fp32, i32
+    T: bool
     
     """
     
@@ -416,7 +416,7 @@ class logical_xor(elementwise_binary):
     
     Attributes
     ----------
-    T: fp16, fp32, i32
+    T: bool
     
     """
     

--- a/coremltools/converters/mil/mil/ops/defs/elementwise_binary.py
+++ b/coremltools/converters/mil/mil/ops/defs/elementwise_binary.py
@@ -102,7 +102,7 @@ class add(elementwise_binary):
     
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     """
     
     def __init__(self, **kwargs):
@@ -134,7 +134,7 @@ class equal(elementwise_binary):
     
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     """
 
     def __init__(self, **kwargs):
@@ -169,7 +169,7 @@ class floor_div(elementwise_binary):
     
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     """
     
     def __init__(self, **kwargs):
@@ -201,7 +201,7 @@ class greater(elementwise_binary):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     """
 
     def __init__(self, **kwargs):
@@ -236,7 +236,7 @@ class greater_equal(elementwise_binary):
     
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     """
 
     def __init__(self, **kwargs):
@@ -271,7 +271,7 @@ class less(elementwise_binary):
     
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     """
 
     def __init__(self, **kwargs):
@@ -306,7 +306,7 @@ class less_equal(elementwise_binary):
     
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     """
     
     def __init__(self, **kwargs):
@@ -342,7 +342,7 @@ class logical_and(elementwise_binary):
     
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     
     """
     
@@ -379,7 +379,7 @@ class logical_or(elementwise_binary):
     
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     
     """
     
@@ -416,7 +416,7 @@ class logical_xor(elementwise_binary):
     
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     
     """
     
@@ -451,7 +451,7 @@ class maximum(elementwise_binary):
     
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     """
     
     def __init__(self, **kwargs):
@@ -482,7 +482,7 @@ class minimum(elementwise_binary):
     
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     """
     
     def __init__(self, **kwargs):
@@ -513,7 +513,7 @@ class mod(elementwise_binary):
     
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     """
     
     def __init__(self, **kwargs):
@@ -544,7 +544,7 @@ class mul(elementwise_binary):
     
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     """
     
     def __init__(self, **kwargs):
@@ -576,7 +576,7 @@ class not_equal(elementwise_binary):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     """
     
     def __init__(self, **kwargs):
@@ -610,7 +610,7 @@ class real_div(elementwise_binary):
     
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     """
     
     def __init__(self, **kwargs):
@@ -648,7 +648,7 @@ class pow(elementwise_binary):
     
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     """
     
     def __init__(self, **kwargs):
@@ -679,7 +679,7 @@ class sub(elementwise_binary):
     
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     """
     
     def __init__(self, **kwargs):

--- a/coremltools/converters/mil/mil/ops/defs/elementwise_unary.py
+++ b/coremltools/converters/mil/mil/ops/defs/elementwise_unary.py
@@ -504,7 +504,7 @@ class logical_not(elementwise_unary):
 
     Attributes
     ----------
-    T: fp16, fp32
+    T: bool
     """
 
     def __init__(self, **kwargs):

--- a/coremltools/converters/mil/mil/ops/defs/elementwise_unary.py
+++ b/coremltools/converters/mil/mil/ops/defs/elementwise_unary.py
@@ -49,7 +49,7 @@ class abs(elementwise_unary):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     """
 
     def __init__(self, **kwargs):
@@ -76,7 +76,7 @@ class acos(elementwise_unary):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     def __init__(self, **kwargs):
@@ -103,7 +103,7 @@ class asin(elementwise_unary):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     def __init__(self, **kwargs):
@@ -130,7 +130,7 @@ class atan(elementwise_unary):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     def __init__(self, **kwargs):
@@ -158,7 +158,7 @@ class atanh(elementwise_unary):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     def __init__(self, **kwargs):
@@ -185,7 +185,7 @@ class ceil(elementwise_unary):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     def __init__(self, **kwargs):
@@ -216,7 +216,7 @@ class clip(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(
@@ -252,7 +252,7 @@ class cos(elementwise_unary):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     def __init__(self, **kwargs):
@@ -279,7 +279,7 @@ class cosh(elementwise_unary):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     def __init__(self, **kwargs):
@@ -306,7 +306,7 @@ class erf(elementwise_unary):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     def __init__(self, **kwargs):
@@ -334,7 +334,7 @@ class exp(elementwise_unary):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     def __init__(self, **kwargs):
@@ -361,7 +361,7 @@ class exp2(elementwise_unary):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     """
 
     def __init__(self, **kwargs):
@@ -389,7 +389,7 @@ class floor(elementwise_unary):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     def __init__(self, **kwargs):
@@ -420,7 +420,7 @@ class inverse(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(
@@ -463,7 +463,7 @@ class log(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(
@@ -504,7 +504,7 @@ class logical_not(elementwise_unary):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     def __init__(self, **kwargs):
@@ -532,7 +532,7 @@ class round(elementwise_unary):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     def __init__(self, **kwargs):
@@ -563,7 +563,7 @@ class rsqrt(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(
@@ -605,7 +605,7 @@ class sign(elementwise_unary):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     """
 
     def __init__(self, **kwargs):
@@ -632,7 +632,7 @@ class sin(elementwise_unary):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     def __init__(self, **kwargs):
@@ -659,7 +659,7 @@ class sinh(elementwise_unary):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     def __init__(self, **kwargs):
@@ -686,7 +686,7 @@ class sqrt(elementwise_unary):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     def __init__(self, **kwargs):
@@ -713,7 +713,7 @@ class square(elementwise_unary):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     """
 
     def __init__(self, **kwargs):
@@ -741,7 +741,7 @@ class tan(elementwise_unary):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     def __init__(self, **kwargs):
@@ -769,7 +769,7 @@ class tanh(elementwise_unary):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     def __init__(self, **kwargs):
@@ -798,7 +798,7 @@ class threshold(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     """
 
     input_spec = InputSpec(

--- a/coremltools/converters/mil/mil/ops/defs/image_resizing.py
+++ b/coremltools/converters/mil/mil/ops/defs/image_resizing.py
@@ -83,7 +83,7 @@ class affine(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(
@@ -178,7 +178,8 @@ class upsample_nearest_neighbor(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
+    U: fp32, i32
     """
 
     input_spec = InputSpec(
@@ -275,8 +276,8 @@ class resample(Operation):
 
     Attributes
     ----------
-    T: fp32
-    U: fp32, i32, i64
+    T: fp16, fp32
+    U: fp32, i32
     """
 
     input_spec = InputSpec(
@@ -365,7 +366,7 @@ class resize_nearest_neighbor(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(
@@ -465,8 +466,8 @@ class upsample_bilinear(Operation):
 
     Attributes
     ----------
-    T: fp32
-    T2 : fp32 or int32
+    T: fp16, fp32
+    T2 : fp32, i32
     """
 
     input_spec = InputSpec(
@@ -593,7 +594,7 @@ class resize_bilinear(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(
@@ -723,7 +724,7 @@ class crop_resize(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(
@@ -809,7 +810,7 @@ class crop(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(

--- a/coremltools/converters/mil/mil/ops/defs/linear.py
+++ b/coremltools/converters/mil/mil/ops/defs/linear.py
@@ -42,7 +42,7 @@ class linear(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     """
     input_spec = InputSpec(
         x=TensorInputType(),
@@ -160,7 +160,7 @@ class matmul(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     """
     input_spec = InputSpec(
         x=TensorInputType(),
@@ -267,7 +267,7 @@ class einsum(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(values=TupleInputType(),

--- a/coremltools/converters/mil/mil/ops/defs/normalization.py
+++ b/coremltools/converters/mil/mil/ops/defs/normalization.py
@@ -58,7 +58,7 @@ class batch_norm(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(
@@ -109,6 +109,10 @@ class instance_norm(Operation):
     -------
     tensor<[n,C,*D], T>
         * Output tensor has the same shape and type as the input ``x``.
+
+    Attributes
+    ----------
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(
@@ -162,7 +166,7 @@ class l2_norm(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(
@@ -223,7 +227,7 @@ class layer_norm(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(
@@ -332,7 +336,7 @@ class local_response_norm(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(

--- a/coremltools/converters/mil/mil/ops/defs/pool.py
+++ b/coremltools/converters/mil/mil/ops/defs/pool.py
@@ -77,14 +77,13 @@ class Pooling(Operation):
 @register_op(doc_str="")
 class avg_pool(Pooling):
     """
-    Perform average pooling. Currently defined only for spatial 1-D and
-    2-D cases. (Can be extended to the 3-D case easily.)
+    Perform average pooling. Supports 1-D, 2-D, and 3-D pool (1, 2, or 3 spatial dimensions).
     
     Parameters
     ----------
     x: tensor<[n,C_in,\*D_in],T> (Required)
         *  ``3 <= rank <= 5``.
-        *  ``D_in`` are spatial dimensions, ``1 <= len(D_in) <= 2``.
+        *  ``D_in`` are spatial dimensions, ``1 <= len(D_in) <= 3``.
         *  ``C_in`` is the number of input channels or depth dimensions.
         *  ``n`` is the batch dimension.
     
@@ -103,48 +102,50 @@ class avg_pool(Pooling):
         * ``valid``: No padding. This is equivalent to custom pad with ``pad[i] = 0, for
           all i``.
         * ``same`` : This is equivalent to custom pad with ``pad[2*i] + pad[2*i+1] = kernel_size[i]``.
-        * ``custom``: Specify custom padding in the parameter pad. note that "same"
+        * ``custom``: Specify custom padding in the parameter pad. note that ``same``
           padding is equivalent to custom padding with
           ``pad[2*i] + pad[2*i+1] = kernel_size[i]``.
     
     pad: const<[P],i32> (Optional. Default to all 0s)
         * ``pad`` represents the number of elements to pad before and after each 
-          dimension: `pad[2*i], pad[2*i+1]` are the pad size before and after spatial
+          dimension: ``pad[2*i], pad[2*i+1]`` are the pad size before and after spatial
           dimension ``i``.
         * ``P = 2 * len(D_in)``.
         * ``pad`` should be specified if and only if ``pad_type == custom``
     
     exclude_padding_from_average: const tensor<[], bool> (Optional, default to False)
-        * If ''True'', padded values (0s) are excluded from the denominator count
+        * If ``True``, padded values (0s) are excluded from the denominator count
           when computing the average over the kernel window.
 
     ceil_mode: const<bool>
-        * same as PyTorch's ceil mode
-        * ceil is used instead of floor in calculating the output size
-        * only supported when its 1D or 2D pool
-        * optional, defaults to False
-        * only applicable when pad_type is ``valid`` or ``custom``
-        * when ceil_mode is True, padding must be symmetric, that is, if specified, ``pad[2*i] == pad[2*i+1]`` must hold
+        * Same as PyTorch's ``ceil`` mode.
+        * ``ceil`` is used instead of floor in calculating the output size.
+        * Optional, defaults to ``False``.
+        * Only applicable when ``pad_type`` is ``valid`` or ``custom``.
+        * When ``ceil_mode`` is True, padding must be symmetric; that is, if specified, 
+          ``pad[2*i] == pad[2*i+1]`` must hold.
     
     Returns
     -------
     tensor<[n, C_out,\*D_out],T>
         * Same rank as ``x``.
-        * when ceil_mode= False:
+        * When ``ceil_mode = False``:
             * ``D_out[i] = floor[(D_in[i] + pad[2*i] + pad[2*i+1] - kernel_sizes[i]) /
               strides[i]] +1, for i = 0, .., len(D_in) - 1`` is mathematically the same
               as (when all parameters involved are integers):
 
                   * ``D_out[i] = ceil [(D_in[i] + pad[2*i] + pad[2*i+1] - kernel_size[i] - 1) / stride[i]], for i = 0, .., len(D_in) - 1``.
-                  * ``*D_out`` is all 1s if ``global_pooling`` is ``true``.
+                  * ``*D_out`` is all ones if ``global_pooling`` is ``true``.
 
-        * when ceil_mode= True
-            * `D_out[i] = ceil[(D_in[i] + pad[2*i] + pad[2*i+1] - kernel_sizes[i]) / strides[i]] +1, for i = 0, .., len(D_in) - 1``
-                * if  `(D_out[i] - 1) * strides[i] >= D_in[i] + pad[2*i] and (pad[2*i] + pad[2*i+1] > 0)`:
-                        then `D_out[i] = D_out[i] - 1`
+        * When ``ceil_mode = True``:
+            * ``D_out[i] = ceil[(D_in[i] + pad[2*i] + pad[2*i+1] - kernel_sizes[i]) / strides[i]] +1, for i = 0, .., len(D_in) - 1``
 
-            * the first equation is same as :
-                * `D_out[i] = floor[(D_in[i] + pad[2*i] + pad[2*i+1] - kernel_sizes[i] + strides[i] - 1) / strides[i]] +1, for i = 0, .., len(D_in) - 1``
+                  * If  ``(D_out[i] - 1) * strides[i] >= D_in[i] + pad[2*i] and (pad[2*i] + pad[2*i+1] > 0)``
+                    then ``D_out[i] = D_out[i] - 1``.
+
+            * The first equation is same as:
+
+                * ``D_out[i] = floor[(D_in[i] + pad[2*i] + pad[2*i+1] - kernel_sizes[i] + strides[i] - 1) / strides[i]] +1, for i = 0, .., len(D_in) - 1``
     
     Attributes
     ----------
@@ -175,7 +176,7 @@ class avg_pool(Pooling):
 @register_op(doc_str="")
 class l2_pool(Pooling):
     """
-    Perform L2 pooling. Currently supports only 1-D and 2-D.
+    Perform L2 pooling. Supports 1-D, 2-D, and 3-D pool.
     
     Parameters
     ----------
@@ -215,7 +216,7 @@ class l2_pool(Pooling):
 @register_op(doc_str="")
 class max_pool(Pooling):
     """
-    Perform max pooling. Currently supports only 1-D and 2-D.
+    Perform max pooling. Supports 1-D, 2-D, and 3-D pool.
     
     Parameters
     ----------

--- a/coremltools/converters/mil/mil/ops/defs/pool.py
+++ b/coremltools/converters/mil/mil/ops/defs/pool.py
@@ -77,13 +77,14 @@ class Pooling(Operation):
 @register_op(doc_str="")
 class avg_pool(Pooling):
     """
-    Perform average pooling. Supports 1-D, 2-D, and 3-D pool (1, 2, or 3 spatial dimensions).
+    Perform average pooling. Currently defined only for spatial 1-D and
+    2-D cases. (Can be extended to the 3-D case easily.)
     
     Parameters
     ----------
     x: tensor<[n,C_in,\*D_in],T> (Required)
         *  ``3 <= rank <= 5``.
-        *  ``D_in`` are spatial dimensions, ``1 <= len(D_in) <= 3``.
+        *  ``D_in`` are spatial dimensions, ``1 <= len(D_in) <= 2``.
         *  ``C_in`` is the number of input channels or depth dimensions.
         *  ``n`` is the batch dimension.
     
@@ -102,54 +103,52 @@ class avg_pool(Pooling):
         * ``valid``: No padding. This is equivalent to custom pad with ``pad[i] = 0, for
           all i``.
         * ``same`` : This is equivalent to custom pad with ``pad[2*i] + pad[2*i+1] = kernel_size[i]``.
-        * ``custom``: Specify custom padding in the parameter pad. note that ``same``
+        * ``custom``: Specify custom padding in the parameter pad. note that "same"
           padding is equivalent to custom padding with
           ``pad[2*i] + pad[2*i+1] = kernel_size[i]``.
     
     pad: const<[P],i32> (Optional. Default to all 0s)
         * ``pad`` represents the number of elements to pad before and after each 
-          dimension: ``pad[2*i], pad[2*i+1]`` are the pad size before and after spatial
+          dimension: `pad[2*i], pad[2*i+1]` are the pad size before and after spatial
           dimension ``i``.
         * ``P = 2 * len(D_in)``.
         * ``pad`` should be specified if and only if ``pad_type == custom``
     
     exclude_padding_from_average: const tensor<[], bool> (Optional, default to False)
-        * If ``True``, padded values (0s) are excluded from the denominator count
+        * If ''True'', padded values (0s) are excluded from the denominator count
           when computing the average over the kernel window.
 
     ceil_mode: const<bool>
-        * Same as PyTorch's ``ceil`` mode.
-        * ``ceil`` is used instead of floor in calculating the output size.
-        * Optional, defaults to ``False``.
-        * Only applicable when ``pad_type`` is ``valid`` or ``custom``.
-        * When ``ceil_mode`` is True, padding must be symmetric; that is, if specified, 
-          ``pad[2*i] == pad[2*i+1]`` must hold.
+        * same as PyTorch's ceil mode
+        * ceil is used instead of floor in calculating the output size
+        * only supported when its 1D or 2D pool
+        * optional, defaults to False
+        * only applicable when pad_type is ``valid`` or ``custom``
+        * when ceil_mode is True, padding must be symmetric, that is, if specified, ``pad[2*i] == pad[2*i+1]`` must hold
     
     Returns
     -------
     tensor<[n, C_out,\*D_out],T>
         * Same rank as ``x``.
-        * When ``ceil_mode = False``:
+        * when ceil_mode= False:
             * ``D_out[i] = floor[(D_in[i] + pad[2*i] + pad[2*i+1] - kernel_sizes[i]) /
               strides[i]] +1, for i = 0, .., len(D_in) - 1`` is mathematically the same
               as (when all parameters involved are integers):
 
                   * ``D_out[i] = ceil [(D_in[i] + pad[2*i] + pad[2*i+1] - kernel_size[i] - 1) / stride[i]], for i = 0, .., len(D_in) - 1``.
-                  * ``*D_out`` is all ones if ``global_pooling`` is ``true``.
+                  * ``*D_out`` is all 1s if ``global_pooling`` is ``true``.
 
-        * When ``ceil_mode = True``:
-            * ``D_out[i] = ceil[(D_in[i] + pad[2*i] + pad[2*i+1] - kernel_sizes[i]) / strides[i]] +1, for i = 0, .., len(D_in) - 1``
+        * when ceil_mode= True
+            * `D_out[i] = ceil[(D_in[i] + pad[2*i] + pad[2*i+1] - kernel_sizes[i]) / strides[i]] +1, for i = 0, .., len(D_in) - 1``
+                * if  `(D_out[i] - 1) * strides[i] >= D_in[i] + pad[2*i] and (pad[2*i] + pad[2*i+1] > 0)`:
+                        then `D_out[i] = D_out[i] - 1`
 
-                  * If  ``(D_out[i] - 1) * strides[i] >= D_in[i] + pad[2*i] and (pad[2*i] + pad[2*i+1] > 0)``
-                    then ``D_out[i] = D_out[i] - 1``.
-
-            * The first equation is same as:
-
-                * ``D_out[i] = floor[(D_in[i] + pad[2*i] + pad[2*i+1] - kernel_sizes[i] + strides[i] - 1) / strides[i]] +1, for i = 0, .., len(D_in) - 1``
+            * the first equation is same as :
+                * `D_out[i] = floor[(D_in[i] + pad[2*i] + pad[2*i+1] - kernel_sizes[i] + strides[i] - 1) / strides[i]] +1, for i = 0, .., len(D_in) - 1``
     
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     
     See Also
     --------
@@ -176,7 +175,7 @@ class avg_pool(Pooling):
 @register_op(doc_str="")
 class l2_pool(Pooling):
     """
-    Perform L2 pooling. Supports 1-D, 2-D, and 3-D pool.
+    Perform L2 pooling. Currently supports only 1-D and 2-D.
     
     Parameters
     ----------
@@ -202,7 +201,7 @@ class l2_pool(Pooling):
     
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     
     See Also
     --------
@@ -216,7 +215,7 @@ class l2_pool(Pooling):
 @register_op(doc_str="")
 class max_pool(Pooling):
     """
-    Perform max pooling. Supports 1-D, 2-D, and 3-D pool.
+    Perform max pooling. Currently supports only 1-D and 2-D.
     
     Parameters
     ----------
@@ -245,7 +244,7 @@ class max_pool(Pooling):
     
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
 
     See Also
     --------

--- a/coremltools/converters/mil/mil/ops/defs/random.py
+++ b/coremltools/converters/mil/mil/ops/defs/random.py
@@ -73,7 +73,11 @@ class random_bernoulli(RandomDistribution):
     -------
     <\*, T>
         * A tensor of the given target output shape filled with random values.
-    
+
+    Attributes
+    ----------
+    T: fp16, fp32
+
     See Also
     --------
     random_categorical, random_normal, random_uniform
@@ -128,7 +132,11 @@ class random_categorical(Operation):
     -------
     <\*D_in[:-1] + [size], T>
         * A tensor of the given target output shape filled with random values.
-    
+
+    Attributes
+    ----------
+    T: fp16, fp32
+
     See Also
     --------
     random_bernoulli, random_normal, random_uniform
@@ -180,7 +188,11 @@ class random_normal(RandomDistribution):
     -------
     <\*, T>
         * A tensor of the given target output shape filled with random values.
-    
+
+    Attributes
+    ----------
+    T: fp16, fp32
+
     See Also
     --------
     random_categorical, random_bernoulli, random_uniform
@@ -246,7 +258,11 @@ class random_uniform(RandomDistribution):
     -------
     <\*, T>
         * A tensor of the given target output shape filled with random values.
-    
+
+    Attributes
+    ----------
+    T: fp16, fp32
+
     See Also
     --------
     random_categorical, random_bernoulli, random_normal

--- a/coremltools/converters/mil/mil/ops/defs/reduction.py
+++ b/coremltools/converters/mil/mil/ops/defs/reduction.py
@@ -163,7 +163,7 @@ class reduce_argmax(reduce_arg):
     
     Attributes
     ----------
-    T: f32, int32
+    T: i32, fp16, fp32
     
     References
     ----------
@@ -202,7 +202,7 @@ class reduce_argmin(reduce_arg):
     
     Attributes
     ----------
-    T: f32, int32
+    T: i32, fp16, fp32
     
     References
     ----------
@@ -241,7 +241,7 @@ class reduce_l1_norm(ReductionAxes):
     
     Attributes
     ----------
-    T: f32, int32
+    T: i32, fp16, fp32
     
     References
     ----------
@@ -283,8 +283,7 @@ class reduce_l2_norm(ReductionAxes):
     
     Attributes
     ----------
-    T: f32, int32
-    
+    T: i32, fp16, fp32
     """
     
     def __init__(self, **kwargs):
@@ -322,8 +321,7 @@ class reduce_log_sum(ReductionAxes):
     
     Attributes
     ----------
-    T: f32, int32
-    
+    T: i32, fp16, fp32
     """
     
     def __init__(self, **kwargs):
@@ -364,7 +362,7 @@ class reduce_log_sum_exp(ReductionAxes):
     
     Attributes
     ----------
-    T: f32, int32
+    T: i32, fp16, fp32
     
     References
     ----------
@@ -414,8 +412,7 @@ class reduce_max(ReductionAxes):
     
     Attributes
     ----------
-    T: f32, int32
-    
+    T: i32, fp16, fp32
     """
     
     def __init__(self, **kwargs):
@@ -449,7 +446,7 @@ class reduce_mean(ReductionAxes):
     
     Attributes
     ----------
-    T: f32, int32
+    T: i32, fp16, fp32
     
     References
     ----------
@@ -487,8 +484,7 @@ class reduce_min(ReductionAxes):
     
     Attributes
     ----------
-    T: f32, int32
-    
+    T: i32, fp16, fp32
     """
     
     def __init__(self, **kwargs):
@@ -522,8 +518,7 @@ class reduce_prod(ReductionAxes):
     
     Attributes
     ----------
-    T: f32, int32
-    
+    T:  i32, fp16, fp32
     """
     
     def __init__(self, **kwargs):
@@ -557,8 +552,7 @@ class reduce_sum(ReductionAxes):
     
     Attributes
     ----------
-    T: f32, int32
-    
+    T: i32, fp16, fp32
     """
 
     def __init__(self, **kwargs):
@@ -592,8 +586,7 @@ class reduce_sum_square(ReductionAxes):
     
     Attributes
     ----------
-    T: f32, int32
-    
+    T: i32, fp16, fp32
     """
     
     def __init__(self, **kwargs):

--- a/coremltools/converters/mil/mil/ops/defs/scatter_gather.py
+++ b/coremltools/converters/mil/mil/ops/defs/scatter_gather.py
@@ -72,7 +72,7 @@ class gather(Operation):
 
     Attributes
     ----------
-    T: fp32
+    U: fp16, fp32, i32
 
     References
     ----------
@@ -195,7 +195,7 @@ class scatter(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     """
 
     input_spec = InputSpec(
@@ -262,7 +262,7 @@ class gather_along_axis(Operation):
 
     Attributes
     ----------
-    T: fp32
+    U: fp16, fp32, i32
     """
 
     input_spec = InputSpec(
@@ -378,7 +378,7 @@ class scatter_along_axis(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     """
 
     input_spec = InputSpec(
@@ -456,7 +456,7 @@ class gather_nd(Operation):
 
     Attributes
     ----------
-    T: fp32
+    U: fp16, fp32, i32
 
     References
     ----------
@@ -516,7 +516,7 @@ class scatter_nd(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     """
 
     input_spec = InputSpec(

--- a/coremltools/converters/mil/mil/ops/defs/tensor_operation.py
+++ b/coremltools/converters/mil/mil/ops/defs/tensor_operation.py
@@ -70,6 +70,10 @@ class band_part(Operation):
     -------
     tensor<\*?, T>
         * Same type and shape as the input tensor.
+
+    Attributes
+    ----------
+    T: fp16, fp32, i32, bool
     """
 
     input_spec = InputSpec(
@@ -119,7 +123,7 @@ class cumsum(Operation):
 
     Attributes
     ----------
-    T: fp32, int32
+    T: fp16, fp32, i32
     """
 
     input_spec = InputSpec(
@@ -186,7 +190,7 @@ class fill(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32, bool
     """
 
     input_spec = InputSpec(
@@ -262,7 +266,7 @@ class non_maximum_suppression(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(
@@ -314,7 +318,7 @@ class non_zero(Operation):
 
     Attributes
     ----------
-    T: fp32, int32
+    T: fp16, fp32, i32, bool
     """
 
     input_spec = InputSpec(x=TensorInputType())
@@ -360,7 +364,7 @@ class one_hot(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32, bool
     """
 
     input_spec = InputSpec(
@@ -453,7 +457,7 @@ class pad(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(
@@ -544,7 +548,7 @@ class range_1d(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: i32, fp16, fp32
     """
 
     input_spec = InputSpec(
@@ -612,7 +616,7 @@ class tile(Operation):
 
     Attributes
     ----------
-    T: Any
+    T: fp16, fp32, i32, bool
     """
 
     input_spec = InputSpec(x=TensorInputType(), reps=TensorInputType(),)
@@ -684,7 +688,7 @@ class argsort(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     """
 
     input_spec = InputSpec(
@@ -742,7 +746,7 @@ class topk(Operation):
 
     Attributes
     ----------
-    T: fp32, int32
+    T: fp16, fp32, i32
     """
 
     input_spec = InputSpec(
@@ -818,7 +822,7 @@ class flatten2d(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32, bool
     """
 
     input_spec = InputSpec(
@@ -870,7 +874,7 @@ class shape(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32, bool
     """
 
     input_spec = InputSpec(x = ScalarOrTensorInputType())
@@ -938,7 +942,7 @@ class concat(Operation):
 
     Attributes
     ----------
-    T: fp32, int32
+    T: fp16, fp32, i32, bool
     """
 
     input_spec = InputSpec(values=TupleInputType(),
@@ -1096,7 +1100,7 @@ class split(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32, bool
     """
 
     input_spec = InputSpec(
@@ -1203,7 +1207,7 @@ class stack(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32, bool
     """
 
     input_spec = InputSpec(values=TupleInputType(),
@@ -1267,6 +1271,9 @@ class identity(Operation):
     tensor<\*?, T>
         * Same type and shape as the input tensor.
 
+    Attributes
+    ----------
+    T: fp16, fp32, i32, bool
     """
 
     input_spec = InputSpec(x=ListOrScalarOrTensorInputType())

--- a/coremltools/converters/mil/mil/ops/defs/tensor_transformation.py
+++ b/coremltools/converters/mil/mil/ops/defs/tensor_transformation.py
@@ -128,7 +128,7 @@ class depth_to_space(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(
@@ -169,7 +169,7 @@ class expand_dims(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32, bool
     """
 
     input_spec = InputSpec(
@@ -267,7 +267,7 @@ class reshape(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32, bool
     """
 
     input_spec = InputSpec(
@@ -385,7 +385,7 @@ class reverse(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32, bool
 
     References
     ----------
@@ -448,7 +448,7 @@ class reverse_sequence(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32, bool
 
     References
     ----------
@@ -518,7 +518,7 @@ class slice_by_index(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32, bool
 
     """
 
@@ -650,7 +650,7 @@ class slice_by_size(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32, bool
     """
 
     input_spec = InputSpec(
@@ -748,7 +748,7 @@ class space_to_depth(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
     """
 
     input_spec = InputSpec(
@@ -786,7 +786,7 @@ class squeeze(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32, bool
     """
 
     input_spec = InputSpec(
@@ -850,7 +850,7 @@ class transpose(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32, bool
 
     References
     ----------
@@ -904,7 +904,7 @@ class pixel_shuffle(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32
 
     References
     ----------
@@ -955,7 +955,7 @@ class sliding_windows(Operation):
 
     Attributes
     ----------
-    T: fp32
+    T: fp16, fp32, i32
     """
 
     input_spec = InputSpec(


### PR DESCRIPTION
This PR edits the attributes in MIL Ops documentation.

It includes the following files:

```
	modified:   coremltools/converters/mil/mil/ops/defs/activation.py
	modified:   coremltools/converters/mil/mil/ops/defs/control_flow.py
	modified:   coremltools/converters/mil/mil/ops/defs/conv.py
	modified:   coremltools/converters/mil/mil/ops/defs/elementwise_binary.py
	modified:   coremltools/converters/mil/mil/ops/defs/elementwise_unary.py
	modified:   coremltools/converters/mil/mil/ops/defs/image_resizing.py
	modified:   coremltools/converters/mil/mil/ops/defs/linear.py
	modified:   coremltools/converters/mil/mil/ops/defs/normalization.py
	modified:   coremltools/converters/mil/mil/ops/defs/pool.py
	modified:   coremltools/converters/mil/mil/ops/defs/random.py
	modified:   coremltools/converters/mil/mil/ops/defs/reduction.py
	modified:   coremltools/converters/mil/mil/ops/defs/scatter_gather.py
	modified:   coremltools/converters/mil/mil/ops/defs/tensor_operation.py
	modified:   coremltools/converters/mil/mil/ops/defs/tensor_transformation.py
```

This PR does _not_ include the generated HTML. After these changes are
reviewed and merged, I will do a separate PR to merge the HTML.

