### PR TITLE
Fix typo in `TreeEnsemble.rst`

### DIFF
--- a/mlmodel/docs/Format/TreeEnsemble.rst
+++ b/mlmodel/docs/Format/TreeEnsemble.rst
@@ -124,7 +124,7 @@ TreeEnsembleParameters.TreeNode.EvaluationInfo
 
 The leaf mode.
 
-If ``nodeBahavior`` == ``LeafNode``,
+If ``nodeBehavior`` == ``LeafNode``,
 then the evaluationValue is added to the base prediction value
 in order to get the final prediction.
 To support multiclass classification


### PR DESCRIPTION
Quick commit to fix a small typo in the `TreeEnsemble.rst` document.