### PR TITLE
Allow `mul` and `add` with bool inputs

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -3904,16 +3904,7 @@ def gelu(context, node):
     assert len(inputs) in (1, 2)
     if len(inputs) == 2:
         approximate = inputs[1].val
-        if approximate == "tanh":
-            approximate = "TANH_APPROXIMATION"
-        elif approximate == "sigmoid":
-            approximate = "SIGMOID_APPROXIMATION"
-        elif approximate == "none":
-            approximate = "EXACT"
-        else:
-            assert False
-    else:
-        approximate = None
+        assert approximate == 'none'
     res = mb.gelu(x=inputs[0], mode=approximate, name=node.name)
     context.add(res)
 

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -3905,7 +3905,7 @@ def gelu(context, node):
     if len(inputs) == 2:
         approximate = inputs[1].val
         assert approximate == 'none'
-    res = mb.gelu(x=inputs[0], mode=approximate, name=node.name)
+    res = mb.gelu(x=inputs[0], name=node.name)
     context.add(res)
 
 

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -3563,6 +3563,66 @@ class TestBitwiseNot(TorchBaseTest):
         )
 
 
+class TestBoolOps(TorchBaseTest):
+    def _get_inputs(self, input_types):
+        x_type, y_type = input_types
+        if x_type == "int":
+            x = torch.tensor([1, 0, 1, 0], dtype=torch.int32)
+        elif x_type == "bool":
+            x = torch.tensor([1, 0, 1, 0], dtype=torch.bool)
+        if y_type == "int":
+            y = torch.tensor([0, 0, 1, 1], dtype=torch.int32)
+        elif y_type == "bool":
+            y = torch.tensor([0, 0, 1, 1], dtype=torch.bool)
+        return (x, y)
+    
+    @pytest.mark.parametrize(
+        "compute_unit, backend, input_types",
+        itertools.product(
+            compute_units,
+            backends,
+            [("int", "int"), ("int", "bool"), ("bool", "int"), ("bool", "bool")],
+        ),
+    )
+    def test_mul_int_or_bool(self, compute_unit, backend, input_types):
+        class TestMulWithBool(nn.Module):
+            def forward(self, x, y):
+                return x * y
+
+        x, y = self._get_inputs(input_types)
+        model = TestMulWithBool()
+        self.run_compare_torch(
+            (x, y),
+            model,
+            backend=backend,
+            compute_unit=compute_unit,
+            input_as_shape=False,
+        )
+
+    @pytest.mark.parametrize(
+        "compute_unit, backend, input_types",
+        itertools.product(
+            compute_units,
+            backends,
+            [("int", "int"), ("int", "bool"), ("bool", "int"), ("bool", "bool")],
+        ),
+    )
+    def test_add_int_or_bool(self, compute_unit, backend, input_types):
+        class TestAddWithBool(nn.Module):
+            def forward(self, x, y):
+                return x + y
+
+        x, y = self._get_inputs(input_types)
+        model = TestAddWithBool()
+        self.run_compare_torch(
+            (x, y),
+            model,
+            backend=backend,
+            compute_unit=compute_unit,
+            input_as_shape=False,
+        )
+
+
 class TestFull(TorchBaseTest):
     @pytest.mark.parametrize(
         "compute_unit, backend, rank",


### PR DESCRIPTION
`mul` and `add` currently allow one of the inputs to be `bool`, by promoting to the type of the other input. However, they fail if both inputs are `bool`.

This is not the case with PyTorch, which interprets `*` on two boolean inputs as a logical `and`, and `+` as a logical `or`. This PR adopts the same convention.

The use of bool tensors is frequent to represent masks. For example, `gpt_bigcode` models in the transformers library, such as the StarCoder coding assistants, cannot be converted to Core ML because the following operation is performed on two boolean inputs: https://github.com/huggingface/transformers/blob/33aafc26ee68df65c7d9457259fc3d59f79eef4f/src/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py#L604-L606

The tests show that two `bool` inputs are now supported. Without the changes to the frontend ops, the same tests succeed for `int` and `bool` operands, but fail when both of them are `bool`.