### PR TITLE
Docs - Add Previous Versions of API Docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,8 @@ import pathlib
 project = 'coremltools API Reference'
 copyright = '2021, Apple Inc'
 author = 'Apple Inc'
-
+release = '7.0'
+version = '7.0'
 
 # -- General configuration ---------------------------------------------------
 
@@ -62,6 +63,10 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # a list of builtin themes.
 #
 html_theme = 'sphinx_rtd_theme'
+
+html_theme_options = {
+    'display_version': True
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ coremltools API
 .. image:: logo.png
    :alt: Core ML Tools logo
 
-This document is the API Reference for coremltools. For guides, installation instructions, and examples, see `Guides <https://coremltools.readme.io/docs>`_.
+This document is the API Reference for Core ML Tools (``coremltools``). For guides, installation instructions, and examples, see the `Guide <https://coremltools.readme.io/docs>`_.
 
 .. toctree::
    :maxdepth: 1
@@ -30,6 +30,8 @@ This document is the API Reference for coremltools. For guides, installation ins
    :maxdepth: 1
    :caption: Resources
 
-   Guides and examples <https://coremltools.readme.io/docs>
+   Guide and Examples <https://coremltools.readme.io/docs>
    Core ML Format Specification <https://apple.github.io/coremltools/mlmodel/index.html>
+   source/api-versions.rst
    GitHub <https://github.com/apple/coremltools>
+

--- a/docs/source/api-versions.rst
+++ b/docs/source/api-versions.rst
@@ -1,0 +1,9 @@
+Previous Versions
+=================
+
+.. toctree::
+   :maxdepth: 1
+
+   coremltools v3.4 <https://apple.github.io/coremltools/v3.4/index.html>
+   coremltools v4.1 <https://apple.github.io/coremltools/v4.1/index.html>
+   coremltools v6.3 <https://apple.github.io/coremltools/v6.3/index.html>


### PR DESCRIPTION
This PR is for the GitHub-hosted public version of `coremltools`. 

The PR:

- Adds **Previous Versions** to the navigation menu under Resources (`index.rst`), with links to the previously-generated HTML content for previous versions of the API: v3.4, v4.1, and v6.3. Another PR, already merged, adds the folders `v3.4`, `v4.1`, and `v6.3` to the `gh-pages` branch so that these links work.

- Makes edits to the `index.rst` file.

- Adds version number (7.0) to the top left header. This automatically changes when we change `version` in `conf.py`.

Branch:
docs-add-previous-vers-of-api-docs

[**Click for Preview**](https://apple.github.io/coremltools/source/api-versions.html)

