### PR TITLE
Docs - Model APIs and Graph Pass

### DIFF
--- a/docs/source/coremltools.models.rst
+++ b/docs/source/coremltools.models.rst
@@ -1,4 +1,4 @@
-Models
+Model APIs
 ==========================
 
 MLModel


### PR DESCRIPTION
This PR is for the public version `coremltools` (in github):

- Change [Models](https://apple.github.io/coremltools/source/coremltools.models.html#models) title to **Model APIs**.

- Edit `coremltools/coremltools/converters/mil/mil/passes/graph_pass.md` for grammar and subheadings.


This PR addresses the following tasks in [CoreMLTools Documentation Needs](https://quip-apple.com/bbuNAc6FgiMY):

- Change "Models" to "Model APIs" in GitHub coremltools.
- Edit `graph_pass.md` in GitHub coremltools.


Generated HTML supplied in a separate PR. Click [**Preview**](https://tonybove-apple.github.io/coremltools/).

Branch:
docs-model-apis-graph-pass
