### PR TITLE
Remove duplicate docs.pip install in /scripts/env_create.sh

### DIFF
--- a/scripts/env_create.sh
+++ b/scripts/env_create.sh
@@ -110,12 +110,6 @@ if [[ $include_docs_deps == 1 ]]; then
   python -m pip install -r $COREMLTOOLS_HOME/reqs/docs.pip --upgrade
 fi
 
-# Install doc requirements (upgrades packages if required)
-if [[ $include_docs_deps == 1 ]]; then
-  echo "Installing additional document requirements."
-  python -m pip install -r $COREMLTOOLS_HOME/reqs/docs.pip --upgrade
-fi
-
 if [[ $DEV == 1 ]]; then
   echo "Setting up environment for development."
   python -m pip install -e "$COREMLTOOLS_HOME/../coremltools" --upgrade


### PR DESCRIPTION
There appears to be a redundant (duplicate) step to install doc requirements in `/scripts/env_create.sh`.
The content of lines `107-111` appears again, verbatim and consecutively, in lines `113-117`:
```bash
# Install doc requirements (upgrades packages if required)
if [[ $include_docs_deps == 1 ]]; then
  echo "Installing additional document requirements."
  python -m pip install -r $COREMLTOOLS_HOME/reqs/docs.pip --upgrade
fi

# Install doc requirements (upgrades packages if required)
if [[ $include_docs_deps == 1 ]]; then
  echo "Installing additional document requirements."
  python -m pip install -r $COREMLTOOLS_HOME/reqs/docs.pip --upgrade
fi

```
This PR simply removes lines `113-118` (line 118 then being the blank line following the removed block).
I'm assuming this duplication is spurious. It appears to be harmless, assuming pip is functioning as expected.

If, for some reason, installing those dependencies twice solves some other issue, I suggest documenting those reasons. It seems counterintuitive to be left as-is.
