### PR TITLE
Support torch.amax and torch.amin

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -4307,6 +4307,34 @@ def max(context, node):
         context.add(values, torch_name=values_name)
         context.add(indices, torch_name=indices_name)
 
+@register_torch_op
+def amax(context, node):
+    inputs = _get_inputs(context, node, expected=[2, 3])
+
+    # mimic functionality from https://pytorch.org/docs/stable/generated/torch.amax.html
+    _input = inputs[0]
+    dim = [inputs[1].val] if type(inputs[1].val) == int else [x for x in inputs[1].val]
+    keepdim = False
+
+    values = mb.reduce_max(x=_input, axes=dim, keep_dims=keepdim)
+    assert len(node.outputs) == 1
+    values_name = node.outputs[0]
+    context.add(values, torch_name=values_name)
+
+@register_torch_op
+def amin(context, node):
+    inputs = _get_inputs(context, node, expected=[2, 3])
+
+    # mimic functionality from https://pytorch.org/docs/stable/generated/torch.amin.html
+    _input = inputs[0]
+    dim = [inputs[1].val] if type(inputs[1].val) == int else [x for x in inputs[1].val]
+    keepdim = False
+
+    values = mb.reduce_min(x=_input, axes=dim, keep_dims=keepdim)
+    assert len(node.outputs) == 1
+    values_name = node.outputs[0]
+    context.add(values, torch_name=values_name)
+
 
 @register_torch_op
 def argsort(context, node):

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -4314,7 +4314,7 @@ def amax(context, node):
     # mimic functionality from https://pytorch.org/docs/stable/generated/torch.amax.html
     _input = inputs[0]
     dim = [inputs[1].val] if type(inputs[1].val) == int else [x for x in inputs[1].val]
-    keepdim = False
+    keepdim = inputs[2] if len(inputs) == 3 else False
 
     values = mb.reduce_max(x=_input, axes=dim, keep_dims=keepdim)
     assert len(node.outputs) == 1
@@ -4328,7 +4328,7 @@ def amin(context, node):
     # mimic functionality from https://pytorch.org/docs/stable/generated/torch.amin.html
     _input = inputs[0]
     dim = [inputs[1].val] if type(inputs[1].val) == int else [x for x in inputs[1].val]
-    keepdim = False
+    keepdim = inputs[2] if len(inputs) == 3 else False
 
     values = mb.reduce_min(x=_input, axes=dim, keep_dims=keepdim)
     assert len(node.outputs) == 1

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -4307,33 +4307,27 @@ def max(context, node):
         context.add(values, torch_name=values_name)
         context.add(indices, torch_name=indices_name)
 
+def _get_input_amax_amin(context, node):
+     # mimic functionality from https://pytorch.org/docs/stable/generated/torch.amax.html
+     # mimic functionality from https://pytorch.org/docs/stable/generated/torch.amin.html
+    assert len(node.outputs) == 1
+    
+    all_inputs = _get_inputs(context, node, expected=[2, 3])
+    input = all_inputs[0]
+    dim = [all_inputs[1].val] if type(all_inputs[1].val) == int else [x for x in all_inputs[1].val]
+    keepdim = all_inputs[2] if len(all_inputs) == 3 else False
+    
+    return input, dim, keepdim
+
 @register_torch_op
 def amax(context, node):
-    inputs = _get_inputs(context, node, expected=[2, 3])
-
-    # mimic functionality from https://pytorch.org/docs/stable/generated/torch.amax.html
-    _input = inputs[0]
-    dim = [inputs[1].val] if type(inputs[1].val) == int else [x for x in inputs[1].val]
-    keepdim = inputs[2] if len(inputs) == 3 else False
-
-    values = mb.reduce_max(x=_input, axes=dim, keep_dims=keepdim)
-    assert len(node.outputs) == 1
-    values_name = node.outputs[0]
-    context.add(values, torch_name=values_name)
+    _input, dim, keepdim = _get_input_amax_amin(context, node)
+    context.add(mb.reduce_max(x=_input, axes=dim, keep_dims=keepdim))
 
 @register_torch_op
 def amin(context, node):
-    inputs = _get_inputs(context, node, expected=[2, 3])
-
-    # mimic functionality from https://pytorch.org/docs/stable/generated/torch.amin.html
-    _input = inputs[0]
-    dim = [inputs[1].val] if type(inputs[1].val) == int else [x for x in inputs[1].val]
-    keepdim = inputs[2] if len(inputs) == 3 else False
-
-    values = mb.reduce_min(x=_input, axes=dim, keep_dims=keepdim)
-    assert len(node.outputs) == 1
-    values_name = node.outputs[0]
-    context.add(values, torch_name=values_name)
+    _input, dim, keepdim = _get_input_amax_amin(context, node)
+    context.add(mb.reduce_min(x=_input, axes=dim, keep_dims=keepdim))
 
 
 @register_torch_op

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -4307,27 +4307,25 @@ def max(context, node):
         context.add(values, torch_name=values_name)
         context.add(indices, torch_name=indices_name)
 
-def _get_input_amax_amin(context, node):
+def _add_amax_amin(context, node, reduce_op):
      # mimic functionality from https://pytorch.org/docs/stable/generated/torch.amax.html
      # mimic functionality from https://pytorch.org/docs/stable/generated/torch.amin.html
     assert len(node.outputs) == 1
     
     all_inputs = _get_inputs(context, node, expected=[2, 3])
-    input = all_inputs[0]
+    _input = all_inputs[0]
     dim = [all_inputs[1].val] if type(all_inputs[1].val) == int else [x for x in all_inputs[1].val]
     keepdim = all_inputs[2] if len(all_inputs) == 3 else False
     
-    return input, dim, keepdim
+    context.add(reduce_op(x=_input, axes=dim, keep_dims=keepdim), torch_name=node.outputs[0])
 
 @register_torch_op
 def amax(context, node):
-    _input, dim, keepdim = _get_input_amax_amin(context, node)
-    context.add(mb.reduce_max(x=_input, axes=dim, keep_dims=keepdim))
+    _add_amax_amin(context, node, mb.reduce_max)
 
 @register_torch_op
 def amin(context, node):
-    _input, dim, keepdim = _get_input_amax_amin(context, node)
-    context.add(mb.reduce_min(x=_input, axes=dim, keep_dims=keepdim))
+    _add_amax_amin(context, node, mb.reduce_min)
 
 
 @register_torch_op

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -2865,6 +2865,37 @@ class TestMaximumMinimum(TorchBaseTest):
             input_shapes, model, backend=backend, compute_unit=compute_unit
         )
 
+class TestAMaxAMin(TorchBaseTest):
+    @pytest.mark.parametrize(
+        "compute_unit, backend, input_shapes, mode, reduce_dim, keepdim",
+        itertools.product(
+            compute_units,
+            backends,
+            [
+                [(2, 5, 7, 3)],
+                [(3, 2, 9)],
+                [(1,)],
+            ],
+            ["minimum", "maximum"],
+            [0, 1, 2, 3],
+            [True, False],
+        ),
+    )
+    def test_minimum_maximum(self, compute_unit, backend, input_shapes, mode, reduce_dim, keepdim):
+        class TestModel(torch.nn.Module):
+            def forward(self, input):
+                if mode == "minimum":
+                    return torch.amin(input, min(input.dim() - 1, reduce_dim), keepdim)
+                elif mode == "maximum":
+                    return torch.amax(input, min(input.dim() - 1, reduce_dim), keepdim)
+                else:
+                    raise ValueError("Unsupported mode: {mode}".format(mode=mode))
+
+        model = TestModel()
+        self.run_compare_torch(
+            input_shapes, model, backend=backend, compute_unit=compute_unit
+        )
+
 
 class TestPoolSymbolicInput(TorchBaseTest):
     def test_max_pool(self):

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -2877,17 +2877,21 @@ class TestAMaxAMin(TorchBaseTest):
                 [(1,)],
             ],
             ["minimum", "maximum"],
-            [0, 1, 2, 3],
+            [0, 1, 2, 3, [0, 1], [0, 1, 2], [0, 1, 2, 3]],
             [True, False],
         ),
     )
     def test_minimum_maximum(self, compute_unit, backend, input_shapes, mode, reduce_dim, keepdim):
         class TestModel(torch.nn.Module):
             def forward(self, input):
+                if type(reduce_dim) == int:
+                    reduce_dim_clamped = min(input.dim() - 1, reduce_dim)
+                else:
+                    reduce_dim_clamped = reduce_dim[:input.dim()]
                 if mode == "minimum":
-                    return torch.amin(input, min(input.dim() - 1, reduce_dim), keepdim)
+                    return torch.amin(input, reduce_dim_clamped, keepdim)
                 elif mode == "maximum":
-                    return torch.amax(input, min(input.dim() - 1, reduce_dim), keepdim)
+                    return torch.amax(input, reduce_dim_clamped, keepdim)
                 else:
                     raise ValueError("Unsupported mode: {mode}".format(mode=mode))
 


### PR DESCRIPTION
This change maps `torch.amax` to `mb.reduce_max` and `torch.amin` to `mb.reduce_min` and adds corresponding tests.