### PR TITLE
Add a GitHub Action to lint Python code with ruff

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,15 @@
+# https://beta.ruff.rs
+name: ruff
+on:
+  push:
+    branches: [main]
+  pull_request:
+  #  branches: [main]
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: pip install --user ruff
+    - run: ruff --exclude=deps --format=github --line-length=53386 --target-version=py37
+                --ignore=E101,E402,E71,E722,E731,E741,F401,F403,F632,F811,F821,F841 .

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -2,9 +2,9 @@
 name: ruff
 on:
   push:
-    branches: [main]
-  pull_request:
   #  branches: [main]
+  pull_request:
+    branches: [main]
 jobs:
   ruff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
[Ruff](https://beta.ruff.rs/) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) and can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), [pyupgrade](https://pypi.org/project/pyupgrade/), and [autoflake](https://pypi.org/project/autoflake/), all while executing (in Rust) tens or hundreds of times faster than any individual tool.

The ruff Action uses minimal steps to run in ~5 seconds, rapidly providing intuitive GitHub Annotations to contributors.

![image](https://user-images.githubusercontent.com/3709715/223758136-afc386d2-70aa-4eff-953a-2c2d82ceea23.png)