### PR TITLE
Patch convert nodes op to allow for ops with private variable names

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -75,11 +75,12 @@ def convert_nodes(context, graph):
     """
     for node in _tqdm(graph.nodes, desc="Converting PyTorch Frontend ==> MIL Ops", unit=" ops"):
         op_lookup = node.kind
-        if op_lookup.endswith("_"):
+        add_op = _TORCH_OPS_REGISTRY.get(op_lookup, None)
+        if add_op is None and op_lookup.endswith("_"):
             # This is an "in place" op.
             # Look up the standard op instead by removing underscore.
             op_lookup = op_lookup[:-1]
-        add_op = _TORCH_OPS_REGISTRY.get(op_lookup, None)
+            add_op = _TORCH_OPS_REGISTRY.get(op_lookup, None)
 
         _logging.info("Converting op {} : {}".format(node.name, node.kind))
         if add_op is None:


### PR DESCRIPTION
This PR addresses an issue with the convert_nodes method that arises for ops with privately named variables such as `__and__`

Convert_nodes assumes that ops ending in _ are in place ops and removes the trailing _ before op lookup.
```
op_lookup = node.kind
if op_lookup.endswith("_"):
    # This is an "in place" op.
    # Look up the standard op instead by removing underscore.
    op_lookup = op_lookup[:-1]
add_op = _TORCH_OPS_REGISTRY.get(op_lookup, None)
```

the patch below fixes this

```
add_op = _TORCH_OPS_REGISTRY.get(op_lookup, None)
if add_op is None and op_lookup.endswith("_"):
    # This is an "in place" op.
    # Look up the standard op instead by removing underscore.
    op_lookup = op_lookup[:-1]
    add_op = _TORCH_OPS_REGISTRY.get(op_lookup, None)
```

I mentioned this previously here https://github.com/apple/coremltools/pull/1509#discussion_r892186687