### PR TITLE
Add torch.concat as an alias of torch.cat

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -1842,7 +1842,7 @@ def hardtanh(context, node):
     context.add(res)
 
 
-@register_torch_op
+@register_torch_op(torch_alias=['concat'])
 def cat(context, node):
     inputs = _get_inputs(context, node)
     axis = 0 if len(inputs) == 1 else inputs[1]

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -3312,6 +3312,32 @@ class TestConcat(TorchBaseTest):
             compute_unit=compute_unit,
         )
 
+    @pytest.mark.parametrize("compute_unit, backend", itertools.product(compute_units, backends))
+    def test_concat_alias(self, compute_unit, backend):
+
+        class Outer(torch.nn.Module):
+            def __init__(self, net):
+                super(Outer, self).__init__()
+                self.net = net
+
+            def forward(self, x):
+                x = self.net(x)
+                return x
+
+        class TestNet(nn.Module):
+            def forward(self, x):
+                x = torch.concat((x, x), axis=1)
+                return x
+
+        # test passes without adding alias if `Outer` is not used
+        model = Outer(TestNet())
+        self.run_compare_torch(
+            (1, 3, 16, 16),
+            model,
+            backend=backend,
+            compute_unit=compute_unit,
+        )
+
 
 class TestBitwiseNot(TorchBaseTest):
     @pytest.mark.parametrize(


### PR DESCRIPTION
I ran into the following error
```
RuntimeError: PyTorch convert function for op 'concat' not implemented.
```
while converting a model like this one
```python
import coremltools as ct
import torch
import torch.nn

print(ct.__version__)
print(torch.__version__)


class Outer(torch.nn.Module):
    def __init__(self, model):
        super(Outer, self).__init__()
        self.model = model

    def forward(self, x):
        x = self.model(x)
        return x


class Inner(torch.nn.Module):
    def forward(self, x):
        return torch.concat([x, x], dim=-1)


torch_model = Outer(Inner())
torch_model.eval()

x = torch.randn([1, 3], dtype=torch.float)
traced_model = torch.jit.trace(torch_model, x)
model = ct.convert(traced_model, inputs=[ct.TensorType(shape=x.shape)])
```
with `torch==1.12.1`, `coremltools==6.1`.

Weirdly, if I just convert the `Inner` module, then it recognizes the concat operator, but when it's wrapped in the `Outer` module it does not. Changing it from `torch.concat` to `torch.cat` also would solve the problem.

This PR adds `torch.concat` as an alias for `torch.cat`.

[PyTorch doc for concat](https://pytorch.org/docs/stable/generated/torch.concat.html)