### PR TITLE
Typos in relu6 and conv-transpose

### DIFF
--- a/coremltools/converters/mil/mil/ops/defs/activation.py
+++ b/coremltools/converters/mil/mil/ops/defs/activation.py
@@ -348,7 +348,7 @@ class relu(elementwise_unary):
 @register_op(doc_str="")
 class relu6(elementwise_unary):
     """
-    Return elementwise-applied rectified linear activation: ``max(min(x, 0), 6)``.
+    Return elementwise-applied rectified linear activation: ``min(max(x, 0), 6)``.
 
     Parameters
     ----------

--- a/coremltools/converters/mil/mil/ops/defs/conv.py
+++ b/coremltools/converters/mil/mil/ops/defs/conv.py
@@ -281,9 +281,9 @@ class conv_transpose(Operation):
           dimension ``i``, where ``0 <= i < len(D_in)``.
 
     output_shape: const tensor<[P],i32> (Optional, default None)
-        * Expected output shape. The first two dim must be ``[n, C_out]``.
-        * The output shape of conv_transpose is underdetermined in general,
-        * Because conv can map multiple input shape to a single output shape.
+        * Expected output shape. The first two dimensions must be ``[n, C_out]``.
+        * The output shape of ``conv_transpose`` is underdetermined in general,
+          because ``conv`` can map multiple input shapes to a single output shape.
           For example, for ``same`` padding mode, ``conv_out = ceil(conv_in/stride)``.
           Hence we need ``output_shape`` when this occurs.
 
@@ -306,8 +306,22 @@ class conv_transpose(Operation):
     Returns
     -------
     tensor<[n,C_out,*D_out],T>
-        * ``D_out[i] = (D_in[i]-1) * strides[i] + pad[2*i] + pad[2*i+1] -
-          (K[i] - 1) * dilations[i] + 1)] for i = 0, 1``.
+		* If ``output_shape`` is not ``None``:
+		  
+		     ``Dout = output_shape``
+
+		* If ``pad_type == "custom"``:
+		  
+		     ``Dout[i] = (D_in[i]-1)*stride[i] + (K[i]-1) * dilation[i] + 1 - pad[2*i] - pad[2*i-1]``
+
+		* If ``pad_type == "valid"``:
+		  
+		     ``Dout[i] = (D_in[i]-1)*stride[i] + (K[i]-1) * dilation[i] + 1``
+
+		* If ``pad_type == "same"``:
+		  
+		     ``Dout[i] = D_in[i] * stride[i]``
+    
 
     Attributes
     ----------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@
 coremltools API
 =====================
 
-This the API Reference for coremltools. For guides, installation instructions, and examples, see `Guides <https://coremltools.readme.io/docs>`_.
+This is the API Reference for coremltools. For guides, installation instructions, and examples, see `Guides <https://coremltools.readme.io/docs>`_.
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
This PR fixes the API Reference documentation as follows:

- `activation.py`: [`Relu6`](https://apple.github.io/coremltools/source/coremltools.converters.mil.mil.ops.defs.html#coremltools.converters.mil.mil.ops.defs.activation.relu6) typo.
- `conv.py`: Fix Returns section and formatting problems in the docstring of [`conv_transpose` op](https://apple.github.io/coremltools/source/coremltools.converters.mil.mil.ops.defs.html#coremltools.converters.mil.mil.ops.defs.conv.conv_transpose).
- `index.rst`: Typo in the first sentence of [the landing page](https://apple.github.io/coremltools/index.html).

This PR does _not_ include the generated HTML. After these changes are
reviewed and merged, I will do a separate PR to merge the HTML.
