### PR TITLE
Refactoring for arbitrary number operands for einsum

### DIFF
--- a/coremltools/converters/mil/frontend/_utils.py
+++ b/coremltools/converters/mil/frontend/_utils.py
@@ -294,15 +294,12 @@ def solve_sum_einsum(parsed_vectors, vars):
     return ret_parsed_vectors, vars
 
 
-def solve_generic_einsum(parsed_vectors, a_var, b_var, name):
+def solve_generic_einsum(parsed_vectors, vars, name) -> Var:
     """
     :param parsed_vectors: list[list[int]]
-    :param a_var:
-        - var
-        - first input variable
-    :param b_var:
-        - var
-        - second input variable
+    :param vars:
+        - list[var]
+        - input variables
     :param name:
         - str
         - name to be assigned to the output var
@@ -312,6 +309,12 @@ def solve_generic_einsum(parsed_vectors, a_var, b_var, name):
         - output var that contains the einsum result
     """
 
+    parsed_vectors, vars = solve_diagonal_einsum(parsed_vectors, vars)
+    parsed_vectors, vars = solve_sum_einsum(parsed_vectors, vars)
+    return solve_binary_generic_einsum(parsed_vectors, [vars[0], vars[1]], name)
+
+
+def solve_binary_generic_einsum(parsed_vectors, vars, name) -> Var:
     def _get_perm(src_axes, dst_axes):
         """
         :param src_axes: list[int]
@@ -328,8 +331,6 @@ def solve_generic_einsum(parsed_vectors, a_var, b_var, name):
                 return 1
         return mb.concat(values=dims, axis=0)
 
-    parsed_vectors, vars = solve_diagonal_einsum(parsed_vectors, [a_var, b_var])
-    parsed_vectors, vars = solve_sum_einsum(parsed_vectors, vars)
     a_var, b_var = vars
     a_axes, b_axes, out_axes = parsed_vectors
 

--- a/coremltools/converters/mil/mil/ops/defs/_utils.py
+++ b/coremltools/converters/mil/mil/ops/defs/_utils.py
@@ -298,7 +298,7 @@ def parse_einsum_equation(equation: str) -> List[List[str]]:
     # TODO: remove here if arbitrary number operands for einsum is supported.
     assert len(inputs) == 2, "unsupported einsum equation {}".format(equation)
 
-    inouts = inputs + [output_str]
+    in_outs = inputs + [output_str]
     map_char_to_int = {}
 
     def _update_vec(str, map_char_to_int, index):
@@ -311,12 +311,12 @@ def parse_einsum_equation(equation: str) -> List[List[str]]:
         return index, vec
 
     index = 0
-    inouts_vec = []
-    for inout_str in inouts:
+    in_outs_vec = []
+    for inout_str in in_outs:
         index, vec = _update_vec(inout_str, map_char_to_int, index)
-        inouts_vec.append(vec)
+        in_outs_vec.append(vec)
 
-    return inouts_vec
+    return in_outs_vec
 
 def compute_gather(params, indices, axis, batch_dims):
     """

--- a/coremltools/converters/mil/mil/ops/defs/_utils.py
+++ b/coremltools/converters/mil/mil/ops/defs/_utils.py
@@ -267,7 +267,7 @@ def spatial_dimensions_out_shape(
     return out_shape
 
 
-def parse_einsum_equation(equation: str) -> Tuple[List]:
+def parse_einsum_equation(equation: str) -> List[List[str]]:
     """
     Args
         equation : str
@@ -296,12 +296,9 @@ def parse_einsum_equation(equation: str) -> Tuple[List]:
 
     inputs = input_str.split(',')
     assert len(inputs) == 2, "unsupported einsum equation {}".format(equation)
-    input1_str = inputs[0]
-    input2_str = inputs[1]
 
-    input1_vec = [-1 for i in range(len(input1_str))]
-    input2_vec = [-1 for i in range(len(input2_str))]
-    output_vec = [-1 for i in range(len(output_str))]
+    inouts = inputs + [output_str]
+    inouts_vec = [[-1 for i in range(len(input_str))] for input_str in inouts]
     map_char_to_int = {}
 
     def _update_vec(str, vec, map_char_to_int, index):
@@ -312,11 +309,11 @@ def parse_einsum_equation(equation: str) -> Tuple[List]:
             vec[i] = map_char_to_int[s]
         return index
 
-    index = _update_vec(input1_str, input1_vec, map_char_to_int, 0)
-    index = _update_vec(input2_str, input2_vec, map_char_to_int, index)
-    _update_vec(output_str, output_vec, map_char_to_int, index)
+    index = 0
+    for inout_str, inout_vec in zip(inputs, inouts_vec):
+        index = _update_vec(input_str, inout_vec, map_char_to_int, index)
 
-    return input1_vec, input2_vec, output_vec
+    return inouts_vec
 
 def compute_gather(params, indices, axis, batch_dims):
     """

--- a/coremltools/converters/mil/mil/ops/defs/_utils.py
+++ b/coremltools/converters/mil/mil/ops/defs/_utils.py
@@ -298,20 +298,22 @@ def parse_einsum_equation(equation: str) -> List[List[str]]:
     assert len(inputs) == 2, "unsupported einsum equation {}".format(equation)
 
     inouts = inputs + [output_str]
-    inouts_vec = [[-1 for i in range(len(input_str))] for input_str in inouts]
     map_char_to_int = {}
 
-    def _update_vec(str, vec, map_char_to_int, index):
+    def _update_vec(str, map_char_to_int, index):
+        vec = []
         for i, s in enumerate(str):
             if s not in map_char_to_int:
                 map_char_to_int[s] = index
                 index += 1
-            vec[i] = map_char_to_int[s]
-        return index
+            vec.append(map_char_to_int[s])
+        return index, vec
 
     index = 0
-    for inout_str, inout_vec in zip(inputs, inouts_vec):
-        index = _update_vec(input_str, inout_vec, map_char_to_int, index)
+    inouts_vec = []
+    for inout_str in inouts:
+        index, vec = _update_vec(inout_str, map_char_to_int, index)
+        inouts_vec.append(vec)
 
     return inouts_vec
 

--- a/coremltools/converters/mil/mil/ops/defs/_utils.py
+++ b/coremltools/converters/mil/mil/ops/defs/_utils.py
@@ -295,6 +295,7 @@ def parse_einsum_equation(equation: str) -> List[List[str]]:
     output_str = input_output_str[1]
 
     inputs = input_str.split(',')
+    # TODO: remove here if arbitrary number operands for einsum is supported.
     assert len(inputs) == 2, "unsupported einsum equation {}".format(equation)
 
     inouts = inputs + [output_str]


### PR DESCRIPTION
I'm preparing for supporting arbitrary number operands for einsum.
This PR is to make it easier to implement.

Changes:
- `parse_einsum_equation` handles arbitrary number inputs
- extract `solve_binary_generic_einsum` from `solve_generic_einsum`.