### PR TITLE
masked_fill: fill value type must match tensor type

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -27,6 +27,7 @@ from coremltools.converters.mil.mil.ops.defs._utils import (
 )
 from coremltools.converters.mil.mil.types import is_bool, nptype_from_builtin
 from coremltools.converters.mil.mil.types.symbolic import any_symbolic, is_symbolic
+from coremltools.converters.mil.mil.types.type_mapping import builtin_to_string
 from coremltools.converters.mil.mil.var import ListVar, Var
 
 from .._utils import build_einsum_mil, value_at
@@ -4240,6 +4241,9 @@ def masked_fill(context, node):
     if not types.is_bool(mask.dtype):
         # cond must be bool type
         mask = mb.cast(x=mask, dtype="bool")
+
+    if value.dtype != x.dtype:
+        value = mb.cast(x=value, dtype=builtin_to_string(x.dtype))
 
     res = mb.select(cond=mask, a=value, b=x, name=node.name)
     context.add(res)

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -7945,14 +7945,17 @@ class TestMaskedFill(TorchBaseTest):
     def test_masked_fill(self, compute_unit, backend, dtype, value):
         SHAPE = (2, 3)
         MASK = torch.bernoulli(torch.rand(SHAPE[-1])).to(torch.bool)
+        inputs = self._get_inputs(SHAPE, dtype)
 
         model = ModuleWrapper(torch.masked_fill, {"mask": MASK, "value": value})
-        inputs = self._get_inputs(SHAPE, dtype)
+        expected_results = model(inputs)
+
         TorchBaseTest.run_compare_torch(
             inputs,
             model,
             backend=backend,
             compute_unit=compute_unit,
+            expected_results=expected_results,
             input_as_shape=False,
         )
 

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -7927,15 +7927,18 @@ class TestPad(TorchBaseTest):
 
 class TestMaskedFill(TorchBaseTest):
     @pytest.mark.parametrize(
-        "compute_unit, backend",
-        itertools.product(compute_units, backends),
+        "compute_unit, backend, value",
+        itertools.product(
+            compute_units,
+            backends,
+            [10.0, 0],
+        ),
     )
-    def test_masked_fill(self, compute_unit, backend):
+    def test_masked_fill(self, compute_unit, backend, value):
         SHAPE = (2, 3)
         MASK = torch.bernoulli(torch.rand(SHAPE[-1])).to(torch.bool)
-        VALUE = 10.0
 
-        model = ModuleWrapper(torch.masked_fill, {"mask": MASK, "value": VALUE})
+        model = ModuleWrapper(torch.masked_fill, {"mask": MASK, "value": value})
 
         TorchBaseTest.run_compare_torch(
             SHAPE,


### PR DESCRIPTION
`masked_fill` in PyTorch accepts a fill value specified as an `int` (`0`, for instance), even if the tensor to fill contains floats. The coremltools `select` op requires both inputs to have the same type, and conversion fails in this particular case. This PR tries to ensure that the fill value matches the tensor dtype.

For additional context, causal language models in the `transformers` library recently started using `masked_fill` to prepare the causal attention masks. Since version 4.30.0, many models contain code such as the following:

https://github.com/huggingface/transformers/blob/main/src/transformers/models/clip/modeling_clip.py#L687

Note the use of `0` as fill value, which causes conversion to fail for all these models because it's interpreted as an `int` during conversion. Current workarounds include pinning transformers to a previous version (see [here](https://github.com/apple/ml-stable-diffusion/blob/b61c9aea05370d4bc06fce2dc00a002b21f13da5/requirements.txt#L4), for example). It's also unfortunate that the transformers function that uses this code is not a method (https://github.com/huggingface/transformers/blob/5bb4430edc7df9f9950d412d98bbe505cc4d328b/src/transformers/models/clip/modeling_clip.py#L678), so patching cannot be easily applied.

In summary, this change makes the `masked_fill` frontend op more similar to PyTorch's, facilitates conversion of transformers models and unlocks the use of the current version of `transformers`, which will be required for new models being added to the library.

For testing coverage, I simply adapted the existing unit test to use `0` in addition to `10.0`.