### PR TITLE
add torch.unflatten

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -603,6 +603,25 @@ def reshape_as(context, node):
     context.add(result)
 
 
+@register_torch_op
+def unflatten(context, node):
+    x, dim_var, unflattened_size_var = _get_inputs(context, node, expected=3)
+    x_shape = x.shape
+    dim = dim_var.val
+    unflattened_size = tuple(unflattened_size_var.val)
+    assert x_shape is not None
+    assert dim is not None
+    assert unflattened_size is not None
+    assert x_shape[dim] == _np.prod(unflattened_size)
+
+    if dim < 0:
+        dim += x.rank
+
+    shape = x_shape[:dim] + unflattened_size + x_shape[dim + 1:]
+    y = mb.reshape(x=x, shape=shape, name=node.name)
+    context.add(y)
+
+
 def _array_construct(context, node, array_type):
     assert len(node.outputs) == 1
     inputs = _get_inputs(context, node)

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -4762,6 +4762,44 @@ class TestFlatten(TorchBaseTest):
         )
 
 
+class TestUnflatten(TorchBaseTest):
+    @pytest.mark.parametrize(
+        "compute_unit, backend, dim",
+        itertools.product(
+            compute_units,
+            backends,
+            (0, 1, -1, -2),
+        ),
+    )
+    def test_unflatten(self, compute_unit, backend, dim):
+        class Head(nn.Module):
+            def __init__(self, nhead, batch_size, input_size, output_size):
+                super(Head, self).__init__()
+                self.linear = nn.Linear(nhead * input_size, nhead * output_size)
+                unflatten_size = batch_size if dim == 0 or dim == -2 else output_size
+                self.unflatten = nn.Unflatten(dim, (nhead, unflatten_size))
+
+            def forward(self, x):
+                y = self.linear(x)
+                y_heads = self.unflatten(y)
+                return y_heads
+
+        NHEAD = 2
+        BATCH_SIZE = 3
+        INPUT_SIZE = 5
+        OUTPUT_SIZE = 7
+
+        model = Head(NHEAD, BATCH_SIZE, INPUT_SIZE, OUTPUT_SIZE)
+        model.eval()
+
+        self.run_compare_torch(
+            (NHEAD * BATCH_SIZE, NHEAD * INPUT_SIZE),
+            model,
+            backend=backend,
+            compute_unit=compute_unit,
+        )
+
+
 class TestGather(TorchBaseTest):
     @pytest.mark.parametrize(
         "compute_unit, backend, rank_and_axis",
@@ -9577,3 +9615,30 @@ class TestScaledDotProductAttention(TorchBaseTest):
             backend=backend,
             compute_unit=compute_unit,
         )
+
+
+class TestTransformer(TorchBaseTest):
+    @pytest.mark.parametrize(
+        "compute_unit, backend",
+        itertools.product(compute_units, backends),
+    )
+    def test_transformer_encoder(self, compute_unit, backend):
+        class TransformerEncoder(nn.Module):
+            def __init__(self, input_size, hidden_size, nhead=1, num_layers=1, dropout_rate=0.1):
+                super(TransformerEncoder, self).__init__()
+                encoder_layers = nn.TransformerEncoderLayer(
+                    d_model=input_size,
+                    nhead=nhead,
+                    dim_feedforward=hidden_size,
+                    dropout=dropout_rate,
+                )
+                self.transformer_encoder = nn.TransformerEncoder(encoder_layers, num_layers=num_layers)
+
+            def forward(self, x):
+                y = self.transformer_encoder(x)
+                return y
+
+        model = TransformerEncoder(32, 16, nhead=4, num_layers=2)
+        model.eval()
+
+        self.run_compare_torch((3, 32), model, backend=backend, compute_unit=compute_unit)


### PR DESCRIPTION
Add translation for `torch.unflatten`

Fix [issue 1868](https://github.com/apple/coremltools/issues/1868)

A unittest for `torch.nn.TransformerEncoderLayer` is also added, since it is claimed to suffer from the absence of `torch.unflatten`. Although I could not reproduce the failure of this layer, it is still good to expand test coverage.