### PR TITLE
Docs - Add Link to Previous API Version (Draft)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,6 +39,4 @@ This document is the API Reference for coremltools. For guides, installation ins
    :caption: Previous API Versions:
 
    v3.4 <https://apple.github.io/coremltools/docs-api-version3/>
-   v4.0 <https://apple.github.io/coremltools/docs-api-version4/>
-   v6.3 <https://apple.github.io/coremltools/docs-api-version6/>
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,13 +23,22 @@ This document is the API Reference for coremltools. For guides, installation ins
    source/coremltools.converters.mil.mil.passes.defs.rst
    source/coremltools.optimize.rst
 
-* :ref:`genindex`
-* :ref:`modindex`
-
 .. toctree::
    :maxdepth: 1
    :caption: Resources
 
    Guides and examples <https://coremltools.readme.io/docs>
    Core ML Format Specification <https://apple.github.io/coremltools/mlmodel/index.html>
-   GitHub <https://github.com/apple/coremltools>
+   API GitHub <https://github.com/apple/coremltools>
+
+* :ref:`genindex`
+* :ref:`modindex`
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Previous API Versions:
+
+   v3.4 <https://apple.github.io/coremltools/docs-api-version3/>
+   v4.0 <https://apple.github.io/coremltools/docs-api-version4/>
+   v6.3 <https://apple.github.io/coremltools/docs-api-version6/>
+


### PR DESCRIPTION
This draft PR is for the GitHub-hosted public version of `coremltools`. 

It adds a link on the front page to the reference guide for a previous API version, v3.4, which was previously copied into `gh-pages` as the folder `docs-api-version3` at the HTML root.

This demonstrates how we could list older versions on the main page. It is a "manual versioning" method that links to another folder containing a complete Sphinx-generated version. This will eventually be a list of previous API versions, including 6.3 and 4.1. I did this first one to see if we really want this form of versioning. Please comment if you want to do this, or not. Thanks!

```
modified:   docs/index.rst
```

Branch:
docs-add-links-to-versions

[**Preview on my fork**](https://tonybove-apple.github.io/coremltools/)

**Screenshot:**

<img width="1308" alt="Screenshot 2023-07-20 at 1 16 56 PM" src="https://github.com/apple/coremltools/assets/70229264/1745a2d6-f505-47b2-a7d1-ab7e78f420f0">
