### PR TITLE
Add support for int32 beta in torch.baddbmm

### DIFF
--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -8400,14 +8400,15 @@ class TestDuplicateOutputTensors(TorchBaseTest):
 
 class TestBaddbmm(TorchBaseTest):
     @pytest.mark.parametrize(
-        "compute_unit, backend, shapes",
+        "compute_unit, backend, shapes, beta",
         itertools.product(
             compute_units,
             backends,
             [(2, 4, 6, 8), (4, 12, 6, 16)],
+            [0.0, 0.5, 1.0, 2],
         ),
     )
-    def test_baddbmm(self, compute_unit, backend, shapes):
+    def test_baddbmm(self, compute_unit, backend, shapes, beta):
         B, N, M, P = shapes
 
         # input shape: any shape broadcastable to (B, N, P)
@@ -8421,7 +8422,7 @@ class TestBaddbmm(TorchBaseTest):
                 self.batch2 = torch.randn(B, M, P)
 
             def forward(self, x):
-                return torch.baddbmm(x, self.batch1, self.batch2)
+                return torch.baddbmm(x, self.batch1, self.batch2, beta=beta)
 
         model = BaddbmmModel()
         # Makes it broadcastable to (B, N, P).


### PR DESCRIPTION
This is in particular relevant to convert `torch.baddbmm` as used for StableDiffusion in https://github.com/huggingface/diffusers/blob/v0.8.1/src/diffusers/models/attention.py#L315