### PR TITLE
Update CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,6 @@ stages:
   - check
   - build
   - test
-  - collect
 
 #########################################################################
 ##
@@ -12,12 +11,13 @@ stages:
 
 check_python_flake8:
   tags:
-    - macos12
+    - macOS13
   stage: check
   script:
     - python -m pip install --upgrade pip
     - pip install flake8
     - flake8 ./coremltools --count --select=E9,F5,F63,F7,F82 --show-source --statistics
+
 
 #########################################################################
 ##
@@ -26,8 +26,6 @@ check_python_flake8:
 #########################################################################
 
 .build_macos: &build_macos
-    tags:
-       - macos12
     stage: build
     script:
       - zsh -e scripts/build.sh --num-procs=4 --python=$PYTHON --dist
@@ -36,20 +34,27 @@ check_python_flake8:
       paths:
         - build/dist/
 
-build_wheel_macos_py37:
+build_wheel_macos_py37_intel:
   <<: *build_macos
+  tags:
+    - macOS13
   variables:
     PYTHON: "3.7"
 
-build_wheel_macos_py38:
+build_wheel_macos_py39_intel:
   <<: *build_macos
-  variables:
-    PYTHON: "3.8"
-
-build_wheel_macos_py39:
-  <<: *build_macos
+  tags:
+    - macOS13
   variables:
     PYTHON: "3.9"
+
+build_wheel_macos_py310:
+  <<: *build_macos
+  tags:
+    - macOS13_M1
+  variables:
+    PYTHON: "3.10"
+
 
 #########################################################################
 ##
@@ -63,65 +68,114 @@ build_wheel_macos_py39:
      - zsh -e scripts/test.sh --wheel-path=${WHEEL_PATH} --python=${PYTHON}
        --test-package=${TEST_PACKAGE} --requirements=${REQUIREMENTS} --fast
 
-test_py39_coremltools_test:
+test_py39_coremltools_test_intel:
   <<: *test_macos_pkg
   tags:
-    - macos12
+    - macOS13
   dependencies:
-    - build_wheel_macos_py39
+    - build_wheel_macos_py39_intel
   variables:
     WHEEL_PATH: build/dist/*cp39*10_15*
     TEST_PACKAGE: coremltools.test
     PYTHON: "3.9"
     REQUIREMENTS: reqs/test.pip
 
-test_py39_pytorch:
+test_py39_pytorch_intel:
   <<: *test_macos_pkg
   tags:
-    - macos12
+    - macOS13
   dependencies:
-    - build_wheel_macos_py39
+    - build_wheel_macos_py39_intel
   variables:
     PYTHON: "3.9"
     TEST_PACKAGE: coremltools.converters.mil.frontend.torch
     WHEEL_PATH: build/dist/*cp39*10_15*
     REQUIREMENTS: reqs/test.pip
 
-test_py37_tf1:
+test_py37_tf1_intel:
   <<: *test_macos_pkg
   tags:
-    - macos12
+    - macOS13
   dependencies:
-    - build_wheel_macos_py37
+    - build_wheel_macos_py37_intel
   variables:
     PYTHON: "3.7"
     TEST_PACKAGE: coremltools.converters.mil.frontend.tensorflow
     WHEEL_PATH: build/dist/*cp37*10_15*
     REQUIREMENTS: reqs/test_tf1.pip
 
-test_py39_tf2:
+test_py39_tf2_intel:
   <<: *test_macos_pkg
   tags:
-    - macos12
+    - macOS13
   dependencies:
-    - build_wheel_macos_py39
+    - build_wheel_macos_py39_intel
   variables:
     PYTHON: "3.9"
     TEST_PACKAGE: coremltools.converters.mil.frontend.tensorflow2
     WHEEL_PATH: build/dist/*cp39*10_15*
     REQUIREMENTS: reqs/test.pip
 
-test_py39_mil:
+test_py39_mil_intel:
   <<: *test_macos_pkg
   tags:
-    - macos12
+    - macOS13
   dependencies:
-    - build_wheel_macos_py39
+    - build_wheel_macos_py39_intel
   variables:
     PYTHON: "3.9"
     TEST_PACKAGE: coremltools.converters.mil.mil
     WHEEL_PATH: build/dist/*cp39*10_15*
     REQUIREMENTS: reqs/test.pip
+
+test_py10_coremltools_test:
+  <<: *test_macos_pkg
+  tags:
+    - macOS13_M1
+  dependencies:
+    - build_wheel_macos_py310
+  variables:
+    WHEEL_PATH: build/dist/*cp310*11*
+    TEST_PACKAGE: coremltools.test
+    PYTHON: "3.10"
+    REQUIREMENTS: reqs/test.pip
+
+test_py310_pytorch:
+  <<: *test_macos_pkg
+  tags:
+    - macOS13_M1
+  dependencies:
+    - build_wheel_macos_py310
+  variables:
+    PYTHON: "3.10"
+    TEST_PACKAGE: coremltools.converters.mil.frontend.torch
+    WHEEL_PATH: build/dist/*cp310*11*
+    REQUIREMENTS: reqs/test.pip
+
+test_py310_tf2:
+  <<: *test_macos_pkg
+  tags:
+    - macOS13_M1
+  dependencies:
+    - build_wheel_macos_py310
+  variables:
+    PYTHON: "3.10"
+    TEST_PACKAGE: coremltools.converters.mil.frontend.tensorflow2
+    WHEEL_PATH: build/dist/*cp310*11*
+    REQUIREMENTS: reqs/test.pip
+
+test_py310_mil:
+  <<: *test_macos_pkg
+  tags:
+    - macOS13_M1
+  dependencies:
+    - build_wheel_macos_py310
+  variables:
+    PYTHON: "3.10"
+    TEST_PACKAGE: coremltools.converters.mil.mil
+    WHEEL_PATH: build/dist/*cp310*11*
+    REQUIREMENTS: reqs/test.pip
+
 
 #########################################################################
 ##
@@ -130,13 +184,13 @@ test_py39_mil:
 #########################################################################
 build_documentation:
   tags:
-    - macos12
+    - macOS13
   stage: test
   script:
     - export PATH=$PATH:/opt/anaconda/bin/
     - bash -e scripts/build_docs.sh --wheel-path=${WHEEL_PATH} --python=${PYTHON}
   dependencies:
-    - build_wheel_macos_py39
+    - build_wheel_macos_py39_intel
   artifacts:
     when: always
     expire_in: 2 weeks
@@ -145,24 +199,3 @@ build_documentation:
   variables:
     WHEEL_PATH: build/dist/coremltools*cp39-none-macosx_10_15_x86_64.whl
     PYTHON: "3.9"
-
-#########################################################################
-##
-##                       Collect artifacts
-##
-#########################################################################
-collect_artifacts:
-  tags:
-    - macos12
-  stage: collect
-  script:
-    echo "Collect artifacts (wheels and documentation)"
-  dependencies:
-    - build_wheel_macos_py37
-    - build_wheel_macos_py38
-    - build_wheel_macos_py39
-    - build_documentation
-  artifacts:
-    expire_in: 2 weeks
-    paths:
-      - build/dist/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -128,7 +128,7 @@ test_py39_mil_intel:
     WHEEL_PATH: build/dist/*cp39*10_15*
     REQUIREMENTS: reqs/test.pip
 
-test_py10_coremltools_test:
+test_py310_coremltools_test:
   <<: *test_macos_pkg
   tags:
     - macOS13_M1

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -4563,7 +4563,7 @@ class TestEinsum(TorchBaseTest):
             def forward(self, x):
                 return torch.einsum(equation, x)
 
-        input_shapes, converter_input_type = gen_input_shapes_einsum(equation, dynamic)
+        input_shapes, converter_input_type = gen_input_shapes_einsum(equation, dynamic, backend)
         model = TestUnaryEinsum()
         self.run_compare_torch(
             input_shapes,
@@ -4588,7 +4588,7 @@ class TestEinsum(TorchBaseTest):
             def forward(self, x, y, z):
                 return torch.einsum(equation, x, y, z)
 
-        input_shapes, converter_input_type = gen_input_shapes_einsum(equation, dynamic)
+        input_shapes, converter_input_type = gen_input_shapes_einsum(equation, dynamic, backend)
         model = TestTernaryEinsum()
         self.run_compare_torch(
             input_shapes,


### PR DESCRIPTION
* Make recently added unit tests work with updated test utils.
* Change tags to macOS13.
* Add M1 jobs. Postfix `_intel` to old jobs.
* Remove unnecessary `Collect` stage.
* Remove unused Python 3.8 build.

CI Run:
https://gitlab.com/coremltools1/coremltools/-/pipelines/913911286