### PR TITLE
Update slice_by_index to sliceStatic mapping

### DIFF
--- a/coremltools/converters/mil/backend/nn/op_mapping.py
+++ b/coremltools/converters/mil/backend/nn/op_mapping.py
@@ -1176,10 +1176,10 @@ def slice_by_index(const_context, builder, op):
         for i in range(rank):
             if (not begin_mask[i] and begin[i] != 0) or \
                (not end_mask[i] and end[i] != op.x.shape[i]) or \
-               squeeze_mask[i] or stride[i] != 1:
+               stride[i] != 1:
                 slice_dim.append(i)
 
-        if len(slice_dim) == 1:
+        if len(slice_dim) == 1 and not any(squeeze_mask):
             dim = slice_dim[0] - rank
             if dim in [-3, -2, -1]:
                 # get the axis, only channel, width, and depth dimension are supported

--- a/coremltools/converters/mil/backend/nn/op_mapping.py
+++ b/coremltools/converters/mil/backend/nn/op_mapping.py
@@ -1176,10 +1176,10 @@ def slice_by_index(const_context, builder, op):
         for i in range(rank):
             if (not begin_mask[i] and begin[i] != 0) or \
                (not end_mask[i] and end[i] != op.x.shape[i]) or \
-               stride[i] != 1:
+               squeeze_mask[i] or stride[i] != 1:
                 slice_dim.append(i)
 
-        if len(slice_dim) == 1 and not squeeze_mask[slice_dim[0]]:
+        if len(slice_dim) == 1:
             dim = slice_dim[0] - rank
             if dim in [-3, -2, -1]:
                 # get the axis, only channel, width, and depth dimension are supported

--- a/coremltools/converters/mil/mil/ops/tests/test_slice.py
+++ b/coremltools/converters/mil/mil/ops/tests/test_slice.py
@@ -307,6 +307,5 @@ class TestSliceByIndex:
 
         model = ct.convert(prog, source="milinternal", convert_to="mlprogram")
         y_mlprogram = list(model.predict({'x': x}).values())[0]
-        # TODO: https://github.com/apple/coremltools/issues/1710
-        # MLProgram does not apply squeeze_mask.
+        # TODO: rdar://103365766 MLProgram does not apply squeeze_mask.
         # np.testing.assert_allclose(y_numpy, y_mlprogram)


### PR DESCRIPTION
 - slice_by_index can be mapped to sliceStatic if slice is working on only one dimension
 - This change includes squeeze_mask into such consideration as well
 - sliceStatic does not support squeezeMask

resolves #1709