### PR TITLE
Support torch more generic einsum.

### DIFF
--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -2799,9 +2799,20 @@ class TestEinsum(TorchBaseTest):
              "btnh,bfnh->bnft",
              "bnft,btnh->bfnh",
              "abcd,cde->abe",
+             "ab,ab->b",
              "abc,acd->abd",
+             "abc,abc->a",
+             "abc,abc->c",
+             "abc,bac->c",
+             "abc,abc->ab",
+             "abc,abc->bc",
+             "abc,bac->ba",
+             "abcd,abde->abce",
+             "acdb,bade->abce",
              "abcd,acdb->ad",
-             "abcd,efbd->eafc"],
+             "abcd,efbd->eafc",
+             "ab,b->a",
+             "abcd,cb->dca"],
             [False, True]
         ),
     )
@@ -2826,12 +2837,34 @@ class TestEinsum(TorchBaseTest):
             input_shapes = [[1,2,3,4], [1,4,2,6]]
         elif equation == "abcd,cde->abe":
             input_shapes = [[1,2,3,4], [3,4,6]]
+        elif equation == "ab,ab->b":
+            input_shapes = [[2, 3], [2, 3]]
         elif equation == "abc,acd->abd":
             input_shapes = [[2,3,4], [2,4,5]]
+        elif equation == "abc,abc->a":
+            input_shapes = [[2, 2, 2], [2, 2, 2]]
+        elif equation == "abc,abc->c":
+            input_shapes = [[2, 2, 2], [2, 2, 2]]
+        elif equation == "abc,bac->c":
+            input_shapes = [[2, 2, 2], [2, 2, 2]]
+        elif equation == "abc,abc->ab":
+            input_shapes = [[2, 2, 2], [2, 2, 2]]
+        elif equation == "abc,abc->bc":
+            input_shapes = [[2, 2, 2], [2, 2, 2]]
+        elif equation == "abc,bac->ba":
+            input_shapes = [[1, 2, 3], [2, 1, 3]]
+        elif equation == "abcd,abde->abce":
+            input_shapes = [[1, 2, 3, 4], [1, 2, 4, 5]]
+        elif equation == "acdb,bade->abce":
+            input_shapes = [[2, 2, 3, 4], [4, 2, 3, 2]]
         elif equation == "abcd,acdb->ad":
             input_shapes = [[1,2,3,4], [1,3,4,2]]
         elif equation == "abcd,efbd->eafc":
             input_shapes = [[1,2,3,4], [1,2,2,4]]
+        elif equation == "ab,b->a":
+            input_shapes = [[2, 3], [3]]
+        elif equation == "abcd,cb->dca":
+            input_shapes = [[1, 2, 3, 4], [3, 2]]
         else:
             raise ValueError("unrecognized equation")
 
@@ -2843,6 +2876,7 @@ class TestEinsum(TorchBaseTest):
 
         model = TestEinsum()
         self.run_compare_torch(input_shapes, model, backend=backend, input_as_shape=True)
+
 
 class TestSqueeze(TorchBaseTest):
     @pytest.mark.parametrize(

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -2798,7 +2798,10 @@ class TestEinsum(TorchBaseTest):
              "abc,cde->abde",
              "btnh,bfnh->bnft",
              "bnft,btnh->bfnh",
-             "abcd,cde->abe"],
+             "abcd,cde->abe",
+             "abc,acd->abd",
+             "abcd,acdb->ad",
+             "abcd,efbd->eafc"],
             [False, True]
         ),
     )
@@ -2823,6 +2826,12 @@ class TestEinsum(TorchBaseTest):
             input_shapes = [[1,2,3,4], [1,4,2,6]]
         elif equation == "abcd,cde->abe":
             input_shapes = [[1,2,3,4], [3,4,6]]
+        elif equation == "abc,acd->abd":
+            input_shapes = [[2,3,4], [2,4,5]]
+        elif equation == "abcd,acdb->ad":
+            input_shapes = [[1,2,3,4], [1,3,4,2]]
+        elif equation == "abcd,efbd->eafc":
+            input_shapes = [[1,2,3,4], [1,2,2,4]]
         else:
             raise ValueError("unrecognized equation")
 


### PR DESCRIPTION
Support more generic einsum.

## Not supported
- Ellipsis (’…’)
- Flexible shape
- 1 or 3 or more operands