### PR TITLE
API Reference Fix for Right Margin

### DIFF
--- a/docs/_static/css/norightmargin.css
+++ b/docs/_static/css/norightmargin.css
@@ -1,0 +1,3 @@
+.wy-nav-content {
+    max-width: none;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,3 +65,6 @@ html_theme = 'sphinx_rtd_theme'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+html_css_files = [
+    'css/norightmargin.css'
+]


### PR DESCRIPTION
This PR changes the API Reference documentation to remove the right margin so that text and examples don't appear to be extending beyond it. See attached figures for examples.

- `_static/css/norightmargin.css`: Overrides the right margin setting to set the maximum width to none. As a result, the right margin changes depending on the side of the window, and text that is supposed to wrap continues to wrap correctly. See attached figures for examples.

- `conf.py`: Add the `html_static_path` and `html_css_files` options. This enables the `css/norightmargin.css` CSS override.

Figures:

**Current #1**: [Converters > Unified](https://apple.github.io/coremltools/source/coremltools.converters.convert.html#module-coremltools.converters._converters_entry): Right margin in Parameters section.
![API-ref-right-margin-currrent1](https://user-images.githubusercontent.com/70229264/180884899-7f346b6d-35bd-4002-9f5f-7bb0d34717cb.png)

**Fixed #1**: Converters > Unified
![API-ref-right-margin-fixed1](https://user-images.githubusercontent.com/70229264/180884963-e956a1b9-eaf9-4437-a468-e6da7954e7e1.png)

**Current #2**: [Models > `compression_utils` > `palettize_weights`](https://apple.github.io/coremltools/source/coremltools.models.ml_program.html#module-0): Right margin in Parameters section.
![API-ref-right-margin-currrent2](https://user-images.githubusercontent.com/70229264/180885022-94603ffb-947f-4d13-9d58-68a9189a6f04.png)

**Fixed #2**: Models > `compression_utils` > `palettize_weights`
![API-ref-right-margin-fixed2](https://user-images.githubusercontent.com/70229264/180885050-3cb72cf6-0c1b-4cfc-91e1-e45ff89f82e8.png)

**Current #3**: [Mil Ops > `tensor_transformation`](https://apple.github.io/coremltools/source/coremltools.converters.mil.mil.ops.defs.html#module-coremltools.converters.mil.mil.ops.defs.tensor_transformation): Right margin for some class headers.
![API-ref-right-margin-currrent3](https://user-images.githubusercontent.com/70229264/180885094-d946423b-a3d8-40d1-ba27-4c1b8a2a4fc6.png)

**Fixed #3** Mil Ops > `tensor_transformation`
![API-ref-right-margin-fixed3](https://user-images.githubusercontent.com/70229264/180885141-db7cb997-9a52-482d-8516-7127b1a69f73.png)

The next PR provides the generated HTML.
