### PR TITLE
Docs - Fix Typo in recurrent lstm API (rdar://103092445)

### DIFF
--- a/coremltools/converters/mil/mil/ops/defs/iOS15/recurrent.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS15/recurrent.py
@@ -179,7 +179,7 @@ class lstm(Operation):
        f_t = \rm{recurrent\_activation}(W_{if} x_t + B_{if} + W_{hf} h_(t-1) + B_{hf})
 
     .. math::
-       z_t = cell_activation(W_{iz} x_t + B_{iz} + W_{hz} h_(t-1) + B_{hz})
+       z_t = cell\_activation(W_{iz} x_t + B_{iz} + W_{hz} h_(t-1) + B_{hz})
 
     .. math::
        o_t = \rm{recurrent\_activation}(W_{io} x_t + B_{io} + W_{ho} h_(t-1) + B_{ho})


### PR DESCRIPTION
This PR fixes a typo in [`iOS15.recurrent.lstm`](https://apple.github.io/coremltools/source/coremltools.converters.mil.mil.ops.defs.html#coremltools.converters.mil.mil.ops.defs.iOS15.recurrent.lstm), `cell_activation` in formula.

This PR addresses [rdar://103092445](https://rdar.apple.com/problem/103092445) ([Infra] Typo in mil python docs).

A subsequent PR will provide the generated HTML.

