### PR TITLE
API Reference for v6.0b1 and Layernorm Fix

### DIFF
--- a/coremltools/converters/mil/mil/ops/defs/normalization.py
+++ b/coremltools/converters/mil/mil/ops/defs/normalization.py
@@ -229,13 +229,13 @@ class layer_norm(Operation):
         * Dimensions to perform layer normalization.
         * Default is ``None`` (all dimensions).
 
-    gamma: const tensor<[K], T> (Optional)
+    gamma: const tensor<\*?, T>, T> (Optional)
         * if provided, the shape must be be ``x.shape[axes]``. For instance, if
           input ``x`` with shape ``(3,4,5,6)`` and ``axes = [2,3]``, gamma must have
           shape ``(5,6)``.
         * Default is all ones.
 
-    beta: const tensor<[K], T> (Optional)
+    beta: const tensor<\*?, T>, T> (Optional)
         * Same shape as gamma.
         * Default is all zeros.
 


### PR DESCRIPTION
This PR changes the API Reference documentation as follows:

- `normalization.py`: [`layer_norm`](https://apple.github.io/coremltools/source/coremltools.converters.mil.mil.ops.defs.html#coremltools.converters.mil.mil.ops.defs.normalization.layer_norm) correction to `gamma` and `beta` parameters (rdar://94354229).

Note: Changes to docstrings in 6.0b1, including new compression utilities under [**Models**](https://apple.github.io/coremltools/source/coremltools.models.html), and new output specification for [`convert()`](https://apple.github.io/coremltools/source/coremltools.converters.convert.html), were done and approved in the internal repo before this PR. However, this is the first time they appear in this public repo.

This PR does _not_ include the generated HTML. After these changes are
reviewed and merged, I will do a separate PR to merge the HTML.
