### PR TITLE
Attempt to fix rank 0 shape in `torch.full`

### DIFF
--- a/coremltools/converters/mil/mil/ops/defs/iOS15/tensor_operation.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS15/tensor_operation.py
@@ -188,11 +188,12 @@ class fill(Operation):
     """
 
     input_spec = InputSpec(
-        shape=TensorInputType(type_domain=types.int32),
+        shape=TensorInputType(type_domain="S"),
         value=TensorInputType(const=True, optional=True, type_domain="T"),
     )
 
     type_domains = {
+        "S": (types.int32, types.fp32),
         "T": (types.fp16, types.fp32, types.int32, types.bool),
     }
 


### PR DESCRIPTION
This is a proof-of-concept fix for #1702, but there's probably a better solution.

It used to be possible to convert GPT-2 to Core ML a few months ago, but as noted by [@tdomhan](https://github.com/tdomhan), conversion ceased to be possible after the release of transformers 4.25.1. I've tracked the reason to [this transformers PR](https://github.com/huggingface/transformers/pull/20061/files), which uses `torch.full` with an empty shape as an efficient way to obtain a rank-0 tensor without CPU-GPU synchronization.

`coremltools` supports `torch.full` via [the `fill` Operation](https://github.com/apple/coremltools/blob/7f1916a962b296a31448f8c08d449bd352037a48/coremltools/converters/mil/mil/ops/defs/iOS15/tensor_operation.py#L167). **However**, and this is where the bug originates, the type of `shape` when using an empty shape is `<class 'coremltools.converters.mil.mil.types.type_double.make_float.<locals>.double'>`, which is not compatible with [its specification](https://github.com/apple/coremltools/blob/7f1916a962b296a31448f8c08d449bd352037a48/coremltools/converters/mil/mil/ops/defs/iOS15/tensor_operation.py#L191).

This PR addresses this symptom by accepting `float` in addition to `int` in the type specification.

A more principled solution would be to deal with empty shapes differently, but I'm not familiar enough with the codebase to propose something reasonable. Another alternative would be to create a special case [in `_make_fill_op`](https://github.com/apple/coremltools/blob/7f1916a962b296a31448f8c08d449bd352037a48/coremltools/converters/mil/frontend/torch/ops.py#L3593). Happy to work in any of those directions if they are preferable.
