### PR TITLE
Docs - Update API Reference to Version 7.0b2

### DIFF
--- a/coremltools/converters/_converters_entry.py
+++ b/coremltools/converters/_converters_entry.py
@@ -252,7 +252,7 @@ def convert(
                                            coremltools.target.tvOS15:
 
         - If neither the ``minimum_deployment_target`` nor the ``convert_to``
-          parameter is specified, the converter produces the ML programs
+          parameter is specified, the converter produces an ML program
           model type with as minimum of a deployment target as possible.
         - If this parameter is specified and ``convert_to`` is also specified,
           they must be compatible. The following are examples of invalid values:

--- a/coremltools/converters/mil/mil/ops/defs/iOS15/elementwise_unary.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS15/elementwise_unary.py
@@ -605,7 +605,7 @@ class sign(elementwise_unary_with_int):
     """
     Return the sign value of the input ``x``, element-wise.
 
-    All elements in the output will be either ``-1``. or ``1``.
+    All elements in the output will be either ``-1`` or ``1``, or zero if the input ``x`` is zero.
 
     Parameters
     ----------

--- a/coremltools/converters/mil/mil/ops/defs/iOS17/elementwise_unary.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS17/elementwise_unary.py
@@ -96,7 +96,8 @@ class clip(_clip_iOS15):
 class inverse(_inverse_iOS15):
     """
     Return the reciprocal value of the input ``x``, element-wise.
-    The only difference from IOS15 is epsilon may have different dtypes than the inputs/outputs.
+    The only difference between this version and the iOS 15 :py:class:`~.iOS15.elementwise_unary.inverse`
+    is ``epsilon`` may have different dtypes than the inputs/outputs.
 
     Parameters
     ----------
@@ -132,7 +133,8 @@ class inverse(_inverse_iOS15):
 class log(_log_iOS15):
     """
     Return the natural logarithm value of the input ``x``, element-wise.
-    The only difference from IOS15 is epsilon may have different dtypes than the inputs/outputs.
+    The only difference between this version and the iOS 15 :py:class:`~.iOS15.elementwise_unary.log`
+    is ``epsilon`` may have different dtypes than the inputs/outputs.
 
     Parameters
     ----------
@@ -167,7 +169,8 @@ class log(_log_iOS15):
 class rsqrt(_rsqrt_iOS15):
     """
     Return the reciprocal value of the square root of the input ``x``, element-wise.
-    The only difference from IOS15 is epsilon may have different dtypes than the inputs/outputs.
+    The only difference between this version and the iOS 15 :py:class:`~.iOS15.elementwise_unary.rsqrt`
+    is ``epsilon`` may have different dtypes than the inputs/outputs.
 
     Parameters
     ----------

--- a/coremltools/converters/mil/mil/ops/defs/iOS17/image_resizing.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS17/image_resizing.py
@@ -223,19 +223,24 @@ class resample(_resample_iOS16):
 class resize(Operation):
     """
     Resizes the input tensor ``x`` by choosing the right-most ``resized_dims`` dimensions from
-    the input shape ``shape``, and by choosing the rest from ``x``'s shape.
+    the input shape ``shape``, and by choosing the rest from ``x`` 's shape.
 
-    This iOS17 ``resize`` is a superset of ``resize_bilinear`` and ``resize_nearest_neighbor`` in
-    iOS15. The main benefit is that this resize op allows a use-case in dynamic tensor shapes where
+    This iOS17 ``resize`` is a superset of iOS 15 :py:class:`~.iOS15.image_resizing.resize_bilinear`
+    and :py:class:`~.iOS15.image_resizing.resize_nearest_neighbor`.
+    The main benefit is that this resize op allows a use-case in dynamic tensor shapes where
     a tensor needs to be resized to a dynamic shape as specified by another tensor.
 
-    To illustrate how output shape is inferred, here are two examples.
-    - Example #1
+    To illustrate how output shape is inferred, the following are two examples:
+
+    - Example #1::
+
         x.shape: [1, 2, 3, 4]
         shape: [1, 6, 8]
         resized_dims: 2
         The output's shape will be [1, 2, 6, 8]
-    - Example #2
+
+    - Example #2::
+
         x.shape: [1, 2, 3, is0]
         shape: [1, 0, 0]
         resized_dims: 2
@@ -246,13 +251,13 @@ class resize(Operation):
     x: tensor<[...], T> (Required)
 
     shape: tensor<[K], U> (Required)
-        * Restriction: ``size(shape)`` <= ``rank(x)``
-        * If shape[i]==0, the dimension in the output tensor will instead be inferred from the
-          corresponding element of x.shape().  Note this might not be x.shape()[i], as size(shape),
-          resized_dims, and size(x) may all be different sizes.
+        * Restriction: ``size(shape)`` <= ``rank(x)``.
+        * If ``shape[i]==0``, the dimension in the output tensor will instead be inferred from the
+          corresponding element of ``x.shape()``.  Note this might not be ``x.shape()[i]``, as ``size(shape)``,
+          ``resized_dims``, and ``size(x)`` may all be different sizes.
 
     resized_dims: const tensor<[], uint32> (Required)
-        * Restriction: ``resized_dims`` <= ``size(shape)``
+        * Restriction: ``resized_dims`` <= ``size(shape)``.
 
     interpolation_mode: const<str> (Optional, default="LINEAR")
         * Available mode: ``LINEAR``, ``NEAREST_NEIGHBOR``.

--- a/coremltools/models/neural_network/builder.py
+++ b/coremltools/models/neural_network/builder.py
@@ -230,7 +230,9 @@ class NeuralNetworkBuilder:
 
     Examples
     --------
+
     .. sourcecode:: python
+
         import numpy as np
 
         from coremltools.models import datatypes

--- a/coremltools/optimize/coreml/_post_training_quantization.py
+++ b/coremltools/optimize/coreml/_post_training_quantization.py
@@ -354,26 +354,24 @@ def decompress_weights(mlmodel: _MLModel):
 
 def get_weights_metadata(mlmodel: _MLModel, weight_threshold: int = 2048):
     """
-    Utility function to get the weights metadata as a dictionary, which map the weight's name to its corresponding CoreMLWeightMetaData.
+    Utility function to get the weights metadata as a dictionary, which maps the weight's name to its corresponding CoreMLWeightMetaData.
 
     CoreMLWeightMetaData contains the following attributes:
 
-    1. val: The weight data.
-    2. sparsity: the percentile of the element whose absolute value ``<= 1e-12``.
-    3. unique_values: number of unique values in the weight.
-    4. child_ops: meta information of the child ops in which the weight is feeding into.
+    1. ``val``: The weight data.
+    2. ``sparsity``: the percentile of the element whose absolute value ``<= 1e-12``.
+    3. ``unique_values``: number of unique values in the weight.
+    4. ``child_ops``: meta information of the child ops in which the weight is feeding into.
 
     Parameters
     ----------
     mlmodel: MLModel
-        Model in which the weight meta data retrieved from.
+        Model in which the weight metadata is retrieved from.
 
     weight_threshold: int
-        The size threshold, above which weights are returned.
-        That is, a weight tensor is included in the resulting dictionary only if its total number of elements are greater than ``weight_threshold``.
-
-        For example, if ``weight_threshold = 1024`` and a weight tensor is of shape ``[10, 20, 1, 1]``, hence ``200``
-        elements, it will not be returned by the ``get_weights_metadata`` API.
+        * The size threshold, above which weights are returned. That is, a weight tensor is included in the resulting dictionary only if its total number of elements are greater than ``weight_threshold``.
+          For example, if ``weight_threshold = 1024`` and a weight tensor is of shape ``[10, 20, 1, 1]``, hence ``200``
+          elements, it will not be returned by the ``get_weights_metadata`` API.
 
         * If not provided, it will be set to ``2048``, in which weights bigger than ``2048`` elements are returned.
 
@@ -384,10 +382,10 @@ def get_weights_metadata(mlmodel: _MLModel, weight_threshold: int = 2048):
 
     Examples
     --------
-    In this example, there are two weights whose size is greater than ``2048``.
+    In this example, there are two weights whose sizes are greater than ``2048``.
     A weight named ``conv_1_weight`` is feeding into a ``conv`` op named ``conv_1``,
     while another weight named ``linear_1_weight`` is feeding into a ``linear`` op named ``linear_1``.
-    You can access the metadata by ``weight_metadata_dict["conv_1_weight"]``, etc.
+    You can access the metadata by ``weight_metadata_dict["conv_1_weight"]``, and so on.
 
     .. sourcecode:: python
 
@@ -502,7 +500,7 @@ class CoreMLOpMetaData:
     Parameters
     ----------
     op_type: str
-        The type of the op. For instance: ``conv``, ``linear``, etc.
+        The type of the op. For instance: ``conv``, ``linear``, and so on.
 
     name: str
         The name of the op.
@@ -547,19 +545,19 @@ class CoreMLWeightMetaData:
         The weight data.
 
     sparsity: float
-        the percentile of the element whose absolute value ``<= 1e-12``
+        The percentile of the element whose absolute value ``<= 1e-12``.
 
     unique_values: int
-        number of unique values in the weight
+        Number of unique values in the weight.
 
     child_ops: list[CoreMLOpMetaData]
-        A list of of ``CoreMLOpMetaData`` which contains information of child ops in which the weight is feeding into.
+        A list of ``CoreMLOpMetaData`` which contains information of child ops in which the weight is feeding into.
 
         The attributes can be accessed by:
-        ``child_ops[idx].op_type``: The operation type of the ``idx``th child op.
-        ``child_ops[idx].name``: The name of the ``idx``th child op.
+        ``child_ops[idx].op_type``: The operation type of the ``idx`` 'th child op.
+        ``child_ops[idx].name``: The name of the ``idx`` 'th child op.
 
-        Other op-dependant attributes also can be accessed. For instance, if ``idx``th child op is a ``conv`` layer,
+        Other op-dependant attributes also can be accessed. For instance, if ``idx`` 'th child op is a ``conv`` layer,
         ``child_ops[idx].weight`` will return its weight name.
 
         For more details, please refer to the ``CoreMLOpMetaData`` doc string.

--- a/docs/source/coremltools.converters.mil.mil.ops.defs.rst
+++ b/docs/source/coremltools.converters.mil.mil.ops.defs.rst
@@ -74,10 +74,18 @@ control\_flow
    .. autoclass:: list_gather
    .. autoclass:: list_scatter
 
-conv
+conv (iOS 15+)
 ---------------------------------------------------
 
 .. automodule:: coremltools.converters.mil.mil.ops.defs.iOS15.conv
+
+   .. autoclass:: conv
+   .. autoclass:: conv_transpose
+
+conv (iOS 17+)
+---------------------------------------------------
+
+.. automodule:: coremltools.converters.mil.mil.ops.defs.iOS17.conv
 
    .. autoclass:: conv
    .. autoclass:: conv_transpose
@@ -146,6 +154,9 @@ elementwise\_unary (iOS 17+)
 
    .. autoclass:: cast
    .. autoclass:: clip
+   .. autoclass:: inverse
+   .. autoclass:: log
+   .. autoclass:: rsqrt
 
 image\_resizing (iOS 15+)
 --------------------------------------------------------------
@@ -176,8 +187,10 @@ image\_resizing (iOS 17+)
 .. automodule:: coremltools.converters.mil.mil.ops.defs.iOS17.image_resizing
 
    .. autoclass:: crop_resize
+   .. autoclass:: resample
+   .. autoclass:: resize
 
-linear
+linear (iOS 15+)
 -----------------------------------------------------
 
 .. automodule:: coremltools.converters.mil.mil.ops.defs.iOS15.linear
@@ -186,10 +199,29 @@ linear
    .. autoclass:: linear
    .. autoclass:: matmul
 
-normalization
+linear (iOS 17+)
+-----------------------------------------------------
+
+.. automodule:: coremltools.converters.mil.mil.ops.defs.iOS17.linear
+
+   .. autoclass:: linear
+   .. autoclass:: matmul
+
+normalization (iOS 15+)
 ------------------------------------------------------------
 
 .. automodule:: coremltools.converters.mil.mil.ops.defs.iOS15.normalization
+
+   .. autoclass:: batch_norm
+   .. autoclass:: instance_norm
+   .. autoclass:: l2_norm
+   .. autoclass:: layer_norm
+   .. autoclass:: local_response_norm
+
+normalization (iOS 17+)
+------------------------------------------------------------
+
+.. automodule:: coremltools.converters.mil.mil.ops.defs.iOS17.normalization
 
    .. autoclass:: batch_norm
    .. autoclass:: instance_norm
@@ -224,10 +256,19 @@ random
    .. autoclass:: random_normal
    .. autoclass:: random_uniform
 
-recurrent
+recurrent (iOS 15+)
 --------------------------------------------------------
 
 .. automodule:: coremltools.converters.mil.mil.ops.defs.iOS15.recurrent
+
+   .. autoclass:: gru
+   .. autoclass:: lstm
+   .. autoclass:: rnn
+
+recurrent (iOS 17+)
+--------------------------------------------------------
+
+.. automodule:: coremltools.converters.mil.mil.ops.defs.iOS17.recurrent
 
    .. autoclass:: gru
    .. autoclass:: lstm
@@ -343,9 +384,9 @@ tensor\_transformation (iOS 15)
    .. autoclass:: reverse_sequence
    .. autoclass:: slice_by_index
    .. autoclass:: slice_by_size
+   .. autoclass:: sliding_windows
    .. autoclass:: space_to_depth
    .. autoclass:: squeeze
-   .. autoclass:: sliding_windows
    .. autoclass:: transpose
 
 tensor\_transformation (iOS 16+)
@@ -361,5 +402,14 @@ tensor\_transformation (iOS 17+)
 
 .. automodule:: coremltools.converters.mil.mil.ops.defs.iOS17.tensor_transformation
 
+   .. autoclass:: expand_dims
    .. autoclass:: reshape
+   .. autoclass:: reshape_like
+   .. autoclass:: reverse
+   .. autoclass:: reverse_sequence
+   .. autoclass:: slice_by_index
+   .. autoclass:: slice_by_size
+   .. autoclass:: sliding_windows
+   .. autoclass:: squeeze
+   .. autoclass:: transpose
 

--- a/docs/source/coremltools.optimize.torch.examples.rst
+++ b/docs/source/coremltools.optimize.torch.examples.rst
@@ -1,5 +1,5 @@
 Training-Time Compression Examples
-=====================
+==================================
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
This PR is for the GitHub-hosted public version of `coremltools`. 

It updates the following source file docstrings for typos and grammar and formatting errors:

```
	modified:   coremltools/converters/_converters_entry.py
	modified:   coremltools/converters/mil/mil/ops/defs/iOS17/elementwise_unary.py
	modified:   coremltools/converters/mil/mil/ops/defs/iOS17/image_resizing.py
	modified:   coremltools/models/neural_network/builder.py
	modified:   coremltools/optimize/coreml/_post_training_quantization.py
	modified:   docs/source/coremltools.optimize.torch.examples.rst
```

The PR modifies the following to accommodate new ops in the navigation:

```
	modified:   docs/source/coremltools.converters.mil.mil.ops.defs.rst
```

The PR also includes a fix for the following radar: [Doc-Incorrect documentation for iOS15+ mil.sign](rdar://113219464)
(rdar://113219464).

```
	modified:   coremltools/converters/mil/mil/ops/defs/iOS15/elementwise_unary.py
```

Branch:
docs-update-api-ref-to-vers-7.0b2


---

**Preview**:

https://tonybove-apple.github.io/coremltools/

