### PR TITLE
Make `convert` faster

### DIFF
--- a/milstoragepython/MilStorage.cpp
+++ b/milstoragepython/MilStorage.cpp
@@ -29,13 +29,13 @@ MilStoragePythonWriter::MilStoragePythonWriter(const std::string& filePath, bool
 namespace {
     template <typename T>
     u_int64_t writeData(MILBlob::Blob::StorageWriter& m_writer,
-                        const std::vector<T>& data) {
+                        const std::vector<const T>& data) {
         return m_writer.WriteData(MILBlob::Util::MakeSpan(data));
     }
 
     template <>
     u_int64_t writeData<uint16_t>(MILBlob::Blob::StorageWriter& m_writer,
-                                  const std::vector<uint16_t>& data) {
+                                  const std::vector<const uint16_t>& data) {
         auto intSpan = MILBlob::Util::MakeSpan(data);
         auto fpSpan = MILBlob::Util::SpanCast<const MILBlob::Fp16>(intSpan);
         return m_writer.WriteData(fpSpan);
@@ -45,19 +45,19 @@ namespace {
 // These methods are needed in addition to the above template methods
 // because pybind does not allow us to expose template methods to
 // Python with gcc on Linux.
-u_int64_t MilStoragePythonWriter::write_int8_data(const std::vector<int8_t>& data) {
+u_int64_t MilStoragePythonWriter::write_int8_data(const std::vector<const int8_t>& data) {
     return writeData<int8_t>(*m_writer, data);
 }
 
-u_int64_t MilStoragePythonWriter::write_uint8_data(const std::vector<uint8_t>& data) {
+u_int64_t MilStoragePythonWriter::write_uint8_data(const std::vector<const uint8_t>& data) {
     return writeData<uint8_t>(*m_writer, data);
 }
 
-u_int64_t MilStoragePythonWriter::write_fp16_data(const std::vector<uint16_t>& data) {
+u_int64_t MilStoragePythonWriter::write_fp16_data(const std::vector<const uint16_t>& data) {
     return writeData<uint16_t>(*m_writer, data);
 }
 
-u_int64_t MilStoragePythonWriter::write_float_data(const std::vector<float>& data) {
+u_int64_t MilStoragePythonWriter::write_float_data(const std::vector<const float>& data) {
     return writeData<float>(*m_writer, data);
 }
 

--- a/milstoragepython/MilStorage.hpp
+++ b/milstoragepython/MilStorage.hpp
@@ -30,10 +30,10 @@ namespace CoreML {
             MilStoragePythonWriter(const std::string& filePath, bool truncateFile);
             ~MilStoragePythonWriter();
 
-            u_int64_t write_int8_data(const std::vector<int8_t>& data);
-            u_int64_t write_uint8_data(const std::vector<uint8_t>& data);
-            u_int64_t write_fp16_data(const std::vector<uint16_t>& data);
-            u_int64_t write_float_data(const std::vector<float>& data);
+            u_int64_t write_int8_data(const std::vector<const int8_t>& data);
+            u_int64_t write_uint8_data(const std::vector<const uint8_t>& data);
+            u_int64_t write_fp16_data(const std::vector<const uint16_t>& data);
+            u_int64_t write_float_data(const std::vector<const float>& data);
 
         private:
             std::unique_ptr<MILBlob::Blob::StorageWriter> m_writer;

--- a/milstoragepython/MilStoragePython.cpp
+++ b/milstoragepython/MilStoragePython.cpp
@@ -32,11 +32,27 @@ PYBIND11_PLUGIN(libmilstoragepython) {
     py::module m("libmilstoragepython", "Library to create, access and edit CoreML blob files.");
 
     py::class_<MilStoragePythonWriter> blobStorageWriter(m, "_BlobStorageWriter");
-    blobStorageWriter.def(py::init<const std::string&, bool>(), py::arg("file_name"), py::arg("truncate_file") = true)
-      .def("write_int8_data", &MilStoragePythonWriter::write_int8_data)
-      .def("write_uint8_data", &MilStoragePythonWriter::write_uint8_data)
-      .def("write_fp16_data", &MilStoragePythonWriter::write_fp16_data)
-      .def("write_float_data", &MilStoragePythonWriter::write_float_data);
+    blobStorageWriter.def(py::init<const std::string &, bool>(), py::arg("file_name"), py::arg("truncate_file") = true)
+        .def("write_int8_data", [](MilStoragePythonWriter &w, py::buffer buf) {
+            auto info = buf.request();
+            std::vector<int8_t> data(static_cast<int8_t*>(info.ptr), static_cast<int8_t*>(info.ptr) + info.size);
+            return w.write_int8_data(data);
+        })
+        .def("write_uint8_data", [](MilStoragePythonWriter &w, py::buffer buf) {
+            auto info = buf.request();
+            std::vector<uint8_t> data(static_cast<uint8_t*>(info.ptr), static_cast<uint8_t*>(info.ptr) + info.size);
+            return w.write_uint8_data(data);
+        })
+        .def("write_fp16_data", [](MilStoragePythonWriter &w, py::buffer buf) {
+            auto info = buf.request();
+            std::vector<uint16_t> data(static_cast<uint16_t*>(info.ptr), static_cast<uint16_t*>(info.ptr) + info.size);
+            return w.write_fp16_data(data);
+        })
+        .def("write_float_data", [](MilStoragePythonWriter &w, py::buffer buf) {
+            auto info = buf.request();
+            std::vector<float> data(static_cast<float*>(info.ptr), static_cast<float*>(info.ptr) + info.size);
+            return w.write_float_data(data);
+        });
 
     py::class_<MilStoragePythonReader> blobStorageReader(m, "_BlobStorageReader");
     blobStorageReader.def(py::init<std::string>())

--- a/milstoragepython/MilStoragePython.cpp
+++ b/milstoragepython/MilStoragePython.cpp
@@ -35,22 +35,22 @@ PYBIND11_PLUGIN(libmilstoragepython) {
     blobStorageWriter.def(py::init<const std::string &, bool>(), py::arg("file_name"), py::arg("truncate_file") = true)
         .def("write_int8_data", [](MilStoragePythonWriter &w, py::buffer buf) {
             auto info = buf.request();
-            std::vector<int8_t> data(static_cast<int8_t*>(info.ptr), static_cast<int8_t*>(info.ptr) + info.size);
+            const std::vector<const int8_t> data(static_cast<int8_t*>(info.ptr), static_cast<int8_t*>(info.ptr) + info.size);
             return w.write_int8_data(data);
         })
         .def("write_uint8_data", [](MilStoragePythonWriter &w, py::buffer buf) {
             auto info = buf.request();
-            std::vector<uint8_t> data(static_cast<uint8_t*>(info.ptr), static_cast<uint8_t*>(info.ptr) + info.size);
+            const std::vector<const uint8_t> data(static_cast<uint8_t*>(info.ptr), static_cast<uint8_t*>(info.ptr) + info.size);
             return w.write_uint8_data(data);
         })
         .def("write_fp16_data", [](MilStoragePythonWriter &w, py::buffer buf) {
             auto info = buf.request();
-            std::vector<uint16_t> data(static_cast<uint16_t*>(info.ptr), static_cast<uint16_t*>(info.ptr) + info.size);
+            const std::vector<const uint16_t> data(static_cast<uint16_t*>(info.ptr), static_cast<uint16_t*>(info.ptr) + info.size);
             return w.write_fp16_data(data);
         })
         .def("write_float_data", [](MilStoragePythonWriter &w, py::buffer buf) {
             auto info = buf.request();
-            std::vector<float> data(static_cast<float*>(info.ptr), static_cast<float*>(info.ptr) + info.size);
+            const std::vector<const float> data(static_cast<float*>(info.ptr), static_cast<float*>(info.ptr) + info.size);
             return w.write_float_data(data);
         });
 


### PR DESCRIPTION
This avoids memory copies across the Python-C++ boundary when using `blob_writer`[^1]. That seems to speed up conversion noticeably e.g. converting gpt2-xl (1.5B) goes from ~3 minutes to ~1 minute on my M1 Max MBP

Caveat: my C++ and Pybind are rusty/non-existent so possible I’m totally missing something.

For testing, I’m not sure the best approach but the models I’ve converted seem functional. Is there a way to compare the weight.bin files? I tried comparing them by converting to text (using `od -An -tx1 -v gpt2.mlpackage`) and diffing them. With that approach, they’re not exactly the same: 1,746 lines of the 194,640,384 out are different.

I’m also curious if this reproduces on other machines or is a quirk of something in my setup.

[^1]: My original intent was to address high memory usage I saw in 6.2. Memory profiling pointed to `blob_writer`. That seems to be dramatically improved in 6.3 ([this array copy](https://github.com/apple/coremltools/commit/d9123f2d7e3be367d9a23a88eadb99512e079965#diff-8b970c330ad4504db7e273a3c687ddb094f880e56f77390d32d5192a68ab9db6R169) also came up when I was profiling). Either way, the speed up seems to still apply.