### PR TITLE
Fix doc about element wise logical ops.

### DIFF
--- a/coremltools/converters/mil/mil/ops/defs/elementwise_binary.py
+++ b/coremltools/converters/mil/mil/ops/defs/elementwise_binary.py
@@ -324,8 +324,6 @@ class logical_and(elementwise_binary):
     """
     Return the truth value of ``x AND y`` element-wise with
     `broadcasting <https://docs.scipy.org/doc/numpy/user/basics.broadcasting.html>`_
-    (``1`` for true, ``0`` for false in numeric domain). A numeric value ``t`` is
-    evaluated to true if ``t != 0``.
 
     Parameters
     ----------
@@ -361,8 +359,6 @@ class logical_or(elementwise_binary):
     """
     Return the truth value of ``x OR y`` element-wise with
     `broadcasting <https://docs.scipy.org/doc/numpy/user/basics.broadcasting.html>`_
-    (``1`` for true, ``0`` for false in numeric domain). A numeric value ``t`` is
-    evaluated to true if ``t != 0``.
     
     Parameters
     ----------
@@ -398,8 +394,6 @@ class logical_xor(elementwise_binary):
     """
     Return the truth value of ``x XOR y`` element-wise with
     `broadcasting <https://docs.scipy.org/doc/numpy/user/basics.broadcasting.html>`_
-    (``1`` for true, ``0`` for false in numeric domain). A numeric value ``t`` is
-    evaluated to true if ``t != 0``.
     
     Parameters
     ----------


### PR DESCRIPTION
I think these sentence does not make sense since `logical_XXX` receive only `bool` Tensor. 
At first, I misunderstood that `logical_XXX` accepts `int` and `float` tensor.

Type alias `T` may also be unnecessary.
We can replace `T` with `bool` in this document.