### PR TITLE
Fix bug in transpose op - don't allow symbolic value in value_inference

### DIFF
--- a/coremltools/converters/mil/mil/ops/defs/iOS15/tensor_transformation.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS15/tensor_transformation.py
@@ -964,7 +964,7 @@ class transpose(Operation):
             ret_shape = x_shape[perm]
         return types.tensor(x_type, tuple(ret_shape))
 
-    @precondition(allow=VALUE | SYMBOL)
+    @precondition(allow=VALUE)
     def value_inference(self):
         return np.transpose(self.x.val, axes=self.perm.val)
 


### PR DESCRIPTION
This PR covers the following issue #1556 