### PR TITLE
Docs - Updates Make Pipeline Extract Submodel for 6.3

### DIFF
--- a/coremltools/converters/mil/debugging_utils.py
+++ b/coremltools/converters/mil/debugging_utils.py
@@ -22,13 +22,13 @@ def extract_submodel(
         function_name: str = "main"
     ) -> MLModel:
     """
-    This utility function allows the user to extract a submodel from a Core ML model.
+    This utility function lets you extract a submodel from a Core ML model.
     
-    For the NeuralNetwork model, only in memory Core ML model can be extracted. That is to say,
-    the user should always call this function to a model directly from `ct.convert`. It is not
-    allowed to load the model from the disk, and call this API.
+    For a NeuralNetwork model, the function extracts only in-memory Core ML models.
+    You should always call this function to a model directly from ``ct.convert``. It is not
+    allowed to load the model from disk and then call this API.
     
-    For the ML program model, both cases (in memory / from disk) are supported.
+    For an ML program model, both cases (in-memory and from disk) are supported.
 
     Parameters
     ----------
@@ -40,10 +40,10 @@ def extract_submodel(
         
     inputs: list[str] (Optional)
         A list of names of Vars, which are the inputs of the extracted submodel.
-        If not provided, we use the inputs from the original model.
+        If not provided, the inputs from the original model are used.
 
     function_name: str (Optional)
-        Name of the function where the subgraph is extracted. Default "main".
+        Name of the function where the subgraph is extracted. Default ``main``.
         
     Examples
     --------
@@ -56,6 +56,7 @@ def extract_submodel(
         >>> submodel = extract_submodel(mlmodel, outputs)
         
     ML Program:
+
         >>> from coremltools.converters.mil.debugging_utils import extract_submodel
         >>> mlmodel = ct.convert(model, convert_to="mlprogram")
         >>> outputs = ["output_0", "output_1"]
@@ -67,7 +68,7 @@ def extract_submodel(
         >>> mlmodel.save("model.mlpackage")
         >>> mlmodel = coremltools.model.models.MLModel("model.mlpackage")
         >>> submodel = extract_submodel(mlmodel, outputs)
-     
+
     """
     def validate_inputs(func, input_vars):
         reachable_vars = set(input_vars)

--- a/coremltools/models/model.py
+++ b/coremltools/models/model.py
@@ -283,6 +283,8 @@ class MLModel:
                 - ``coremltools.ComputeUnit.CPU_ONLY``: Limit the model to only use the CPU.
                 - ``coremltools.ComputeUnit.CPU_AND_GPU``: Use both the CPU and GPU,
                   but not the neural engine.
+                - ``coremltools.ComputeUnit.CPU_AND_NE``: Use both the CPU and neural engine, but
+                  not the GPU. Available only for macOS >= 13.0.
 
         weights_dir: str
             Path to the weight directory, required when loading an MLModel of type mlprogram,

--- a/coremltools/models/utils.py
+++ b/coremltools/models/utils.py
@@ -1010,7 +1010,8 @@ def make_pipeline(*models):
 
     Parameters
     ----------
-    *models - two or more instances of ct.models.MLModel
+    *models
+        Two or more instances of ct.models.MLModel.
 
     Returns
     -------
@@ -1018,10 +1019,13 @@ def make_pipeline(*models):
 
     Examples
     --------
-    my_model1 = ct.models.MLModel('/tmp/m1.mlpackage')
-    my_model2 = ct.models.MLModel('/tmp/m2.mlmodel')
+    .. sourcecode:: python
 
-    my_pipeline_model = ct.utils.make_pipeline(my_model1, my_model2)
+        my_model1 = ct.models.MLModel('/tmp/m1.mlpackage')
+        my_model2 = ct.models.MLModel('/tmp/m2.mlmodel')
+        
+        my_pipeline_model = ct.utils.make_pipeline(my_model1, my_model2)
+
     """
 
     def updateBlobFileName(proto_message, new_path):

--- a/docs/source/coremltools.models.rst
+++ b/docs/source/coremltools.models.rst
@@ -23,6 +23,13 @@ array\_feature\_extractor
    :members:
 
 
+extract_submodel
+----------------
+
+.. automodule:: coremltools.converters.mil.debugging_utils
+	:members: extract_submodel
+
+
 feature\_vectorizer
 ---------------------------------------------
 


### PR DESCRIPTION
This PR for the public version `coremltools` (in github):

- Adds `CPU_AND_NE` to [MLModel](https://apple.github.io/coremltools/source/coremltools.models.html#coremltools.models.model.MLModel) in the public API Reference. 
    
    ```
    modified:   coremltools/models/model.py
    ```

- Adds `converters.mil.debugging_utils.extract_submodel` to the ``.rst`` navigation file and edits the docstring. See screenshot below for placement in the docs.

    ```
	modified:   coremltools/converters/mil/debugging_utils.py
	modified:   coremltools/models/model.py
	modified:   docs/source/coremltools.models.rst
    ```

- Edits docstring in `utils.make_pipeline`.

    ```
	modified:   coremltools/models/utils.py
    ```

This PR addresses the following tasks in [CoreMLTools Documentation Needs](https://quip-apple.com/bbuNAc6FgiMY):

- Add `CPU_AND_NE` to MLModel in the public API Reference.
- Document `converters.mil.debugging_utils.extract_submodel`.
- Document `utils.make_pipeline`.

HTML generation will occur in a separate PR and will include all changes made to the internal repo (including formatted graphs in graph passes).

Screenshot showing `exrtract-submodel`:
<img width="1256" alt="extract-submodel" src="https://user-images.githubusercontent.com/70229264/229627981-bafd4f66-a931-479d-a343-6709979711ef.png">

Branch:
docs-utils-pipeline-debugging-update
