### PR TITLE
Fixed _logistic_regression python 3.10 compatibility

### DIFF
--- a/coremltools/converters/sklearn/_logistic_regression.py
+++ b/coremltools/converters/sklearn/_logistic_regression.py
@@ -3,7 +3,11 @@
 # Use of this source code is governed by a BSD-3-clause license that can be
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
-from collections import Iterable
+try:
+    from collections import Iterable
+except ImportError:
+    from collections.abc import Iterable
+
 
 from ..._deps import _HAS_SKLEARN
 from ...models import MLModel as _MLModel


### PR DESCRIPTION
Python 3.10 has removed `Iterable` from `collections`, we can fallback to use `collections.abc` if can't import