### PR TITLE
GitLab CI: Lint Python code with ruff instead of flake8

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,14 +10,15 @@ stages:
 ##
 #########################################################################
 
-check_python_flake8:
+check_python_ruff:
   tags:
     - macos12
   stage: check
   script:
     - python -m pip install --upgrade pip
-    - pip install flake8
-    - flake8 ./coremltools --count --select=E9,F5,F63,F7,F82 --show-source --statistics
+    - pip install ruff
+    - ruff --exclude=deps --line-length=53386 --target-version=py37 \
+           --ignore=E101,E402,E71,E722,E731,E741,F401,F403,F632,F811,F821,F841 .
 
 #########################################################################
 ##


### PR DESCRIPTION
Fixes #1834

[Ruff](https://beta.ruff.rs/) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) and can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), [pyupgrade](https://pypi.org/project/pyupgrade/), and [autoflake](https://pypi.org/project/autoflake/), all while executing (in Rust) tens or hundreds of times faster than any individual tool.

A [`--format=gitlab`](https://beta.ruff.rs/docs/settings/#format) option could be added but I do not have a way to test that to see how effective it is.