### PR TITLE
Raise warning when model not in eval mode

### DIFF
--- a/coremltools/converters/mil/frontend/torch/load.py
+++ b/coremltools/converters/mil/frontend/torch/load.py
@@ -41,6 +41,8 @@ def load(model_spec, debug=False, **kwargs):
         only.
     """
     torchscript = _torchscript_from_model(model_spec)
+    if torchscript.training:
+        _logging.warning("Model not in eval mode")
 
     if type(torchscript) == _torch.jit._script.RecursiveScriptModule:
         _logging.warning("Support for converting Torch Script Models is experimental. "

--- a/coremltools/converters/mil/frontend/torch/load.py
+++ b/coremltools/converters/mil/frontend/torch/load.py
@@ -42,7 +42,8 @@ def load(model_spec, debug=False, **kwargs):
     """
     torchscript = _torchscript_from_model(model_spec)
     if torchscript.training:
-        _logging.warning("Model not in eval mode")
+        _logging.warning("Model is not in eval mode. "
+                         "Consider calling '.eval()' on your model prior to conversion")
 
     if type(torchscript) == _torch.jit._script.RecursiveScriptModule:
         _logging.warning("Support for converting Torch Script Models is experimental. "


### PR DESCRIPTION
**Issue:** #1616

**What does this implement/fix ?**
Adds warning if torch model is not in eval mode.

@TobyRoseman 
Please let me know if any changes are needed.