### PR TITLE
Create dependabot.yml (automatic version updates)

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "enhancement"
+      - "p1"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "enhancement"
+      - "p1"


### PR DESCRIPTION
This will make dependabot, owned by github I think, scan coremltools (the repository) for the latest version updates and stuff and if it sees a version outdated with the package ecosystem, it will open a PR to change that.