### PR TITLE
Explicitly import things which are getting import implicitly.

### DIFF
--- a/coremltools/__init__.py
+++ b/coremltools/__init__.py
@@ -108,6 +108,10 @@ from .converters.mil._deployment_compatibility import AvailableTarget as target
 from .converters.mil.mil.passes import quantization_passes as transform
 from .converters.mil.mil.passes.quantization_passes import ComputePrecision as precision
 
+try:
+    from . import libcoremlpython
+except:
+    pass
 
 # Time profiling for functions in coremltools package, decorated with @profile
 import os as _os

--- a/coremltools/models/__init__.py
+++ b/coremltools/models/__init__.py
@@ -7,8 +7,10 @@ from . import datatypes
 
 from . import _feature_management
 
+from . import nearest_neighbors
 from . import pipeline
 from . import tree_ensemble
+from . import feature_vectorizer
 
 from . import _interface_management
 


### PR DESCRIPTION
With this change, test_api_visibilities.py passes when run in isolation. 