### PR TITLE
not create new symbol with immutable shape convolution.

### DIFF
--- a/coremltools/converters/mil/mil/ops/defs/_utils.py
+++ b/coremltools/converters/mil/mil/ops/defs/_utils.py
@@ -252,7 +252,10 @@ def spatial_dimensions_out_shape(
         # * `effective_ks` (effective kernel size, determined from kernel size + dilations) cannot be symbolic
         # * strides cannot be symbolic
         if is_symbolic(input_shape[r]):
-            out_shape.append(get_new_symbol())
+            if not is_symbolic(pad[r]) and pad[r] - effective_ks[r] == -1 and strides[r] == 1:
+                out_shape.append(input_shape[r])
+            else:
+                out_shape.append(get_new_symbol())
         else:
             out_dim = 0
             if not ceil_mode:

--- a/coremltools/converters/mil/mil/ops/tests/test_utils.py
+++ b/coremltools/converters/mil/mil/ops/tests/test_utils.py
@@ -4,6 +4,7 @@
 #  found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
 import numpy as np
+from coremltools.converters.mil import get_new_symbol
 
 from coremltools.converters.mil.mil.ops.defs._utils import (
     aggregated_pad, effective_kernel, spatial_dimensions_out_shape)
@@ -260,3 +261,15 @@ class TestOutputShape:
 
         expected = [5, 5]
         np.testing.assert_equal(actual, expected)
+
+    def test_symbolic_custom_pad(self):
+        input_shape = (get_new_symbol(), get_new_symbol())
+        actual = spatial_dimensions_out_shape(
+            pad_type="custom",
+            input_shape=input_shape,
+            kernel_shape=(1, 1),
+            strides=(1, 1),
+            dilations=(1, 1),
+            custom_pad=(0, 0, 0, 0),
+        )
+        np.testing.assert_equal(actual, input_shape)


### PR DESCRIPTION
Resolve #1763 
If conv uses custom_pad and `pad[r] - effective_ks[r] == -1 and strides[r] == 1`, output_shape equals input_shape.
In this case we should not create new symbol for shape.

I confirmed flexible MultiHeadAttention works with this change.

```python
import torch  # 1.13.1
import numpy as np  # 1.22.3
import coremltools as ct  # 6.2

from ane_transformers.reference.multihead_attention import MultiHeadAttention

N = 10
x = torch.rand(1, 512, 1, N)
y = torch.rand(1, 512, 1, N)
z = torch.rand(1, 512, 1, N)

with torch.no_grad():
    layer = MultiHeadAttention(512, n_head=8, dropout=0.0).eval()
    jit = torch.jit.trace(layer, (x, y, z))

    # Flexible input shape - fails
    flexible_shape = ct.Shape(shape=(1, 512, 1, ct.RangeDim(1, 448)))
    mlmod_flexible_shape = ct.convert(
        jit,
        inputs=[
            ct.TensorType("q", flexible_shape),
            ct.TensorType("k", flexible_shape),
            ct.TensorType("v", flexible_shape),
        ]
    )

    out = layer(x, x, x)
    out_dict = mlmod_flexible_shape.predict({'q': x.detach().numpy().astype(np.float32),
                                             'k': x.detach().numpy().astype(np.float32),
                                             'v': x.detach().numpy().astype(np.float32)})
    np.allclose(out[0], out_dict['var_195'], rtol=0.001, atol=0.001)  # OK
```