### PR TITLE
Update API: utils.evaluate_regressor and utils.evaluate_classifier

### DIFF
--- a/coremltools/models/utils.py
+++ b/coremltools/models/utils.py
@@ -284,9 +284,7 @@ def _fp32_to_fp16_byte_array(fp32_arr):
             "half precision.\n"
         )
 
-    import sys
-
-    if sys.byteorder == "little":
+    if _sys.byteorder == "little":
         return _np.float16(fp32_arr).tobytes()
     else:
         return _fp32_to_reversed_fp16_byte_array(fp32_arr)
@@ -359,8 +357,7 @@ def evaluate_regressor(model, data, target="target", verbose=False):
         Test data on which to evaluate the models
 
     target: str
-       Name of the column in the dataframe that must be interpreted
-       as the target column.
+       Name of the column in the dataframe to be compared against the prediction
 
     verbose: bool
        Set to true for a more verbose output.
@@ -386,11 +383,11 @@ def evaluate_regressor(model, data, target="target", verbose=False):
     max_error = 0
     error_squared = 0
 
-    for index, row in data.iterrows():
+    for _, row in data.iterrows():
         input_dict = dict(row)
         _remove_invalid_keys(input_dict, model)
         predicted = model.predict(input_dict)[_to_unicode(target)]
-        other_framework = row["prediction"]
+        other_framework = row[target]
         delta = predicted - other_framework
 
         if verbose:
@@ -451,11 +448,11 @@ def evaluate_classifier(model, data, target="target", verbose=False):
 
     num_errors = 0
 
-    for index, row in data.iterrows():
+    for _, row in data.iterrows():
         input_dict = dict(row)
         _remove_invalid_keys(input_dict, model)
         predicted = model.predict(input_dict)[_to_unicode(target)]
-        other_framework = row["prediction"]
+        other_framework = row[target]
         if predicted != other_framework:
             num_errors += 1
 

--- a/coremltools/test/sklearn_tests/test_NuSVC.py
+++ b/coremltools/test/sklearn_tests/test_NuSVC.py
@@ -3,11 +3,12 @@
 # Use of this source code is governed by a BSD-3-clause license that can be
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
-import unittest
-import tempfile
 import os
-import pandas as pd
+import tempfile
 import random
+import unittest
+
+import pandas as pd
 import pytest
 
 from coremltools.models.utils import (
@@ -90,7 +91,6 @@ class NuSvcScikitTest(unittest.TestCase):
                 cur_params.update(param2)
                 cur_params["probability"] = use_probability_estimates
                 cur_params["max_iter"] = 10  # Don't want test to take too long
-                # print("cur_params=" + str(cur_params))
 
                 cur_model = NuSVC(**cur_params)
                 cur_model.fit(x, y)
@@ -112,7 +112,7 @@ class NuSvcScikitTest(unittest.TestCase):
                             metrics["max_probability_error"], allowed_prob_delta
                         )
                     else:
-                        df["prediction"] = cur_model.predict(x)
+                        df["target"] = cur_model.predict(x)
                         metrics = evaluate_classifier(spec, df, verbose=False)
                         self.assertEqual(metrics["num_errors"], 0)
 
@@ -159,8 +159,6 @@ class NuSvcScikitTest(unittest.TestCase):
         self._evaluation_test_helper(["X", "Y", "z"], True, allow_slow=False)
 
     def test_conversion_bad_inputs(self):
-        from sklearn.preprocessing import OneHotEncoder
-
         # Error on converting an untrained model
         with self.assertRaises(TypeError):
             model = NuSVC()

--- a/coremltools/test/sklearn_tests/test_NuSVR.py
+++ b/coremltools/test/sklearn_tests/test_NuSVR.py
@@ -3,10 +3,11 @@
 # Use of this source code is governed by a BSD-3-clause license that can be
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
-import pandas as pd
 import tempfile
 import random
 import unittest
+
+import pandas as pd
 import pytest
 
 from coremltools._deps import (
@@ -18,8 +19,13 @@ from coremltools._deps import (
 from coremltools.models.utils import evaluate_regressor, _macos_version, _is_macos
 
 if _HAS_LIBSVM:
-    from libsvm import svmutil
-    from libsvm import svm
+    from libsvm import (
+        svm,
+        svm_parameter,
+        svm_problem,
+        svmutil,
+    )
+    from svmutil import svm_train, svm_predict
     from coremltools.converters import libsvm
 
 if _HAS_SKLEARN:
@@ -109,7 +115,7 @@ class NuSVRScikitTest(unittest.TestCase):
 
                 cur_model = NuSVR(**cur_params)
                 cur_model.fit(x, y)
-                df["prediction"] = cur_model.predict(x)
+                df["target"] = cur_model.predict(x)
 
                 spec = scikit_converter.convert(cur_model, input_names, "target")
 
@@ -175,9 +181,6 @@ class NuSVRLibSVMTest(unittest.TestCase):
         """
         Test that the same predictions are made
         """
-        from svm import svm_parameter, svm_problem
-        from svmutil import svm_train, svm_predict
-
         # Generate some smallish (poly kernels take too long on anything else) random data
         x, y = [], []
         for _ in range(50):
@@ -212,7 +215,7 @@ class NuSVRLibSVMTest(unittest.TestCase):
                 param = svm_parameter(param_str)
 
                 model = svm_train(prob, param)
-                (df["prediction"], _, _) = svm_predict(y, x, model)
+                (df["target"], _, _) = svm_predict(y, x, model)
 
                 spec = libsvm.convert(model, input_names, "target")
 

--- a/coremltools/test/sklearn_tests/test_NuSVR.py
+++ b/coremltools/test/sklearn_tests/test_NuSVR.py
@@ -19,12 +19,7 @@ from coremltools._deps import (
 from coremltools.models.utils import evaluate_regressor, _macos_version, _is_macos
 
 if _HAS_LIBSVM:
-    from libsvm import (
-        svm,
-        svm_parameter,
-        svm_problem,
-        svmutil,
-    )
+    from libsvm import svm, svmutil
     from svmutil import svm_train, svm_predict
     from coremltools.converters import libsvm
 
@@ -190,7 +185,7 @@ class NuSVRLibSVMTest(unittest.TestCase):
 
         input_names = ["x1", "x2"]
         df = pd.DataFrame(x, columns=input_names)
-        prob = svm_problem(y, x)
+        prob = svmutil.svm_problem(y, x)
 
         # Parameters
         base_param = "-s 4"  # model type is nu-SVR
@@ -212,7 +207,7 @@ class NuSVRLibSVMTest(unittest.TestCase):
         for param1 in non_kernel_parameters:
             for param2 in kernel_parameters:
                 param_str = " ".join([base_param, param1, param2])
-                param = svm_parameter(param_str)
+                param = svmutil.svm_parameter(param_str)
 
                 model = svm_train(prob, param)
                 (df["target"], _, _) = svm_predict(y, x, model)

--- a/coremltools/test/sklearn_tests/test_SVR.py
+++ b/coremltools/test/sklearn_tests/test_SVR.py
@@ -3,11 +3,12 @@
 # Use of this source code is governed by a BSD-3-clause license that can be
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
-import pandas as pd
-import numpy as np
 import random
 import tempfile
 import unittest
+
+import numpy as np
+import pandas as pd
 import pytest
 
 from coremltools._deps import (
@@ -115,7 +116,7 @@ class SvrScikitTest(unittest.TestCase):
 
                 cur_model = SVR(**cur_params)
                 cur_model.fit(x, y)
-                df["prediction"] = cur_model.predict(x)
+                df["target"] = cur_model.predict(x)
 
                 spec = sklearn_converter.convert(cur_model, input_names, "target")
 
@@ -164,7 +165,7 @@ class EpsilonSVRLibSVMTest(unittest.TestCase):
         # Default values
         spec = libsvm.convert(self.libsvm_model)
         if _is_macos() and _macos_version() >= (10, 13):
-            (df["prediction"], _, _) = svmutil.svm_predict(
+            (df["target"], _, _) = svmutil.svm_predict(
                 data["target"], data["data"].tolist(), self.libsvm_model
             )
             metrics = evaluate_regressor(spec, df)
@@ -243,7 +244,7 @@ class EpsilonSVRLibSVMTest(unittest.TestCase):
                 param = svm_parameter(param_str)
 
                 model = svm_train(prob, param)
-                (df["prediction"], _, _) = svm_predict(y, x, model)
+                (df["target"], _, _) = svm_predict(y, x, model)
 
                 spec = libsvm.convert(
                     model, input_names=input_names, target_name="target"

--- a/coremltools/test/sklearn_tests/test_composite_pipelines.py
+++ b/coremltools/test/sklearn_tests/test_composite_pipelines.py
@@ -3,12 +3,12 @@
 # Use of this source code is governed by a BSD-3-clause license that can be
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
-import unittest
-import os
-
-import pandas as pd
 import itertools
+import os
+import unittest
+
 import numpy as np
+import pandas as pd
 
 from coremltools._deps import _HAS_SKLEARN
 from coremltools.models.utils import evaluate_transformer
@@ -27,7 +27,6 @@ if _HAS_SKLEARN:
 @unittest.skipIf(not _HAS_SKLEARN, "Missing sklearn. Skipping tests.")
 class GradientBoostingRegressorBostonHousingScikitNumericTest(unittest.TestCase):
     def test_boston_OHE_plus_normalizer(self):
-
         data = load_boston()
 
         pl = Pipeline(
@@ -68,7 +67,7 @@ class GradientBoostingRegressorBostonHousingScikitNumericTest(unittest.TestCase)
         if _is_macos() and _macos_version() >= (10, 13):
             # Get predictions
             df = pd.DataFrame(data.data, columns=data.feature_names)
-            df["prediction"] = pl.predict(data.data)
+            df["target"] = pl.predict(data.data)
 
             # Evaluate it
             result = evaluate_regressor(spec, df, "target", verbose=False)

--- a/coremltools/test/sklearn_tests/test_glm_classifier.py
+++ b/coremltools/test/sklearn_tests/test_glm_classifier.py
@@ -4,9 +4,11 @@
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
 import itertools
-import pandas as pd
 import os
+import random
 import unittest
+
+import pandas as pd
 
 from coremltools._deps import _HAS_SKLEARN
 from coremltools.converters.sklearn import convert
@@ -32,8 +34,6 @@ class GlmCassifierTest(unittest.TestCase):
 
     @staticmethod
     def _generate_random_data(labels):
-        import random
-
         random.seed(42)
 
         # Generate some random data
@@ -60,7 +60,6 @@ class GlmCassifierTest(unittest.TestCase):
         df = pd.DataFrame(x, columns=column_names)
 
         for cur_args in args:
-            print(class_labels, cur_args)
             cur_model = LogisticRegression(**cur_args)
             cur_model.fit(x, y)
 
@@ -101,7 +100,6 @@ class GlmCassifierTest(unittest.TestCase):
         df = pd.DataFrame(x, columns=column_names)
 
         for cur_args in ARGS:
-            print(class_labels, cur_args)
             cur_model = LinearSVC(**cur_args)
             cur_model.fit(x, y)
 
@@ -110,7 +108,7 @@ class GlmCassifierTest(unittest.TestCase):
             )
 
             if _is_macos() and _macos_version() >= (10, 13):
-                df["prediction"] = cur_model.predict(x)
+                df["target"] = cur_model.predict(x)
 
                 cur_eval_metics = evaluate_classifier(spec, df, verbose=False)
                 self.assertEqual(cur_eval_metics["num_errors"], 0)

--- a/coremltools/test/sklearn_tests/test_linear_regression.py
+++ b/coremltools/test/sklearn_tests/test_linear_regression.py
@@ -4,13 +4,17 @@
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
 import os
-import pandas as pd
 import unittest
+
+import pandas as pd
+
 from coremltools._deps import _HAS_SKLEARN
 from coremltools.models.utils import evaluate_regressor, _macos_version, _is_macos
 
 if _HAS_SKLEARN:
+    from sklearn.datasets import load_boston
     from sklearn.linear_model import LinearRegression
+    from sklearn.preprocessing import OneHotEncoder
     from sklearn.svm import LinearSVR
     from coremltools.converters.sklearn import convert
 
@@ -26,9 +30,6 @@ class LinearRegressionScikitTest(unittest.TestCase):
         """
         Set up the unit test by loading the dataset and training a model.
         """
-        from sklearn.datasets import load_boston
-        from sklearn.linear_model import LinearRegression
-
         scikit_data = load_boston()
         scikit_model = LinearRegression()
         scikit_model.fit(scikit_data["data"], scikit_data["target"])
@@ -80,8 +81,6 @@ class LinearRegressionScikitTest(unittest.TestCase):
             spec = convert(model, "data", "out")
 
         # Check the expected class during covnersion.
-        from sklearn.preprocessing import OneHotEncoder
-
         with self.assertRaises(TypeError):
             model = OneHotEncoder()
             spec = convert(model, "data", "out")
@@ -101,7 +100,7 @@ class LinearRegressionScikitTest(unittest.TestCase):
             cur_model.fit(self.scikit_data["data"], self.scikit_data["target"])
             spec = convert(cur_model, input_names, "target")
 
-            df["prediction"] = cur_model.predict(self.scikit_data.data)
+            df["target"] = cur_model.predict(self.scikit_data.data)
 
             metrics = evaluate_regressor(spec, df)
             self.assertAlmostEqual(metrics["max_error"], 0)
@@ -126,12 +125,11 @@ class LinearRegressionScikitTest(unittest.TestCase):
         df = pd.DataFrame(self.scikit_data.data, columns=input_names)
 
         for cur_args in ARGS:
-            print(cur_args)
             cur_model = LinearSVR(**cur_args)
             cur_model.fit(self.scikit_data["data"], self.scikit_data["target"])
             spec = convert(cur_model, input_names, "target")
 
-            df["prediction"] = cur_model.predict(self.scikit_data.data)
+            df["target"] = cur_model.predict(self.scikit_data.data)
 
             metrics = evaluate_regressor(spec, df)
             self.assertAlmostEqual(metrics["max_error"], 0)

--- a/coremltools/test/sklearn_tests/test_random_forest_classifier_numeric.py
+++ b/coremltools/test/sklearn_tests/test_random_forest_classifier_numeric.py
@@ -3,18 +3,22 @@
 # Use of this source code is governed by a BSD-3-clause license that can be
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
-import unittest
 import itertools
 import os
-import pandas as pd
-import numpy as np
-from coremltools._deps import _HAS_SKLEARN, _SKLEARN_VERSION
-from coremltools.models.utils import evaluate_classifier, _macos_version, _is_macos
+import unittest
+
 from distutils.version import StrictVersion
+import numpy as np
+import pandas as pd
 import pytest
 
+from coremltools._deps import _HAS_SKLEARN, _SKLEARN_VERSION
+from coremltools.models.utils import evaluate_classifier, _macos_version, _is_macos
+
 if _HAS_SKLEARN:
+    from sklearn.datasets import load_boston
     from sklearn.ensemble import RandomForestClassifier
+    from sklearn.tree import DecisionTreeClassifier
     from coremltools.converters import sklearn as skl_converter
 
 
@@ -37,7 +41,7 @@ class RandomForestClassificationBostonHousingScikitNumericTest(unittest.TestCase
         if _is_macos() and _macos_version() >= (10, 13):
             # Get predictions
             df = pd.DataFrame(self.X, columns=self.feature_names)
-            df["prediction"] = scikit_model.predict(self.X)
+            df["target"] = scikit_model.predict(self.X)
 
             # Evaluate it
             metrics = evaluate_classifier(spec, df, verbose=False)
@@ -53,8 +57,6 @@ class RandomForestBinaryClassifierBostonHousingScikitNumericTest(
         """
         Set up the unit test by loading the dataset and training a model.
         """
-        from sklearn.datasets import load_boston
-
         # Load data and train model
         scikit_data = load_boston()
         self.X = scikit_data.data.astype("f").astype(
@@ -98,12 +100,7 @@ class RandomForestMultiClassClassificationBostonHousingScikitNumericTest(
 ):
     @classmethod
     def setUpClass(self):
-        from sklearn.datasets import load_boston
-        from sklearn.tree import DecisionTreeClassifier
-
         # Load data and train model
-        import numpy as np
-
         scikit_data = load_boston()
         self.X = scikit_data.data.astype("f").astype(
             "d"

--- a/coremltools/test/sklearn_tests/test_random_forest_regression_numeric.py
+++ b/coremltools/test/sklearn_tests/test_random_forest_regression_numeric.py
@@ -3,15 +3,19 @@
 # Use of this source code is governed by a BSD-3-clause license that can be
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
+import itertools
+import os
 import unittest
+
 import numpy as np
 import pandas as pd
-import os
-from coremltools._deps import _HAS_SKLEARN
-from coremltools.models.utils import evaluate_regressor, _macos_version, _is_macos
 import pytest
 
+from coremltools._deps import _HAS_SKLEARN
+from coremltools.models.utils import evaluate_regressor, _macos_version, _is_macos
+
 if _HAS_SKLEARN:
+    from sklearn.datasets import load_boston
     from sklearn.ensemble import RandomForestRegressor
     from coremltools.converters import sklearn as skl_converter
 
@@ -27,8 +31,6 @@ class RandomForestRegressorBostonHousingScikitNumericTest(unittest.TestCase):
         """
         Set up the unit test by loading the dataset and training a model.
         """
-        from sklearn.datasets import load_boston
-
         # Load data and train model
         scikit_data = load_boston()
         self.scikit_data = scikit_data
@@ -69,7 +71,7 @@ class RandomForestRegressorBostonHousingScikitNumericTest(unittest.TestCase):
         if _is_macos() and _macos_version() >= (10, 13):
             # Get predictions
             df = pd.DataFrame(self.X, columns=self.feature_names)
-            df["prediction"] = scikit_model.predict(self.X)
+            df["target"] = scikit_model.predict(self.X)
 
             # Evaluate it
             metrics = evaluate_regressor(spec, df, verbose=False)
@@ -97,8 +99,6 @@ class RandomForestRegressorBostonHousingScikitNumericTest(unittest.TestCase):
         )
 
         # Make a cartesian product of all options
-        import itertools
-
         product = itertools.product(*options.values())
         args = [dict(zip(options.keys(), p)) for p in product]
 

--- a/coremltools/test/xgboost_tests/test_boosted_trees_classifier_numeric.py
+++ b/coremltools/test/xgboost_tests/test_boosted_trees_classifier_numeric.py
@@ -4,9 +4,11 @@
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
 import itertools
-import pytest
-import pandas as pd
 import unittest
+
+import numpy as np
+import pandas as pd
+import pytest
 
 from coremltools._deps import _HAS_SKLEARN, _HAS_XGBOOST
 from coremltools.models.utils import (
@@ -25,6 +27,7 @@ if _HAS_XGBOOST:
     import xgboost
     from coremltools.converters import xgboost as xgb_converter
 
+
 @unittest.skipIf(not _HAS_SKLEARN, "Missing sklearn. Skipping tests.")
 class BoostedTreeClassificationBostonHousingScikitNumericTest(unittest.TestCase):
     """
@@ -36,8 +39,6 @@ class BoostedTreeClassificationBostonHousingScikitNumericTest(unittest.TestCase)
         """
         Set up the unit test by loading the dataset and training a model.
         """
-        from sklearn.datasets import load_boston
-
         # Load data and train model
         scikit_data = load_boston()
         self.scikit_data = scikit_data
@@ -66,7 +67,6 @@ class BoostedTreeClassificationBostonHousingScikitNumericTest(unittest.TestCase)
         spec = skl_converter.convert(scikit_model, self.feature_names, self.output_name)
 
         if hasattr(scikit_model, '_init_decision_function') and scikit_model.n_classes_ > 2:
-            import numpy as np
             # fix initial default prediction for multiclass classification
             # https://github.com/scikit-learn/scikit-learn/pull/12983
             assert hasattr(scikit_model, 'init_')
@@ -76,7 +76,7 @@ class BoostedTreeClassificationBostonHousingScikitNumericTest(unittest.TestCase)
         if _is_macos() and _macos_version() >= (10, 13):
             # Get predictions
             df = pd.DataFrame(self.X, columns=self.feature_names)
-            df["prediction"] = scikit_model.predict(self.X)
+            df["target"] = scikit_model.predict(self.X)
 
             # Evaluate it
             metrics = evaluate_classifier(spec, df)
@@ -116,11 +116,7 @@ class BoostedTreeMultiClassClassificationBostonHousingScikitNumericTest(
 ):
     @classmethod
     def setUpClass(self):
-        from sklearn.datasets import load_boston
-
         # Load data and train model
-        import numpy as np
-
         scikit_data = load_boston()
         num_classes = 3
         self.X = scikit_data.data.astype("f").astype(
@@ -221,8 +217,6 @@ class BoostedTreeBinaryClassificationBostonHousingXGboostNumericTest(
         """
         Set up the unit test by loading the dataset and training a model.
         """
-        from sklearn.datasets import load_boston
-
         # Load data and train model
         scikit_data = load_boston()
         self.scikit_data = scikit_data
@@ -249,11 +243,6 @@ class BoostedTreeMultiClassClassificationBostonHousingXGboostNumericTest(
 ):
     @classmethod
     def setUpClass(self):
-        from sklearn.datasets import load_boston
-
-        # Load data and train model
-        import numpy as np
-
         scikit_data = load_boston()
         num_classes = 3
         self.X = scikit_data.data.astype("f").astype(

--- a/coremltools/test/xgboost_tests/test_boosted_trees_regression_numeric.py
+++ b/coremltools/test/xgboost_tests/test_boosted_trees_regression_numeric.py
@@ -3,10 +3,11 @@
 # Use of this source code is governed by a BSD-3-clause license that can be
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
-import pandas as pd
 import itertools
-import pytest
 import unittest
+
+import pandas as pd
+import pytest
 
 from coremltools._deps import _HAS_SKLEARN, _HAS_XGBOOST
 from coremltools.models.utils import evaluate_regressor, _macos_version, _is_macos
@@ -20,6 +21,7 @@ if _HAS_SKLEARN:
     from sklearn.ensemble import GradientBoostingRegressor
     from coremltools.converters import sklearn as skl_converter
     from sklearn.tree import DecisionTreeRegressor
+
 
 @unittest.skipIf(not _HAS_SKLEARN, "Missing sklearn. Skipping tests.")
 class GradientBoostingRegressorBostonHousingScikitNumericTest(unittest.TestCase):
@@ -57,7 +59,7 @@ class GradientBoostingRegressorBostonHousingScikitNumericTest(unittest.TestCase)
         if _is_macos() and _macos_version() >= (10, 13):
             # Get predictions
             df = pd.DataFrame(self.X, columns=self.feature_names)
-            df["prediction"] = scikit_model.predict(self.X)
+            df["target"] = scikit_model.predict(self.X)
 
             # Evaluate it
             metrics = evaluate_regressor(spec, df, "target", verbose=False)
@@ -141,7 +143,7 @@ class XgboostBoosterBostonHousingNumericTest(unittest.TestCase):
         if _is_macos() and _macos_version() >= (10, 13):
             # Get predictions
             df = pd.DataFrame(self.X, columns=self.feature_names)
-            df["prediction"] = xgb_model.predict(self.dtrain)
+            df["target"] = xgb_model.predict(self.dtrain)
 
             # Evaluate it
             metrics = evaluate_regressor(spec, df, target="target", verbose=False)
@@ -247,7 +249,7 @@ class XGboostRegressorBostonHousingNumericTest(unittest.TestCase):
         if _is_macos() and _macos_version() >= (10, 13):
             # Get predictions
             df = pd.DataFrame(self.X, columns=self.feature_names)
-            df["prediction"] = xgb_model.predict(self.X)
+            df["target"] = xgb_model.predict(self.X)
 
             # Evaluate it
             metrics = evaluate_regressor(spec, df, target="target", verbose=False)

--- a/coremltools/test/xgboost_tests/test_decision_tree_classifier_numeric.py
+++ b/coremltools/test/xgboost_tests/test_decision_tree_classifier_numeric.py
@@ -3,16 +3,20 @@
 # Use of this source code is governed by a BSD-3-clause license that can be
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
-import os
 import itertools
-import pandas as pd
+import os
 import unittest
+
+import numpy as np
+import pandas as pd
+import pytest
+
 from coremltools._deps import _HAS_SKLEARN
 from coremltools.models.utils import evaluate_classifier, _macos_version, _is_macos
-import pytest
 
 if _HAS_SKLEARN:
     from coremltools.converters import sklearn as skl_converter
+    from sklearn.datasets import load_boston
     from sklearn.tree import DecisionTreeClassifier
 
 
@@ -35,7 +39,7 @@ class DecisionTreeClassificationBostonHousingScikitNumericTest(unittest.TestCase
         if _is_macos() and _macos_version() >= (10, 13):
             # Get predictions
             df = pd.DataFrame(self.X, columns=self.feature_names)
-            df["prediction"] = scikit_model.predict(self.X)
+            df["target"] = scikit_model.predict(self.X)
 
             # Evaluate it
             metrics = evaluate_classifier(spec, df)
@@ -48,9 +52,6 @@ class DecisionTreeBinaryClassificationBostonHousingScikitNumericTest(
 ):
     @classmethod
     def setUpClass(self):
-        from sklearn.datasets import load_boston
-        from sklearn.tree import DecisionTreeClassifier
-
         # Load data and train model
         scikit_data = load_boston()
         self.scikit_data = scikit_data
@@ -78,8 +79,6 @@ class DecisionTreeBinaryClassificationBostonHousingScikitNumericTest(
         )
 
         # Make a cartesian product of all options
-        import itertools
-
         product = itertools.product(*options.values())
         args = [dict(zip(options.keys(), p)) for p in product]
 
@@ -94,9 +93,6 @@ class DecisionTreeMultiClassClassificationBostonHousingScikitNumericTest(
 ):
     @classmethod
     def setUpClass(self):
-        from sklearn.datasets import load_boston
-        import numpy as np
-
         # Load data and train model
         scikit_data = load_boston()
         num_classes = 3

--- a/coremltools/test/xgboost_tests/test_decision_tree_regression_numeric.py
+++ b/coremltools/test/xgboost_tests/test_decision_tree_regression_numeric.py
@@ -3,8 +3,10 @@
 # Use of this source code is governed by a BSD-3-clause license that can be
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
-import pandas as pd
+import itertools
 import pytest
+
+import pandas as pd
 import unittest
 
 from coremltools.models.utils import evaluate_regressor, _macos_version, _is_macos
@@ -65,7 +67,7 @@ class DecisionTreeRegressorBostonHousingScikitNumericTest(unittest.TestCase):
         if _is_macos() and _macos_version() >= (10, 13):
             # Get predictions
             df = pd.DataFrame(self.X, columns=self.feature_names)
-            df["prediction"] = scikit_model.predict(self.X)
+            df["target"] = scikit_model.predict(self.X)
 
             # Evaluate it
             metrics = evaluate_regressor(spec, df, target="target", verbose=False)
@@ -92,8 +94,6 @@ class DecisionTreeRegressorBostonHousingScikitNumericTest(unittest.TestCase):
         )
 
         # Make a cartesian product of all options
-        import itertools
-
         product = itertools.product(*options.values())
         args = [dict(zip(options.keys(), p)) for p in product]
 


### PR DESCRIPTION
Don't assume source predictions are always stored (in the data frame)  in a column called `prediction`. Instead, assume that column name matches the key in the dictionary returned by `predict`, similar to how we assume input keys to `predict` match other columns. This parameter value defaults to `target`.

This is an API breaking change.

Fixes #58