### PR TITLE
Torch Where op with one parameter

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -4360,11 +4360,19 @@ def where(context, node):
     if len(inputs) == 1:
         x = inputs[0]
         non_zero = mb.non_zero(x=x)
-        a = mb.slice_by_index(x=non_zero, begin=[0, 0], end=[-1, -1], end_mask=[True, True], squeeze_mask=[False, True])
-        b = mb.slice_by_index(x=non_zero, begin=[0, 1], end=[-1, -1], end_mask=[True, True], squeeze_mask=[False, True])
 
-        context.add((a, b), node.name)
+        result = []
+        for i in range(x.rank):
+            result.append(mb.slice_by_index(x=non_zero,
+                                            begin=[0, i],
+                                            end=[-1, -1], # Will be ignored, but is required
+                                            end_mask=[True, True],
+                                            squeeze_mask=[False, True])
+            )
+
+        context.add(result, node.name)
         return
+
 
     assert len(inputs) == 3
     cond = inputs[0]

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -4355,14 +4355,17 @@ def logical_xor(context, node):
 
 
 def _nonzero_as_tuple(context, node, x):
+    '''
+    Calculates the non-zero elements of x then slices results by each inner index.
+    '''
     non_zero = mb.non_zero(x=x)
 
     result = []
     for i in range(x.rank):
         result.append(mb.slice_by_index(x=non_zero,
                                         begin=[0, i],
-                                        end=[-1, -1], # Will be ignored, but is required
-                                        end_mask=[True, True],
+                                        end=[-1, -1], # Ignored, but required
+                                        end_mask=[True, False],
                                         squeeze_mask=[False, True])
         )
 

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -4360,8 +4360,8 @@ def where(context, node):
     if len(inputs) == 1:
         x = inputs[0]
         non_zero = mb.non_zero(x=x)
-        a = mb.slice_by_index(x=non_zero, begin=[0, 0], end=[3, 1], end_mask=[True, False], squeeze_mask=[False, True])
-        b = mb.slice_by_index(x=non_zero, begin=[0, 1], end=[3, 2], end_mask=[True, True], squeeze_mask=[False, True])
+        a = mb.slice_by_index(x=non_zero, begin=[0, 0], end=[-1, -1], end_mask=[True, True], squeeze_mask=[False, True])
+        b = mb.slice_by_index(x=non_zero, begin=[0, 1], end=[-1, -1], end_mask=[True, True], squeeze_mask=[False, True])
 
         context.add((a, b), node.name)
         return

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -4355,7 +4355,18 @@ def logical_xor(context, node):
 
 @register_torch_op
 def where(context, node):
-    inputs = _get_inputs(context, node, expected=3)
+    inputs = _get_inputs(context, node)
+
+    if len(inputs) == 1:
+        x = inputs[0]
+        non_zero = mb.non_zero(x=x)
+        a = mb.slice_by_index(x=non_zero, begin=[0, 0], end=[3, 1], end_mask=[True, False], squeeze_mask=[False, True])
+        b = mb.slice_by_index(x=non_zero, begin=[0, 1], end=[3, 2], end_mask=[True, True], squeeze_mask=[False, True])
+
+        context.add((a, b), node.name)
+        return
+
+    assert len(inputs) == 3
     cond = inputs[0]
     if not types.is_bool(cond.dtype):
         # cond must be bool type

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -3916,6 +3916,30 @@ class TestWhere(TorchBaseTest):
             input_as_shape=False,
         )
 
+    @pytest.mark.parametrize("backend", backends)
+    def test_where_single_param(self, backend):
+        class WhereModel(nn.Module):
+            def forward(self, x):
+                return torch.where(x)
+
+        '''
+        x = torch.tensor([[0.6, 0.0, 0.0, 0.0],
+                          [0.0, 0.4, 0.0, 0.0],
+                          [0.0, 0.0, 1.2, 0.0],
+                          [0.0, 3.0, 0.0, -0.4]])
+        '''
+        x = torch.zeros(20, dtype=torch.float32).reshape((10, 2))
+        #x[1,1] = 12
+        x[3,0] = -1
+        x[4,1] = 9
+
+        self.run_compare_torch(
+            x,
+            WhereModel(),
+            backend=backend,
+            input_as_shape=False,
+        )
+
 
 class TestSelect(TorchBaseTest):
     @pytest.mark.parametrize(

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -3922,16 +3922,10 @@ class TestWhere(TorchBaseTest):
             def forward(self, x):
                 return torch.where(x)
 
-        '''
         x = torch.tensor([[0.6, 0.0, 0.0, 0.0],
                           [0.0, 0.4, 0.0, 0.0],
                           [0.0, 0.0, 1.2, 0.0],
                           [0.0, 3.0, 0.0, -0.4]])
-        '''
-        x = torch.zeros(20, dtype=torch.float32).reshape((10, 2))
-        #x[1,1] = 12
-        x[3,0] = -1
-        x[4,1] = 9
 
         self.run_compare_torch(
             x,

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -3918,17 +3918,18 @@ class TestWhere(TorchBaseTest):
         )
 
     @pytest.mark.parametrize("shape, backend",
-        itertools.product([(4,4)], backends))
+        itertools.product(COMMON_SHAPES + [(10,)], backends)
+    )
     def test_where_single_param(self, shape, backend):
         class WhereModelSingleParam(nn.Module):
             def forward(self, x):
                 return torch.where(x)
 
-        # Create a tensor of `shape` of ~90% non-zero entries
+        # Create a tensor of given shape with ~90% zero entries
         x = np.zeros(shape)
         all_indices = list(zip(*np.where(x == 0)))
         num_indices = len(all_indices)
-        random_picks = np.random.choice(np.arange(num_indices), size=num_indices//10)
+        random_picks = np.random.choice(np.arange(num_indices), size=num_indices//10, replace=False)
         for i in random_picks:
             x[all_indices[i]] = np.random.choice([-1, 12, 100])
         x = torch.Tensor(x)

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -3967,16 +3967,17 @@ class TestSelect(TorchBaseTest):
             input_shape, model, backend=backend,
         )
 
+
 class TestNonZero(TorchBaseTest):
     @pytest.mark.parametrize(
-        "backend, rank",
+        "backend, rank, as_tuple",
         itertools.product(
             backends,
             [1, 3],
+            [False, True],
         ),
     )
-    def test_non_zero(self, backend, rank):
-
+    def test_non_zero(self, backend, rank, as_tuple):
         if rank == 1:
             input_shape = (10)
             zeros_indices = np.array([1, 4, 7, 9])
@@ -3989,12 +3990,11 @@ class TestNonZero(TorchBaseTest):
         input = np.reshape(input, input_shape)
         input = torch.tensor(input)
 
-        model = ModuleWrapper(
-            torch.nonzero,
-        )
+        model = ModuleWrapper(torch.nonzero, {'as_tuple':as_tuple})
 
         self.run_compare_torch(input, model,
             input_as_shape=False, backend=backend)
+
 
 class TestTorchTensor(TorchBaseTest):
     @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes: #1360
Also make `torch.nonzero` work with `as_tuple=True`.
CI: https://gitlab.com/coremltools1/coremltools/-/pipelines/683963832