### PR TITLE
Fix baddbmm handling of "beta" special-case

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -5271,7 +5271,7 @@ def baddbmm(context, node):
     inputs = _get_inputs(context, node, expected=5)
     bias, batch1, batch2, beta, alpha = inputs
 
-    if beta.val != 1.0:
+    if beta.val != 0.0:
         # Apply scaling factor beta to the bias.
         bias = mb.mul(x=beta, y=bias, name=bias.name + "_scaled")
         context.add(bias)


### PR DESCRIPTION
`baddbmm()` has a `beta` coefficient, by which bias may be multiplied.

in the special-case where `beta=0`: bias may be ignored (confirmed by [docs](https://pytorch.org/docs/stable/generated/torch.baddbmm.html)):

> If `beta` is 0, then `input` will be ignored, and _nan_ and _inf_ in it will not be propagated.

we use this in diffusers / stable-diffusion to avoid adding attention bias when none is specified:  
https://github.com/huggingface/diffusers/blob/bbab8553224d12f7fd58b0e65b0daf899769ef0b/src/diffusers/models/cross_attention.py#L237

_currently_, the special-case is determined by a comparison with _`1.0`_ rather than `0.0`. it looks like it was copied from `alpha`'s special-case:

https://github.com/apple/coremltools/blob/fa190decf7248028e3a265f44195f054370325ca/coremltools/converters/mil/frontend/torch/ops.py#L5274-L5282

changing this, fixed compilation of diffusers' UNetCondition2D model for me (which employs that baddbmm in CrossAttnProcessor).