### PR TITLE
Stop load spec from trying to interpret *.mlmodel files as *.mlpackage

### DIFF
--- a/coremltools/models/utils.py
+++ b/coremltools/models/utils.py
@@ -206,16 +206,31 @@ def load_spec(filename):
     --------
     save_spec
     """
-    if _ModelPackage is None:
-        raise Exception(
-            "Unable to load libmodelpackage. Cannot make save spec."
-        )
+    name, ext = _os.path.splitext(filename)
+    
+    is_package = False
+
+    if not ext:
+        filename = "{}{}".format(filename, _MLMODEL_EXTENSION)
+    elif ext == _MLPACKAGE_EXTENSION:
+        is_package = True
+    elif ext == _MLMODEL_EXTENSION:
+        is_package = False
+    else:
+        raise Exception("Extension must be {} or {} (not {})".format(_MLMODEL_EXTENSION, _MLPACKAGE_EXTENSION, ext))
+    
+    if is_package:
+        if _ModelPackage is None:
+            raise Exception(
+                "Unable to load libmodelpackage. Cannot make save spec."
+            )
 
     spec = _Model_pb2.Model()
 
     specfile = filename
-    if _ModelPackage.isValid(filename):
-        specfile = _ModelPackage(filename).getRootModel().path()
+    if is_package:
+        if _ModelPackage.isValid(filename):
+            specfile = _ModelPackage(filename).getRootModel().path()
 
     with open(specfile, "rb") as f:
         contents = f.read()


### PR DESCRIPTION
I implemented this fix after finding that while attempting to inspect a model's layer types, the module would break when loading the model as a *.mlpackage instead of the *.mlmodel extension. The following script content is what demonstrated this failure to me:

```
# surgery.py
import coremltools
import sys
model = coremltools.models.MLModel(sys.argv[1])
spec = model._spec
nn = spec.neuralNetwork
for layer in nn.layers:
    print(layer.WhichOneof("layer"))
```

Then this output was yielded:
```
pbrooks@Pierce Documents % python3 ./surgery.py ./temp.mlmodel
Traceback (most recent call last):
  File "/Users/pbrooks/Documents/./surgery.py", line 4, in <module>
    model = coremltools.models.MLModel(sys.argv[1])
  File "/usr/local/lib/python3.10/site-packages/coremltools/models/model.py", line 328, in __init__
    self.__proxy__, self._spec, self._framework_error = _get_proxy_and_spec(
  File "/usr/local/lib/python3.10/site-packages/coremltools/models/model.py", line 123, in _get_proxy_and_spec
    specification = _load_spec(filename)
  File "/usr/local/lib/python3.10/site-packages/coremltools/models/utils.py", line 210, in load_spec
    raise Exception(
Exception: Unable to load libmodelpackage. Cannot make save spec.
```

This was resolved with my commit which can be found here:
https://github.com/apple/coremltools/commit/462404e56e7fc20d1638ccac79e94ae8b9580f8d

Afterwards, the desired results were achieved:
```
pbrooks@Pierce Documents % python3 ./surgery.py ./temp.mlmodel
convolution
activation
pooling
convolution
activation
pooling
flatten
innerProduct
activation
innerProduct
softmax
```

I hope that this work is found to be useful for others trying to do similar tasks! :)