### PR TITLE
API Ref Update and Fix for MIL Ops

### DIFF
--- a/coremltools/converters/_converters_entry.py
+++ b/coremltools/converters/_converters_entry.py
@@ -346,7 +346,7 @@ def convert(
             - ``coremltools.ComputeUnit.CPU_AND_GPU``: Use both the CPU and GPU, but not the
               neural engine.
             - ``coremltools.ComputeUnit.CPU_AND_NE``: Use both the CPU and neural engine, but
-              not the GPU. Only available on macOS >= 13.0.
+              not the GPU. Available only for macOS >= 13.0.
 
     package_dir : str
         Post conversion, the model is saved at a temporary location and

--- a/coremltools/converters/libsvm/_libsvm_converter.py
+++ b/coremltools/converters/libsvm/_libsvm_converter.py
@@ -23,9 +23,10 @@ def _infer_min_num_features(model):
 
 
 def convert(libsvm_model, feature_names, target, input_length, probability):
-    """Convert a svm model to the protobuf spec.
+    """
+    Convert a support vector machine (SVM) model to the protobuf spec.
 
-    This currently supports:
+    Supports:
       * C-SVC
       * nu-SVC
       * Epsilon-SVR

--- a/coremltools/converters/mil/mil/ops/defs/iOS15/classify.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS15/classify.py
@@ -18,26 +18,27 @@ from coremltools.converters.mil.mil.types.symbolic import any_symbolic
 @register_op
 class classify(Operation):
     """
-    Presence of this op indicates that the model is of type classifier,
-    which accordingly constructs the model output, that is, the predicted class label
+    The presence of this op indicates that the model is of type classifier. The op
+    constructs the model output accordingly; that is, the predicted class label
     and the output probability dictionary. The parameters of this op are set
-    based on the attributes set for the class "coremltools.ClassifierConfig" by the user.
-    The outputs of this op cannot be used by another op.
+    based on the attributes set for the 
+    `coremltools.ClassifierConfig <https://apple.github.io/coremltools/source/coremltools.converters.mil.input_types.html#classifierconfig>`_ class
+    by the user. The outputs of this op cannot be used by another op.
 
     Parameters
     ----------
-    * probabilities: tensor<[* , ProbT]> (Required)
-        * a tensor in the graph, which is used to compute the classifier output(s)
-        * This is the tensor whose values are mapped to the class labels and used for
-        * constructing the predicted class label and the output dictionary of class names
-        *  and values
-    * classes: list<*, ClassT> (Required)
-        * list of classes
+    probabilities: tensor<[\* , ProbT]> (Required)
+        A tensor in the graph, which is used to compute the classifier output(s). This
+        is the tensor whose values are mapped to the class labels and used for constructing
+        the predicted class label and the output dictionary of class names and values.
+
+    classes: list<\*, ClassT> (Required)
+        List of classes.
 
     Returns
     -------
-    * <classT>
-    * Dict[classT, probT]
+    <classT>
+    Dict[classT, probT]
 
 
     Attributes

--- a/coremltools/converters/mil/mil/ops/defs/iOS15/image_resizing.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS15/image_resizing.py
@@ -758,7 +758,7 @@ class resample(Operation):
     """
     Resample the input image tensor ``x`` at the ``coordinates``.
     Resampling is required if the coordinates do not correspond to exact
-    pixels in the input image. The ``sampling_mode ``determines
+    pixels in the input image. The ``sampling_mode`` determines
     the algorithm used for resampling and computing the values.
 
     Parameters
@@ -826,7 +826,7 @@ class resample(Operation):
     Attributes
     ----------
     T: fp16, fp32
-    U: fp32, i32
+    U: fp32, int32
     """
 
     input_spec = InputSpec(

--- a/coremltools/converters/mil/mil/ops/defs/iOS15/linear.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS15/linear.py
@@ -236,34 +236,34 @@ class einsum(Operation):
     dimensions -1 and -3, treating all the other dimensions as batch. Broadcasting is supported along batch dimensions.
     In particular, the inputs must be of the following shapes:
 
-    * Rank 4 input case
-        * Input 1: ``[B, C, H, W1]``
-        * Input 2: ``[B, W1, H, W2]``
-        * Output: ``[B, C, H, W2]``
+    * Rank 4 input case:
+        * Input 1: ``[B, C, H, W1]``.
+        * Input 2: ``[B, W1, H, W2]``.
+        * Output: ``[B, C, H, W2]``.
         * If, for one of the inputs, the dimensions ``"B"`` or ``"H"`` is 1, they are broadcast to match the other input.
 
-    * Rank 3 input case
-        * Input 1: ``[C, H, W1]``
-        * Input 2: ``[W1, H, W2]``
-        * Output: ``[C, H, W2]``
+    * Rank 3 input case:
+        * Input 1: ``[C, H, W1]``.
+        * Input 2: ``[W1, H, W2]``.
+        * Output: ``[C, H, W2]``.
         * If, for one of the inputs, the dimension ``"H"`` is 1, it is broadcast to match the other input.
 
     Parameters
     ----------
     values : Tuple(tensor_1, tensor_2)
         * Where:
-            * ``tensor_1``: ``tensor<[*D, C, H, W1], T>``
+            * ``tensor_1``: ``tensor<[*D, C, H, W1], T>``.
             * Must be of rank 3 or 4.
-            * ``tensor_2``: ``tensor<[*D, W1, H, W2], T>``
+            * ``tensor_2``: ``tensor<[*D, W1, H, W2], T>``.
             * Must be of rank 3 or 4.
     equation: const<str>
         * Supported equations are:
-            * ``"nchw,nwhu->nchu"`` and its equivalent equation strings
-            * ``"chw,whr->chr"`` and its equivalent equation strings
+            * ``"nchw,nwhu->nchu"`` and its equivalent equation strings.
+            * ``"chw,whr->chr"`` and its equivalent equation strings.
 
     Returns
     -------
-    tensor<[*D, C, H, W2], T>
+    tensor<[\*D, C, H, W2], T>
         * Same ranks as the inputs.
 
     Attributes

--- a/coremltools/converters/mil/mil/ops/defs/iOS15/tensor_operation.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS15/tensor_operation.py
@@ -745,7 +745,7 @@ class topk(Operation):
 
     Attributes
     ----------
-    T: fp16, fp32, i32
+    T: fp16, fp32, int32
     """
 
     input_spec = InputSpec(

--- a/coremltools/converters/mil/mil/ops/defs/iOS15/tensor_transformation.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS15/tensor_transformation.py
@@ -1039,7 +1039,7 @@ class sliding_windows(Operation):
 
     Attributes
     ----------
-    T: fp16, fp32, i32
+    T: fp16, fp32, int32
     """
 
     input_spec = InputSpec(

--- a/coremltools/converters/mil/mil/ops/defs/iOS16/image_resizing.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS16/image_resizing.py
@@ -23,7 +23,11 @@ from coremltools.converters.mil.mil.ops.defs.iOS16 import _IOS16_TARGET
 @register_op(opset_version=_IOS16_TARGET)
 class resample(_resample_iOS15):
     """
-    iOS16 version of resample supports float16 coordinates
+    The iOS 16 version of ``resample`` supports float 16 coordinates.
+    
+    For the complete documentation, see the 
+    `iOS 15 version <#module-coremltools.converters.mil.mil.ops.defs.iOS15.image_resizing>`_.
+
     """
     input_spec = InputSpec(
         x=TensorInputType(),

--- a/coremltools/converters/mil/mil/ops/defs/iOS16/tensor_operation.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS16/tensor_operation.py
@@ -23,17 +23,21 @@ from coremltools.converters.mil.mil.ops.defs.iOS16 import _IOS16_TARGET
 @register_op(opset_version=_IOS16_TARGET)
 class topk(_topk_iOS15):
     """
-    An iOS16 version of topk
+    A version of ``topk`` for iOS 16+. This section documents the differences. For the
+    rest of the documentation, see `the iOS 15 version of topk <#coremltools.converters.mil.mil.ops.defs.iOS15.tensor_operation.topk>`_.
 
-    Additional Parameters
+    Parameters
     ----------
-    * sort: const<bool> (Optional)
-        * Default to ``True``
-        * If true, top-k elements are themselves sorted. 
+       * The following are additional parameters for the iOS 16+ version. (For more parameters, see
+         `the iOS 15 version of topk <#coremltools.converters.mil.mil.ops.defs.iOS15.tensor_operation.topk>`_.)
+    
+    sort: const<bool> (Optional)
+        * Default to ``True``.
+        * If ``True``, ``top-k`` elements are themselves sorted.
           Otherwise, no particular ordering is guaranteed.
-    * return_indices: const<bool> (Optional)
-        # Default to ``True``
-        # If true, returns both values and indices. Otherwise, returns only the top-k values.
+    return_indices: const<bool> (Optional)
+        # Default to ``True``.
+        # If ``True`, returns both values and indices. Otherwise, returns only the ``top-k`` values.
 
     Returns
     -------

--- a/coremltools/converters/mil/mil/ops/defs/iOS16/tensor_transformation.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS16/tensor_transformation.py
@@ -20,7 +20,7 @@ from coremltools.converters.mil.mil.ops.defs.iOS16 import _IOS16_TARGET
 class pixel_unshuffle(Operation):
     """
     Rearrange elements in a tensor from spatial dimensions into depth (channel).
-    It is basically the inverse operation of pixel_shuffle.
+    It is basically the inverse operation of `pixel_shuffle <#coremltools.converters.mil.mil.ops.defs.iOS15.tensor_transformation.pixel_shuffle>`_.
     Equivalent to PyTorch's ``PixelUnshuffle``.
 
     Parameters

--- a/coremltools/models/ml_program/compression_utils.py
+++ b/coremltools/models/ml_program/compression_utils.py
@@ -220,7 +220,7 @@ def palettize_weights(mlmodel, nbits=None, mode="kmeans", op_selector=None, lut_
     """
     Utility function to convert a float precision MLModel of type ``mlprogram`` to a
     compressed MLModel by reducing the overall number of weights using a lookup table
-    (LUT). A LUT contains a list float values. An `nbit` LUT has 2\ :sup:`nbits` entries.
+    (LUT). A LUT contains a list of float values. An `nbit` LUT has 2\ :sup:`nbits` entries.
     
     For example, a float weight vector such as ``{0.3, 0.3, 0.5, 0.5}`` can be compressed
     using a 1-bit LUT: ``{0.3, 0.5}``. In this case the float vector can be replaced

--- a/docs/source/coremltools.converters.mil.mil.ops.defs.rst
+++ b/docs/source/coremltools.converters.mil.mil.ops.defs.rst
@@ -6,7 +6,7 @@ Operators supported by the Model Intermediate Language (MIL):
 activation
 ---------------------------------------------------------
 
-.. automodule:: coremltools.converters.mil.mil.ops.defs.activation
+.. automodule:: coremltools.converters.mil.mil.ops.defs.iOS15.activation
 
    .. autoclass:: clamped_relu
    .. autoclass:: elu
@@ -27,10 +27,29 @@ activation
    .. autoclass:: thresholded_relu
 
 
+classify
+---------------------------------------------------
+
+.. automodule:: coremltools.converters.mil.mil.ops.defs.iOS15.classify
+
+   .. autoclass:: classify
+
+
+constexpr_ops
+---------------------------------------------------
+
+.. automodule:: coremltools.converters.mil.mil.ops.defs.iOS16.constexpr_ops
+
+   .. autoclass:: constexpr_affine_dequantize
+   .. autoclass:: constexpr_cast
+   .. autoclass:: constexpr_lut_to_dense
+   .. autoclass:: constexpr_sparse_to_dense
+
+
 control\_flow
 ------------------------------------------------------------
 
-.. automodule:: coremltools.converters.mil.mil.ops.defs.control_flow
+.. automodule:: coremltools.converters.mil.mil.ops.defs.iOS15.control_flow
 
    .. autoclass:: cond
    .. autoclass:: Const
@@ -47,7 +66,7 @@ control\_flow
 conv
 ---------------------------------------------------
 
-.. automodule:: coremltools.converters.mil.mil.ops.defs.conv
+.. automodule:: coremltools.converters.mil.mil.ops.defs.iOS15.conv
 
    .. autoclass:: conv
    .. autoclass:: conv_transpose
@@ -56,7 +75,7 @@ conv
 elementwise\_binary
 ------------------------------------------------------------------
 
-.. automodule:: coremltools.converters.mil.mil.ops.defs.elementwise_binary
+.. automodule:: coremltools.converters.mil.mil.ops.defs.iOS15.elementwise_binary
 
    .. autoclass:: add
    .. autoclass:: equal
@@ -81,7 +100,7 @@ elementwise\_binary
 elementwise\_unary
 -----------------------------------------------------------------
 
-.. automodule:: coremltools.converters.mil.mil.ops.defs.elementwise_unary
+.. automodule:: coremltools.converters.mil.mil.ops.defs.iOS15.elementwise_unary
 
    .. autoclass:: abs
    .. autoclass:: acos
@@ -112,10 +131,10 @@ elementwise\_unary
    .. autoclass:: cast
 
 
-image\_resizing
+image\_resizing (iOS 15)
 --------------------------------------------------------------
 
-.. automodule:: coremltools.converters.mil.mil.ops.defs.image_resizing
+.. automodule:: coremltools.converters.mil.mil.ops.defs.iOS15.image_resizing
 
    .. autoclass:: affine
    .. autoclass:: upsample_nearest_neighbor
@@ -126,11 +145,18 @@ image\_resizing
    .. autoclass:: crop_resize
    .. autoclass:: crop
 
+image\_resizing (iOS 16+)
+--------------------------------------------------------------
+
+.. automodule:: coremltools.converters.mil.mil.ops.defs.iOS16.image_resizing
+
+   .. autoclass:: resample
+
 
 linear
 -----------------------------------------------------
 
-.. automodule:: coremltools.converters.mil.mil.ops.defs.linear
+.. automodule:: coremltools.converters.mil.mil.ops.defs.iOS15.linear
 
    .. autoclass:: linear
    .. autoclass:: matmul
@@ -140,7 +166,7 @@ linear
 normalization
 ------------------------------------------------------------
 
-.. automodule:: coremltools.converters.mil.mil.ops.defs.normalization
+.. automodule:: coremltools.converters.mil.mil.ops.defs.iOS15.normalization
 
    .. autoclass:: batch_norm
    .. autoclass:: instance_norm
@@ -152,7 +178,7 @@ normalization
 pool
 ---------------------------------------------------
 
-.. automodule:: coremltools.converters.mil.mil.ops.defs.pool
+.. automodule:: coremltools.converters.mil.mil.ops.defs.iOS15.pool
 
    .. autoclass:: avg_pool
    .. autoclass:: l2_pool
@@ -162,7 +188,7 @@ pool
 random
 -----------------------------------------------------
 
-.. automodule:: coremltools.converters.mil.mil.ops.defs.random
+.. automodule:: coremltools.converters.mil.mil.ops.defs.iOS15.random
 
    .. autoclass:: random_bernoulli
    .. autoclass:: random_categorical
@@ -173,7 +199,7 @@ random
 recurrent
 --------------------------------------------------------
 
-.. automodule:: coremltools.converters.mil.mil.ops.defs.recurrent
+.. automodule:: coremltools.converters.mil.mil.ops.defs.iOS15.recurrent
 
    .. autoclass:: gru
    .. autoclass:: lstm
@@ -183,7 +209,7 @@ recurrent
 reduction
 --------------------------------------------------------
 
-.. automodule:: coremltools.converters.mil.mil.ops.defs.reduction
+.. automodule:: coremltools.converters.mil.mil.ops.defs.iOS15.reduction
 
    .. autoclass:: reduce_argmax
    .. autoclass:: reduce_argmin
@@ -202,7 +228,7 @@ reduction
 scatter\_gather
 --------------------------------------------------------------
 
-.. automodule:: coremltools.converters.mil.mil.ops.defs.scatter_gather
+.. automodule:: coremltools.converters.mil.mil.ops.defs.iOS15.scatter_gather
 
    .. autoclass:: gather
    .. autoclass:: scatter
@@ -212,10 +238,10 @@ scatter\_gather
    .. autoclass:: scatter_nd
 
 
-tensor\_operation
+tensor\_operation (iOS 15)
 ----------------------------------------------------------------
 
-.. automodule:: coremltools.converters.mil.mil.ops.defs.tensor_operation
+.. automodule:: coremltools.converters.mil.mil.ops.defs.iOS15.tensor_operation
 
    .. autoclass:: band_part
    .. autoclass:: cumsum
@@ -236,10 +262,18 @@ tensor\_operation
    .. autoclass:: identity
 
 
-tensor\_transformation
+tensor\_operation (iOS 16+)
+----------------------------------------------------------------
+
+.. automodule:: coremltools.converters.mil.mil.ops.defs.iOS16.tensor_operation
+
+   .. autoclass:: topk
+
+
+tensor\_transformation (iOS 15)
 ---------------------------------------------------------------------
 
-.. automodule:: coremltools.converters.mil.mil.ops.defs.tensor_transformation
+.. automodule:: coremltools.converters.mil.mil.ops.defs.iOS15.tensor_transformation
 
    .. autoclass:: depth_to_space
    .. autoclass:: expand_dims
@@ -253,4 +287,12 @@ tensor\_transformation
    .. autoclass:: transpose
    .. autoclass:: pixel_shuffle
    .. autoclass:: sliding_windows
+
+
+tensor\_transformation (iOS 16+)
+---------------------------------------------------------------------
+
+.. automodule:: coremltools.converters.mil.mil.ops.defs.iOS16.tensor_transformation
+
+   .. autoclass:: pixel_unshuffle
 

--- a/docs/source/coremltools.converters.mil.rst
+++ b/docs/source/coremltools.converters.mil.rst
@@ -4,5 +4,5 @@ MIL Builder
 .. automodule:: coremltools.converters.mil.mil
 
    .. autoclass:: Builder
-      :members:
+      :members: program
       


### PR DESCRIPTION
This PR updates the API Reference documentation for version 6.0b2, including a fix to support the separation of MIL ops into `iOS15` and `iOS16` folders and to include the following MIL ops:

* `constexpr_ops` in `iOS16`
* `pixel_unshuffle` in `iOS16/tensor_transformation.py`
* `resample` in `iOS16/image_resizing.py`
* `topk` in `iOS16/tensor_operation.py`
* `classify` in `iOS15`

```
	modified:   docs/source/coremltools.converters.mil.mil.ops.defs.rst
```

This PR also fixes the MIL Builder documentation, which needed only to show `program` with the class:

```
	modified:   docs/source/coremltools.converters.mil.rst
```

This PR also includes edits for grammar or formatting:

```
	modified:   coremltools/converters/_converters_entry.py
	modified:   coremltools/converters/libsvm/_libsvm_converter.py
	modified:   coremltools/converters/mil/mil/ops/defs/iOS15/classify.py
	modified:   coremltools/converters/mil/mil/ops/defs/iOS15/image_resizing.py
	modified:   coremltools/converters/mil/mil/ops/defs/iOS15/linear.py
	modified:   coremltools/converters/mil/mil/ops/defs/iOS15/tensor_operation.py
	modified:   coremltools/converters/mil/mil/ops/defs/iOS15/tensor_transformation.py
	modified:   coremltools/converters/mil/mil/ops/defs/iOS16/constexpr_ops.py
	modified:   coremltools/converters/mil/mil/ops/defs/iOS16/image_resizing.py
	modified:   coremltools/converters/mil/mil/ops/defs/iOS16/tensor_operation.py
	modified:   coremltools/converters/mil/mil/ops/defs/iOS16/tensor_transformation.py
	modified:   coremltools/models/ml_program/compression_utils.py
```

A subsequent PR provides the generated HTML.
