### PR TITLE
Fix GroupNorm dynamic input

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -1828,23 +1828,16 @@ def group_norm(context, node):
     bias = inputs[3]
     eps = inputs[4]
     n,c = x.shape[0],x.shape[1] # at minimum (N, C) required
-    input_shape = [*x.shape] # n, c, *
     num_groups = builtins.min(num_groups,c)
     new_shape = [n, num_groups, c//num_groups]
+    # optimization for non symbolic shapes. This get rids of 3 mil ops that required on dynamic shapes
     if not any_symbolic(x.shape[2:]):
         new_shape += [*x.shape[2:]] # adds remaining dims
+        input_shape = [*x.shape] # n, c, *
     else:
-        # Create the new_shape and input_shape to support dynamic sizes.
-        xshape = mb.shape(x=x)
-        for i, v in enumerate(x.shape[2:]):
-            if is_symbolic(v):
-                si = mb.gather(x=xshape, indices=i+2, axis=0)
-                new_shape.append(si)
-                input_shape[i+2] = si
-            else:
-                new_shape.append(v)
-        new_shape = mb.concat(values=new_shape, axis=0)
-        input_shape = mb.concat(values=input_shape, axis=0)
+        input_shape = mb.shape(x=x)
+        input_shape_sliced = mb.slice_by_size(x=input_shape, begin=[2], size=[-1]) # x_shape[2:]
+        new_shape = mb.concat(values=[new_shape, input_shape_sliced], axis=0)
 
     num_extra_axes = len(x.shape[2:])
     axes_ = [int(i) for i in range(2, 2 + num_extra_axes + 1)]


### PR DESCRIPTION
Fixes #1303 for GroupNorm only.

Added a test case for this issue. Without this patch the test fails with
```
cls = <class 'coremltools.converters.mil.mil.builder.Builder'>, val = [6, 1, 1, is28, is29], name = 'reshape_14_shape', before_op = None

    @classmethod
    def _add_const(cls, val, name, before_op):
        if not is_python_value(val):
>           raise ValueError("Cannot add const {}".format(val))
E           ValueError: Cannot add const [6, 1, 1, is28, is29]

coremltools/converters/mil/mil/builder.py:76: ValueError
```