### PR TITLE
Adds type cast in reduce_sum to support bool in PyTorch.

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -1308,7 +1308,12 @@ def sub(context, node):
 def mean(context, node):
     inputs = _get_inputs(context, node)
 
-    kwargs = {"x": inputs[0], "name": node.name}
+    x = inputs[0]
+    if types.is_bool(x.dtype):
+        # TODO: In the future when MIL op supports bool, we need to use curr_opset_version to decide
+        # if we want to cast or not.
+        x = mb.cast(x=x, dtype="fp32")
+    kwargs = {"x": x, "name": node.name}
 
     # @axes is optional, so omit if None.
     axes = inputs[1]

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -4859,3 +4859,26 @@ class TestRemainder(TorchBaseTest):
                 return output_tensor
 
         self.run_compare_torch(shapes, RemainderModel(), backend=backend)
+
+
+class TestSum(TorchBaseTest):
+    @pytest.mark.parametrize(
+        "backend, input_dtype",
+        itertools.product(
+            backends,
+            [torch.int32, torch.float32, torch.bool]
+        )
+    )
+    def test_sum(self, backend, input_dtype):
+        model = ModuleWrapper(function=torch.sum)
+
+        input_data = torch.zeros(2, 3).to(input_dtype)
+        expected_results = model(input_data)
+
+        TorchBaseTest.run_compare_torch(
+            input_data,
+            model,
+            expected_results=expected_results,
+            input_as_shape=False,
+            backend=backend,
+        )


### PR DESCRIPTION
Background:
- MIL reduce_sum op doesn't support bool input.
- For PyTorch, the `torch.sum` supports bool input, so we need to add a cast to make it compatible with MIL reduce_sum op.
- For TensorFlow, the `tf.reduce_sum` doesn't support bool input, so there is nothing we need to do at the current stage.

This could solve the issue https://github.com/apple/coremltools/issues/1570.

CI: https://gitlab.com/coremltools1/coremltools/-/pipelines/657214141
The newly added test case of tf when that CI was run has been removed. As the modification is on PyTorch side, it should be safe to merge.