### PR TITLE
Bump `protobuf` to 3.20.2 

### DIFF
--- a/reqs/build.pip
+++ b/reqs/build.pip
@@ -3,8 +3,8 @@ numpy<1.20; platform_machine != "arm64" and python_version != "3.10"
 numpy==1.21.3; python_version == "3.10"
 
 # rdar://93977023
-protobuf<=3.20.1; python_version < "3.7"
-protobuf==3.20.1; python_version >= "3.7"
+protobuf<=3.20.2; python_version < "3.7"
+protobuf==3.20.2; python_version >= "3.7"
 
 pytest
 six

--- a/reqs/build.pip
+++ b/reqs/build.pip
@@ -3,8 +3,8 @@ numpy<1.20; platform_machine != "arm64" and python_version != "3.10"
 numpy==1.21.3; python_version == "3.10"
 
 # rdar://93977023
-protobuf<=3.20.2; python_version < "3.7"
-protobuf==3.20.2; python_version >= "3.7"
+protobuf<=3.20.3; python_version < "3.7"
+protobuf==3.20.3; python_version >= "3.7"
 
 pytest
 six

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     },
     install_requires=[
         "numpy >= 1.14.5",
-        "protobuf >= 3.1.0, <= 4.0.0",
+        "protobuf >= 3.1.0, < 4.0.0",
         "sympy",
         "tqdm",
         "packaging",

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     },
     install_requires=[
         "numpy >= 1.14.5",
-        "protobuf >= 3.1.0, <= 3.20.1",
+        "protobuf >= 3.1.0, <= 3.20.2",
         "sympy",
         "tqdm",
         "packaging",

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     },
     install_requires=[
         "numpy >= 1.14.5",
-        "protobuf >= 3.1.0, <= 3.20.2",
+        "protobuf >= 3.1.0, <= 4.0.0",
         "sympy",
         "tqdm",
         "packaging",


### PR DESCRIPTION
Fix for CVE https://security.snyk.io/package/pip/protobuf/3.20.1
Build is successful. 