### PR TITLE
[Illustrative; not for merge] How to prefer float16 as the main float type

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -2949,6 +2949,19 @@ def upsample_nearest2d(context, node):
         else:
             raise ValueError("Failed to infer scale factors from inputs.")
 
+    # CoreML only supports upsampling int32 or float32.
+    # pixel-doubling is a common use-case, so prefer integer if it looks close enough could be the intention.
+    if scales_h.dtype == _np.float16:
+        scales_h_int32 = scales_h.astype(_np.int32)
+        scales_h = scales_h_int32 if (
+            _np.allclose(scales_h, scales_h_int32)
+        ) else scales_h.astype(_np.float32)
+    if scales_w.dtype == _np.float16:
+        scales_w_int32 = scales_w.astype(_np.int32)
+        scales_w = scales_w_int32 if (
+            _np.allclose(scales_w, scales_w_int32)
+        ) else scales_w.astype(_np.float32)
+
     upsample_nearest2d = mb.upsample_nearest_neighbor(
         x=_input,
         scale_factor_height=scales_h,

--- a/coremltools/converters/mil/mil/ops/defs/iOS15/control_flow.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS15/control_flow.py
@@ -160,7 +160,7 @@ class Const(Operation):
     def _get_type_val(self, value):
 
         if isinstance(value, (float, np.float64)):
-            value = np.float32(value)
+            value = np.float16(value)
         elif isinstance(value, bool):
             pass
         elif isinstance(value, (int, np.int64)):
@@ -176,11 +176,11 @@ class Const(Operation):
                 value = value.astype(np.int32)
 
 
-            # For the float type, we use float32 by default
+            # For the float type, we use float16 by default
             elif value.dtype == np.float64:
-                msg = "Downcast const op {} data fp64 as fp32".format(self.name)
+                msg = "Downcast const op {} data fp64 as fp16".format(self.name)
                 logger.debug(msg)
-                value = value.astype(np.float32)
+                value = value.astype(np.float16)
 
         elif isinstance(value, mil_list):
             # if val that was passed in is of type mil_list, which is just a wrapper on top of python list

--- a/coremltools/converters/mil/mil/passes/apply_common_pass_pipeline.py
+++ b/coremltools/converters/mil/mil/passes/apply_common_pass_pipeline.py
@@ -51,7 +51,7 @@ def apply_common_pass_pipeline(prog, passes):
         "common::noop_elimination",
         "common::fuse_matmul_weight_bias",
         "common::fuse_linear_bias",
-        "common::fuse_gelu_tanh_approximation",
+        # "common::fuse_gelu_tanh_approximation",
         "common::fuse_gelu_exact",
         "common::fuse_leaky_relu",
         "common::rank0_expand_dims_swap",
@@ -73,7 +73,7 @@ def apply_common_pass_pipeline(prog, passes):
         "common::fuse_conv_batchnorm", # In some cases, we need to run conv / batch_norm fusion again after the fuse_conv_scale and fuse_conv_bias passes
         "common::detect_concat_interleave",
         "common::concat_to_pixel_shuffle", # should come after detect_concat_interleave and after replace_stack_reshape
-        "common::fuse_prelu", # reduce_transpose pass should run before and after this pass (the one after will be run during the cleanup passes stage)
+        # "common::fuse_prelu", # reduce_transpose pass should run before and after this pass (the one after will be run during the cleanup passes stage)
         "common::prelu_to_lrelu",
         "common::merge_consecutive_relus",
         #  "remove_redundant_ops" pass should be applied towards the end, once other graph passes have done their optimizations.

--- a/coremltools/converters/mil/mil/passes/elementwise_batchnorm_fusion.py
+++ b/coremltools/converters/mil/mil/passes/elementwise_batchnorm_fusion.py
@@ -73,8 +73,8 @@ def _try_to_transform(mul_op, add_op, block):
     out_name = add_op.outputs[0].name
     x = mb.batch_norm(
         x=non_const_input_mul,
-        mean=np.zeros((C,), np.float32),
-        variance=np.ones((C,), np.float32),
+        mean=np.zeros((C,), np.float16),
+        variance=np.ones((C,), np.float16),
         gamma=np.squeeze(gamma),
         beta=np.squeeze(beta),
         name=out_name,

--- a/coremltools/converters/mil/mil/types/type_mapping.py
+++ b/coremltools/converters/mil/mil/types/type_mapping.py
@@ -102,7 +102,7 @@ def np_dtype_to_py_type(np_dtype):
         return int
     if np_dtype in [bool, np.bool_]:
         return bool
-    if np_dtype in [np.float32, np.float64]:
+    if np_dtype in [np.float16, np.float32, np.float64]:
         return float
     if np_dtype in [np.complex64, np.complex128]:
         return complex
@@ -304,11 +304,9 @@ def numpy_type_to_builtin_type(nptype):
     elif np.issubclass_(nptype, np.object_):
         # symbolic shape is considered int32
         return types_int32
-    elif np.issubclass_(nptype, np.float16):
+    elif np.issubclass_(nptype, (np.float16, np.half)) or nptype == float:
         return types_fp16
-    elif (
-        np.issubclass_(nptype, (np.float32, np.single)) or nptype == float
-    ):
+    elif np.issubclass_(nptype, (np.float32, np.single)):
         return types_fp32
     elif np.issubclass_(nptype, (np.float64, np.double)):
         return types_fp64
@@ -337,7 +335,7 @@ def type_to_builtin_type(type):
     elif np.issubclass_(type, str):
         return types_str
     elif np.issubclass_(type, float):
-        return types_fp32
+        return types_fp16
     elif np.issubclass_(type, complex):
         return types_complex64
     else:


### PR DESCRIPTION
Currently, if your intention is to build a CoreML model which targets float16 (very likely if you're targeting ANE):  
the process for tracing+converting the model is "trace in float32; casts to float16 will be added during conversion, then we try to optimize away those casts". I think.

This does have an (admittedly minor) downside of having to load a float32 model (and start with 32-bit weights), only to ultimately throw half of them away.

It also relies on optimization passes being effective in eliding all the casts. And you have to wait for them (slightly).

The main downside for me was when trying to debug failures: the ops were complicated by lots of casts, and looked more different from the initial torchscript than they needed to be.

To simplify all this: I changed everywhere I could find, the convention:   
"Python floats will be interpreted as ~`np.float32`~ `np.float16`".

I'm not proposing to merge this or anything, but it actually wasn't many places that the changes needed to be made, in order to successfully compile stable-diffusion, using a model that was traced by torchscript in float16.  
_Note: on PyTorch, the CPU device doesn't implement float16 operations, so this trick requires one to trace the model in float16 via the MPS device instead._

If it turns out it's not just me who finds this useful:  
I wonder whether this could be exposed somehow as a configurable option? "default float width".