### PR TITLE
fix: Support scalar source parameter in ops.scatter

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -4607,6 +4607,10 @@ def _scatter(context, inputs, mode, name):
     axis = inputs[1].val
     indices = inputs[2]
     updates = inputs[3]
+    if not types.is_tensor(updates.sym_type):
+        # torch.scatter allows for src (updates) argument to be either tensor or scalar
+        # while coremltools requires updates to be a tensor
+        updates = mb.fill(shape=indices.shape, value=updates.val, name=name)
     result = mb.scatter_along_axis(data=data, indices=indices, updates=updates,
                                    axis=axis, mode=mode, name=name)
     context.add(result)

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -4607,9 +4607,7 @@ def _scatter(context, inputs, mode, name):
     axis = inputs[1].val
     indices = inputs[2]
     updates = inputs[3]
-    if not types.is_tensor(updates.sym_type):
-        # torch.scatter allows for src (updates) argument to be either tensor or scalar
-        # while coremltools requires updates to be a tensor
+    if types.is_scalar(updates.sym_type):
         updates = mb.fill(shape=indices.shape, value=updates.val, name=name)
     result = mb.scatter_along_axis(data=data, indices=indices, updates=updates,
                                    axis=axis, mode=mode, name=name)

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -4603,6 +4603,33 @@ class TestScatter(TorchBaseTest):
             m = TestModel(0, shapes)
             self.run_compare_torch(shapes, m, backend=backend)
 
+    @pytest.mark.parametrize(
+        "shapes_dims, backend",
+        itertools.product(
+            [
+                [(10,), (0, -1)],
+                [(2, 3), (1, -1)],
+                [(2, 3, 4, 5), (0, -2)],
+            ],
+            backends
+        ),
+    )
+    def test_scatter_with_scalar_source(self, shapes_dims, backend):
+        class TestModel(nn.Module):
+            def __init__(self, dim, shapes):
+                super(TestModel, self).__init__()
+                self.dim = dim
+                self.source = 1.0
+                self.index = torch.randint(0, shapes[dim], size=shapes)
+                
+            def forward(self, x):
+                return x.scatter_(self.dim, self.index, self.source)
+
+        shapes, dims = shapes_dims
+        for dim in dims:
+            m = TestModel(0, shapes)
+            self.run_compare_torch(shapes, m, backend=backend)
+
 
     @pytest.mark.parametrize(
         "shapes_dims, mode, backend",


### PR DESCRIPTION
As per py torch documentation, the torch.scatter method supports the `src` parameter to be either a tensor or a scalar value. However, coremltools does not support a scalar value for the `updates` parameter. This PR updates the `ops._scatter` method to check whether the `updates` parameter is a scalar and fills a tensor with shape `indices.shape` before calling `scatter_along_axis`.

I ran into this issue trying to convert taming-transformers VQGAN model into CoreML. I had to implement the scatter torch op myself, and so I've submitted this PR to publish this fix.