### PR TITLE
Changed example to reflect current file structure

### DIFF
--- a/coremltools/models/neural_network/builder.py
+++ b/coremltools/models/neural_network/builder.py
@@ -232,8 +232,10 @@ class NeuralNetworkBuilder:
     --------
     .. sourcecode:: python
 
-        from coremltools.models.neural_network import datatypes, NeuralNetworkBuilder
+        from coremltools.models import datatypes
+        from coremltools.models.neural_network import NeuralNetworkBuilder
         from coremltools.models.utils import save_spec
+
 
         # Create a neural network binary classifier that classifies
         # 3-dimensional data points

--- a/coremltools/models/neural_network/builder.py
+++ b/coremltools/models/neural_network/builder.py
@@ -236,7 +236,6 @@ class NeuralNetworkBuilder:
         from coremltools.models.neural_network import NeuralNetworkBuilder
         from coremltools.models.utils import save_spec
 
-
         # Create a neural network binary classifier that classifies
         # 3-dimensional data points
         # Specify input and output dimensions


### PR DESCRIPTION
Related to #1899, coremltools.models.neural_network.datatypes was not a valid location