### PR TITLE
Allow gelu approximations

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -3896,15 +3896,14 @@ def hardsigmoid(context, node):
 def gelu(context, node):
     inputs = _get_inputs(context, node)
     assert len(inputs) in (1, 2)
+    mode = None
     if len(inputs) == 2:
         approximate = inputs[1].val
         if approximate == "tanh":
-            approximate = "TANH_APPROXIMATION"
-        elif approximate == "none":
-            approximate = "EXACT"
-    else:
-        approximate = None
-    res = mb.gelu(x=inputs[0], mode=approximate, name=node.name)
+            mode = "TANH_APPROXIMATION"
+        else:
+            assert approximate == "none"
+    res = mb.gelu(x=inputs[0], mode=mode, name=node.name)
     context.add(res)
 
 

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -3898,8 +3898,15 @@ def gelu(context, node):
     assert len(inputs) in (1, 2)
     if len(inputs) == 2:
         approximate = inputs[1].val
-        assert approximate == 'none'
-    res = mb.gelu(x=inputs[0], name=node.name)
+        if approximate == "tanh":
+            approximate = "TANH_APPROXIMATION"
+        elif approximate == "sigmoid":
+            approximate = "SIGMOID_APPROXIMATION"
+        elif approximate == "none":
+            approximate = "EXACT"
+    else:
+        approximate = None
+    res = mb.gelu(x=inputs[0], mode=approximate, name=node.name)
     context.add(res)
 
 

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -3900,8 +3900,6 @@ def gelu(context, node):
         approximate = inputs[1].val
         if approximate == "tanh":
             approximate = "TANH_APPROXIMATION"
-        elif approximate == "sigmoid":
-            approximate = "SIGMOID_APPROXIMATION"
         elif approximate == "none":
             approximate = "EXACT"
     else:

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -4982,11 +4982,11 @@ class TestActivation(TorchBaseTest):
         )
 
     @pytest.mark.parametrize(
-        "compute_unit, backend, shape",
-        itertools.product(compute_units, backends, COMMON_SHAPES_ALL),
+        "compute_unit, backend, shape, approximate",
+        itertools.product(compute_units, backends, COMMON_SHAPES_ALL, ["none", "tanh"]),
     )
-    def test_gelu(self, compute_unit, backend, shape):
-        model = nn.GELU().eval()
+    def test_gelu(self, compute_unit, backend, shape, approximate):
+        model = nn.GELU(approximate=approximate).eval()
         self.run_compare_torch(shape, model, backend=backend, compute_unit=compute_unit)
 
     @pytest.mark.parametrize(

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -4983,10 +4983,11 @@ class TestActivation(TorchBaseTest):
 
     @pytest.mark.parametrize(
         "compute_unit, backend, shape, approximate",
-        itertools.product(compute_units, backends, COMMON_SHAPES_ALL, ["none", "tanh"]),
+        itertools.product(compute_units, backends, COMMON_SHAPES_ALL, ["none", "tanh", None]),
     )
     def test_gelu(self, compute_unit, backend, shape, approximate):
-        model = nn.GELU(approximate=approximate).eval()
+        model = nn.GELU() if approximate is None else nn.GELU(approximate=approximate)
+        model = model.eval()
         self.run_compare_torch(shape, model, backend=backend, compute_unit=compute_unit)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
The [MIL gelu implementation](https://apple.github.io/coremltools/source/coremltools.converters.mil.mil.ops.defs.html#coremltools.converters.mil.mil.ops.defs.iOS15.activation.gelu) accepts tanh or sigmoid approximations, but the frontend asserts that no approximation is requested.

This PR allows the supported approximations to be specified. `tanh` approximation is used in [models such as the ones with the `gpt_bigcode` architecture](https://github.com/huggingface/transformers/blob/33aafc26ee68df65c7d9457259fc3d59f79eef4f/src/transformers/models/gpt_bigcode/configuration_gpt_bigcode.py#L54-L56), so conversion can now proceed by applying the same approximation. 