### PR TITLE
Support Torch op logsumexp

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -1421,7 +1421,11 @@ def sub(context, node):
     context.add(res)
 
 
-@register_torch_op(torch_alias=["sum"])
+@register_torch_op(
+    torch_alias=[
+        "sum",
+        "logsumexp",
+    ])
 def mean(context, node):
     inputs = _get_inputs(context, node)
 
@@ -1451,8 +1455,12 @@ def mean(context, node):
     # Last input to mean is an optional output tensor. We always expect this to
     # be None or absent.
     assert len(inputs) <= 3 or inputs[3] is None
-    func = mb.reduce_sum if node.kind == "sum" else mb.reduce_mean
-    res = func(**kwargs)
+    if node.kind == "sum":
+        res = mb.reduce_sum(**kwargs)
+    elif node.kind == "logsumexp":
+        res = mb.reduce_log_sum_exp(**kwargs)
+    else:
+        res = mb.reduce_mean(**kwargs)
     context.add(res)
 
 

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -7421,15 +7421,16 @@ class TestSum(TorchBaseTest):
 
 class TestLogsumexp(TorchBaseTest):
     @pytest.mark.parametrize(
-        "compute_unit, backend, shape",
+        "compute_unit, backend, shape, dim",
         itertools.product(
             compute_units,
             backends,
             COMMON_SHAPES,
+            [0, -1],
         ),
     )
-    def test_logsumexp(self, compute_unit, backend, shape):
-        params = {"dim": 0}
+    def test_logsumexp(self, compute_unit, backend, shape, dim):
+        params = {"dim": dim}
         model = ModuleWrapper(
             function=torch.logsumexp,
             kwargs=params,

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -7419,6 +7419,29 @@ class TestSum(TorchBaseTest):
         )
 
 
+class TestLogsumexp(TorchBaseTest):
+    @pytest.mark.parametrize(
+        "compute_unit, backend, shape",
+        itertools.product(
+            compute_units,
+            backends,
+            COMMON_SHAPES,
+        ),
+    )
+    def test_logsumexp(self, compute_unit, backend, shape):
+        params = {"dim": 0}
+        model = ModuleWrapper(
+            function=torch.logsumexp,
+            kwargs=params,
+        )
+        TorchBaseTest.run_compare_torch(
+            shape,
+            model,
+            backend=backend,
+            compute_unit=compute_unit,
+        )
+
+
 class TestHannWindow(TorchBaseTest):
     @pytest.mark.parametrize(
         "compute_unit, backend, window_length, periodic",


### PR DESCRIPTION
Resolve #1693.

Test code:
```
import torch
import coremltools as ct

class MyModel(torch.nn.Module):
    def forward(self, x):
        return torch.logsumexp(x, dim=1)

print(ct.__version__)
print(torch.__version__)
m = MyModel()
m.eval()
a = torch.ones(1,2)
m = torch.jit.trace(m, a)
model = ct.convert(m, inputs=[ct.TensorType(shape=a.shape)])
out = model.predict({'x': a.numpy()})
print(f'm(a): {m(a)}; out: {out}')
```

Output:
```
6.1
1.12.1
Converting PyTorch Frontend ==> MIL Ops:  75%|█████████████████████▊       | 3/4 [00:00<00:00, 1795.51 ops/s]
Running MIL Common passes:   0%|                                                 | 0/39 [00:00<?, ? passes/s]/Users/chinchangyang/Code/coremltools/envs/coremltools-py3.9/lib/python3.9/site-packages/coremltools/converters/mil/mil/passes/name_sanitization_utils.py:135: UserWarning: Output, '5', of the source model, has been renamed to 'var_5' in the Core ML model.
  warnings.warn(msg.format(var.name, new_name))
Running MIL Common passes: 100%|██████████████████████████████████████| 39/39 [00:00<00:00, 6664.13 passes/s]
Running MIL Clean up passes: 100%|███████████████████████████████████| 11/11 [00:00<00:00, 26244.22 passes/s]
Translating MIL ==> NeuralNetwork Ops: 100%|██████████████████████████████| 3/3 [00:00<00:00, 24197.91 ops/s]
m(a): tensor([1.6931]); out: {'var_5': array([1.6931474], dtype=float32)}
```