### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,6 +62,12 @@ build_wheel_linux_py39:
   variables:
     PYTHON: "3.9"
 
+build_wheel_linux_py310:
+  <<: *build_linux
+  image: registry.gitlab.com/zach_nation/coremltools/build-image-ubuntu-18.04:1.0.0
+  variables:
+    PYTHON: "3.10"
+
 #########################################################################
 ##
 ##                         macOS - Build
@@ -98,6 +104,11 @@ build_wheel_macos_py39:
   <<: *build_macos
   variables:
     PYTHON: "3.9"
+
+build_wheel_macos_py310:
+  <<: *build_macos
+  variables:
+    PYTHON: "3.10"
 
 #########################################################################
 ##

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -19,7 +19,7 @@ Follow these steps:
 1. Fork and clone the GitHub [coremltools repository](https://github.com/apple/coremltools).
 
 2. Run the [build.sh](scripts/build.sh) script to build `coremltools`. 
-	* By default this script uses Python 3.7, but you can include `--python=3.6` (or `3.7`, `3.8`, `3.9`) as a argument to change the Python version.
+	* By default this script uses Python 3.7, but you can include `--python=3.6` (or `3.7`, `3.8`, `3.9`, `3.10`) as an argument to change the Python version.
 	* The script creates a new `build` folder with the coremltools distribution, and a `dist` folder with Python wheel files.
 	
 3. Run the [test.sh](scripts/test.sh) script to test the build.
@@ -45,7 +45,7 @@ The following build targets help you configure the development environment. If y
 * `test_slow` | Run all non-fast tests.
 * `wheel` | Build wheels in release mode.
 
-The script uses Python 3.7, but you can include `--python=3.6` (or `3.7`, `3.8`, `3.9`) as a argument to change the Python version.
+The script uses Python 3.7, but you can include `--python=3.6` (or `3.7`, `3.8`, `3.9`, `3.10`) as an argument to change the Python version.
 
 ## Resources
 

--- a/reqs/build.pip
+++ b/reqs/build.pip
@@ -1,4 +1,4 @@
-numpy<1.20; platform_machine != "arm64"
+numpy
 
 # rdar://93977023
 protobuf<=3.20.1; python_version < "3.7"

--- a/scripts/env_create.sh
+++ b/scripts/env_create.sh
@@ -91,11 +91,6 @@ fi
 echo "Installing basic build requirements."
 if [[ $include_build_deps == 1 ]]; then
     python -m pip install -r $COREMLTOOLS_HOME/reqs/build.pip
-
-    if [[ $(uname -m) == "arm64" ]]; then
-	# Install the earliest version of numpy, we can find, that support arm64
-	conda install -c apple numpy==1.19.5 -y
-    fi
 fi
 
 # Install test requirements (upgrades packages if required)

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
         "": ["LICENSE.txt", "README.md", "libmilstoragepython.so", "libcoremlpython.so", "libmodelpackage.so"]
     },
     install_requires=[
-        "numpy >= 1.14.5",
+        "numpy",
         "protobuf >= 3.1.0, <= 3.20.1",
         "sympy",
         "tqdm",
@@ -84,6 +84,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Scientific/Engineering",
         "Topic :: Software Development",
     ],


### PR DESCRIPTION
`numpy` [supports](https://github.com/numpy/numpy/releases/tag/v1.21.3) Python 3.10 starting with version `1.21.3`, so we need to upgrade `numpy`.

Fixes #1484.