### PR TITLE
Make test-package a required parameter to test.sh

### DIFF
--- a/coremltools/converters/mil/backend/mil/load.py
+++ b/coremltools/converters/mil/backend/mil/load.py
@@ -4,8 +4,9 @@
 #  found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
 import logging
-import numpy as np
 import os
+
+import numpy as np
 
 from .passes import mil_passes
 from ..backend_helper import _get_colorspace_enum, _validate_image_input_output_shapes

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -63,6 +63,11 @@ while [ $# -gt 0 ]
   shift
 done
 
+if [[ $TEST_PACKAGE == "" ]]; then
+    echo "\"--test-package\" is a required paramter."
+    exit 1
+fi
+
 # First configure
 cd ${COREMLTOOLS_HOME}
 if [[ $CHECK_ENV == 1 ]]; then


### PR DESCRIPTION
Running `test.sh` without `test-package` parameter does not work. It also does not make much sense, since it would take many hours to run all the test not in parallel.

Fixes: #1533

CI run: https://gitlab.com/coremltools1/coremltools/-/pipelines/620009018