### PR TITLE
Fallback to sensible options for Soft NMS and NN upsampling

### DIFF
--- a/coremltools/converters/mil/backend/nn/op_mapping.py
+++ b/coremltools/converters/mil/backend/nn/op_mapping.py
@@ -3064,18 +3064,26 @@ def shape(const_context, builder, op):
 
 
 def add_upsample_nn(const_context, builder, op, scale_factor_h, scale_factor_w):
+    mode = "NN"
+    linear_upsample_mode = "DEFAULT"
     if _np.abs(_np.round(scale_factor_h) - scale_factor_h) < 1e-4 and scale_factor_h >= 1 - 1e-4:
         scale_factor_h = int(scale_factor_h)
     else:
-        raise NotImplementedError(
-           f"Unsupported float type 'scale_factor_height' ({scale_factor_h}) for neuralnetwork."
+        logger.warning(
+           f"Unsupported float type 'scale_factor_height' ({scale_factor_h}) for neuralnetwork. "
+           "Falling back to bilinear interpolation."
         )
+        mode = "BILINEAR"
+        linear_upsample_mode = "ALIGN_CORNERS_TRUE"
     if _np.abs(_np.round(scale_factor_w) - scale_factor_w) < 1e-4 and scale_factor_w >= 1 - 1e-4:
         scale_factor_w = int(scale_factor_w)
     else:
-        raise NotImplementedError(
-           f"Unsupported float type 'scale_factor_width' ({scale_factor_w}) for neuralnetwork."
+        logger.warning(
+           f"Unsupported float type 'scale_factor_width' ({scale_factor_w}) for neuralnetwork. "
+           "Falling back to bilinear interpolation."
         )
+        mode = "BILINEAR"
+        linear_upsample_mode = "ALIGN_CORNERS_TRUE"
 
     builder.add_upsample(
         name=op.name,
@@ -3083,7 +3091,8 @@ def add_upsample_nn(const_context, builder, op, scale_factor_h, scale_factor_w):
         scaling_factor_w=scale_factor_w,
         input_name=make_input(const_context, builder, op.x),
         output_name=op.outputs[0].name,
-        mode="NN",
+        mode=mode,
+        linear_upsample_mode=linear_upsample_mode,
     )
 
 

--- a/coremltools/converters/mil/mil/types/type_double.py
+++ b/coremltools/converters/mil/mil/types/type_double.py
@@ -121,7 +121,7 @@ def make_float(width):
 
         @annotate(delay_type.bool)
         def __bool__(self):
-            return self.val
+            return self.val != 0
 
         @annotate(delay_type.int)
         def __int__(self):


### PR DESCRIPTION
**Who can do more can do less:** in `add_upsample_nn`, why raise an exception for nearest-neighbor interpolation when bilinear interpolation is available?

**Half a loaf is better than none:** in `NonMaxSuppressionV5`, why raise an exception for "soft" NMS when "hard" NMS is available?

This MR follows the logic that converting to an altered but working version of a model is better than failing to convert.

If in doubt about the change in `type_double.py`, see https://github.com/apple/coremltools/blob/main/coremltools/converters/mil/mil/types/type_int.py#L131