### PR TITLE
Add `randn` and `randn_like` for torch frontend

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -3632,6 +3632,22 @@ def randint(context, node):
     rand_int = mb.cast(x=rand_uniform, dtype="int32", name=node.name)
     context.add(rand_int)
 
+@register_torch_op
+def randn(context, node):
+    inputs = _get_inputs(context, node, expected=5)
+    shape = inputs[0]
+    rand_normal = mb.random_normal(shape=shape)
+    rand_fp32 = mb.cast(x=rand_normal, dtype="fp32", name=node.name)
+    context.add(rand_fp32)
+
+@register_torch_op
+def randn_like(context, node):
+    inputs = _get_inputs(context, node, expected=6)
+    x = inputs[0]
+    shape = mb.shape(x=x)
+    rand_normal = mb.random_normal(shape=shape)
+    rand_fp32 = mb.cast(x=rand_normal, dtype="fp32", name=node.name)
+    context.add(rand_fp32)
 
 @register_torch_op
 def bitwise_not(context, node):

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -3825,21 +3825,21 @@ class TestRandn(TorchBaseTest):
 
 class TestRandnLike(TorchBaseTest):
     @pytest.mark.parametrize(
-        "compute_unit, backend, other",
+        "compute_unit, backend, shape",
         itertools.product(
             compute_units,
             backends,
-            [torch.randn(1,2,3), torch.randn(2, 3)],
+            [(1,), (2, 3)],
         ),
     )
-    def test_randn_like(self, compute_unit, backend, other):
+    def test_randn_like(self, compute_unit, backend, shape):
         class TestModel(nn.Module):
             def forward(self, x):
-                y = torch.randn_like(x)
+                y = torch.randn_like(torch.randn(shape))
                 return torch.Tensor([len(y)])
 
         self.run_compare_torch(
-            other, TestModel(), backend=backend, compute_unit=compute_unit
+            shape, TestModel(), backend=backend, compute_unit=compute_unit
         )
 
 

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -3803,6 +3803,46 @@ class TestRandint(TorchBaseTest):
         )
 
 
+class TestRandn(TorchBaseTest):
+    @pytest.mark.parametrize(
+        "compute_unit, backend, shape",
+        itertools.product(
+            compute_units,
+            backends,
+            [(1,), (2, 3)],
+        ),
+    )
+    def test_randn(self, compute_unit, backend, shape):
+        class TestModel(nn.Module):
+            def forward(self, x):
+                y = torch.randn(*x.shape)
+                return torch.Tensor([len(y)])
+
+        self.run_compare_torch(
+            shape, TestModel(), backend=backend, compute_unit=compute_unit
+        )
+
+
+class TestRandnLike(TorchBaseTest):
+    @pytest.mark.parametrize(
+        "compute_unit, backend, other",
+        itertools.product(
+            compute_units,
+            backends,
+            [torch.randn(1,2,3), torch.randn(2, 3)],
+        ),
+    )
+    def test_randn_like(self, compute_unit, backend, other):
+        class TestModel(nn.Module):
+            def forward(self, x):
+                y = torch.randn_like(x)
+                return torch.Tensor([len(y)])
+
+        self.run_compare_torch(
+            other, TestModel(), backend=backend, compute_unit=compute_unit
+        )
+
+
 class TestTypeAs(TorchBaseTest):
     @pytest.mark.parametrize(
         "compute_unit, backend, type",


### PR DESCRIPTION
Add `randn` and `randn_like` for torch frontend.
Fixes #788.