### PR TITLE
fix protobuf version for build error.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     },
     install_requires=[
         "numpy >= 1.14.5",
-        "protobuf >= 3.1.0",
+        "protobuf == 3.20.1",
         "sympy",
         "tqdm",
         "packaging",


### PR DESCRIPTION
Resolve #1499 
This is quick fix.
Otherwise, we can regenerate pb2.py file with latest protobuf.