### PR TITLE
Docs-Guides - Add Index Entries for Index

### DIFF
--- a/docs-guides/index.rst
+++ b/docs-guides/index.rst
@@ -15,6 +15,8 @@ Core ML Tools
 
 This guide includes instructions and examples. For details about using the API classes and methods, see the `coremltools API Reference <https://apple.github.io/coremltools/index.html>`_.
 
+:ref:`genindex`  |  :ref:`search`
+
 --------------
 
 .. toctree::
@@ -78,10 +80,4 @@ This guide includes instructions and examples. For details about using the API c
    source/model-prediction.md
    source/updatable-model-examples.rst
 
-
-Index
------
-
-* :ref:`genindex`
-* :ref:`search`
 

--- a/docs-guides/source/classifiers.md
+++ b/docs-guides/source/classifiers.md
@@ -1,3 +1,8 @@
+```{eval-rst}
+.. index::
+    single: classifier; preview and produce
+```
+
 # Classifiers
 
 A [classifier](https://deepai.org/machine-learning-glossary-and-terms/classifier) is a special kind of [Core ML](https://developer.apple.com/documentation/coreml) model that provides a class label and class name to a probability dictionary as outputs. This topic describes the steps to produce a classifier model using the [Unified Conversion API](unified-conversion-api) by using the [ClassifierConfig](https://apple.github.io/coremltools/source/coremltools.converters.mil.input_types.html#classifierconfig) class.
@@ -46,6 +51,11 @@ To produce a classifier model, follow these steps:
 	)
 	```
 
+```{eval-rst}
+.. index::
+    single: PIL
+```
+
 3. Use PIL to load and resize the image to the expected size:
     
 	```python
@@ -69,4 +79,8 @@ To produce a classifier model, follow these steps:
 All Core ML models use the Core ML framework and its APIs. However, with image input models you can also use the [Vision Classifier Observation API](https://developer.apple.com/documentation/vision/vnclassificationobservation), which provides image analysis and additional convenience features for preprocessing images.
 ```
 
+```{eval-rst}
+.. index::
+    single: Vision Classifier Observation API
+```
 

--- a/docs-guides/source/comparing-ml-programs-and-neural-networks.md
+++ b/docs-guides/source/comparing-ml-programs-and-neural-networks.md
@@ -1,3 +1,10 @@
+```{eval-rst}
+.. index::
+    single: ML program; compared to neural network
+    single: neural network; compared to ML program
+```
+
+
 # Comparing ML Programs and Neural Networks
 
 As ML models evolve in sophistication and complexity, their [representations](#model-representations) are also evolving to describe how they work. _ML programs_ are models that are represented as operations in code. The ML program model type is the foundation for future Core ML improvements.
@@ -11,6 +18,15 @@ A few of the major the differences between a neural network and an ML program ar
 | Intermediate tensor type implicit | Intermediate tensor type explicit |
 | Limited control over precision | More granular control over precision |
 
+
+```{eval-rst}
+.. index:: 
+	single: typed execution
+	single: GPU runtime
+	single: Metal Performance Shaders Graph framework
+	single: compiling an ML program
+	single: ML program; compiling
+```
 
 ## ML Program Benefits
 
@@ -41,6 +57,10 @@ There are several ways to represent a deep learning model. At a foundational lev
 :class: imgnoborder
 
 Three ways to represent a deep learning model.
+```
+
+```{eval-rst}
+.. index:: Core ML NeuralNetwork
 ```
 
 To express a neural network, the mathematical descriptions are often abstracted into a _computational graph_, which is a more concise and scalable representation (as shown in the center of the previous figure). A computational graph is a directed graph in which computational layers connect to each other — the input feeds into the _source_ layers and undergoes a series of mathematical transformations to generate the outputs through the _sink_ layers. 
@@ -91,6 +111,9 @@ While the new ML program model type supports most of the functionality supported
     
     ML programs currently support both float 16 and float 32 typed weights and activations.
 
+```{eval-rst}
+.. index:: MIL, Model Intermediate Language
+```
 
 ## ML Programs and MIL
 

--- a/docs-guides/source/composite-operators.md
+++ b/docs-guides/source/composite-operators.md
@@ -1,3 +1,8 @@
+```{eval-rst}
+.. index::
+    single: composite operators
+```
+
 # Composite Operators
 
 As machine learning continually evolves, new operations are regularly added to source frameworks such as [TensorFlow](https://www.tensorflow.org/) and [PyTorch](https://pytorch.org/). While converting a model to [Core ML](https://developer.apple.com/documentation/coreml), you may encounter an unsupported operation.
@@ -41,6 +46,11 @@ You may need to first install [Transformers](https://huggingface.co/transformers
 
 ![Not-implemented error](images/not-implemented-error.png)
 
+
+```{eval-rst}
+.. index::
+    single: MIL operators
+```
 
 ## Decompose into Existing MIL Operators
 

--- a/docs-guides/source/convert-a-tensorflow-1-deepspeech-model.md
+++ b/docs-guides/source/convert-a-tensorflow-1-deepspeech-model.md
@@ -1,3 +1,9 @@
+```{eval-rst}
+.. index:: 
+    single: TensorFlow 1; convert DeepSpeech model
+```
+
+
 # Converting a TensorFlow 1 DeepSpeech Model
 
 The following example explores the automatic handling of flexible shapes and other related capabilities of the Core ML Tools converter. It uses an [automatic speech recognition](https://en.wikipedia.org/wiki/Speech_recognition#End-to-end_automatic_speech_recognition) (ASR) task in which the input is a speech audio file and the output is the text transcription of it.

--- a/docs-guides/source/convert-a-tensorflow-1-image-classifier.md
+++ b/docs-guides/source/convert-a-tensorflow-1-image-classifier.md
@@ -1,3 +1,11 @@
+```{eval-rst}
+.. index:: 
+    single: TensorFlow 1; convert image classifier
+    single: classifier; convert TensorFlow 1
+    single: classifier; image
+```
+
+
 # Converting a TensorFlow 1 Image Classifier
 
 The following example converts the TensorFlow Inception V1 image classifier to a Core ML neural network classifier model that directly predicts the class label of the input image. It demonstrates the importance of setting the image preprocessing parameters correctly to get the right results.

--- a/docs-guides/source/convert-a-torchvision-model-from-pytorch.md
+++ b/docs-guides/source/convert-a-torchvision-model-from-pytorch.md
@@ -1,3 +1,9 @@
+```{eval-rst}
+.. index:: 
+    single: PyTorch; convert torchvision model
+    single: torchvision model
+```
+
 # Converting a torchvision Model from PyTorch
 
 The following example shows how to convert into Core ML a [MobileNetV2](https://pytorch.org/hub/pytorch_vision_mobilenet_v2/) model trained using PyTorch. MobileNet is a type of convolutional neural network designed for mobile and embedded vision applications. 
@@ -68,6 +74,13 @@ class_labels = urllib.request.urlopen(label_url).read().decode("utf-8").splitlin
 class_labels = class_labels[1:] # remove the first class which is background
 assert len(class_labels) == 1000
 ```
+
+```{eval-rst}
+.. index:: 
+    single: PyTorch; preprocess image input
+    single: preprocessing for images
+```
+
 
 ## Preprocess the Image Input for torchvision Models
 
@@ -140,6 +153,10 @@ Right-click the following image and save it as `daisy.jpg` in the same folder as
 Right-click this image and save it as `daisy.jpg` in the same folder as your Python project.
 ```
 
+```{eval-rst}
+.. index:: 
+    single: protobuf spec
+```
 
 ## Get the protobuf spec
 
@@ -152,6 +169,11 @@ for out in spec.description.output:
     if out.type.WhichOneof('Type') == "dictionaryType":
         coreml_dict_name = out.name
         break
+```
+
+```{eval-rst}
+.. index:: 
+    single: PyTorch; make prediction
 ```
 
 ## Make a Core ML Prediction
@@ -185,6 +207,7 @@ class name: daisy, raw score value: 15.690682411193848
 class name: vase, raw score value: 8.516773223876953
 class name: ant, raw score value: 8.169312477111816
 ```
+
 
 ## Make a PyTorch Prediction and Compare
 

--- a/docs-guides/source/convert-nlp-model.md
+++ b/docs-guides/source/convert-nlp-model.md
@@ -1,5 +1,11 @@
 # Converting a Natural Language Processing Model
 
+```
+.. index:: 
+    single: PyTorch; combine tracing and scripting
+    single: PyTorch; convert natural language proocessing model
+```
+
 The following example demonstrates how you can combine [model tracing](model-tracing) and [model scripting](model-scripting) in order to properly convert a model that includes a data-dependent control flow, such as a loop or conditional. 
 
 ```{warning}

--- a/docs-guides/source/convert-pytorch-workflow.md
+++ b/docs-guides/source/convert-pytorch-workflow.md
@@ -1,3 +1,10 @@
+```{eval-rst}
+.. index:: 
+    single: PyTorch; convert workflow
+    single: Torchscript
+```
+
+
 # PyTorch Conversion Workflow
 
 ```{admonition} Minimum Deployment Target

--- a/docs-guides/source/convert-tensorflow-2-bert-transformer-models.md
+++ b/docs-guides/source/convert-tensorflow-2-bert-transformer-models.md
@@ -1,3 +1,9 @@
+```{eval-rst}
+.. index:: 
+    single: TensorFlow 2; convert BERT Transformer Models
+```
+
+
 # Converting TensorFlow 2 BERT Transformer Models
 
 The following examples demonstrate converting TensorFlow 2 models to Core ML using Core ML Tools.

--- a/docs-guides/source/convert-to-ml-program.md
+++ b/docs-guides/source/convert-to-ml-program.md
@@ -1,3 +1,9 @@
+```{eval-rst}
+.. index::
+    pair: ML program; convert to
+```
+
+
 # Convert Models to ML Programs
 
 This section describes the `ML program` model type. It is an evolution of the neural network model type that has been available since the first version of Core ML. 
@@ -19,6 +25,12 @@ model = ct.convert(source_model)
 ```
 
 The above example produces an `mlprogram` with an `iOS15`/`macOS12` deployment target (or newer). You can override this behavior by providing a `minimum_deployment_target` value, such as `minimum_deployment_target=target.iOS14` or older.
+
+```{eval-rst}
+.. index:: 
+   single: precision type
+   single: ML program; precision type
+```
 
 ## Set the ML Program Precision
 
@@ -43,6 +55,13 @@ For details on ML program precision, see [Typed Execution](typed-execution).
 ```{admonition} Float 16 Default
 
 For ML programs, Core ML Tools version 5.0b3 and newer produces a model with float 16 precision by default (previous beta versions produced float 32 by default). You can override the default precision by using the `compute_precision` parameter of [`coremltools.convert()`](https://apple.github.io/coremltools/source/coremltools.converters.convert.html#coremltools.converters._converters_entry.convert).
+```
+
+```{eval-rst}
+.. index:: 
+   single: model package
+   single: ML program; save as model package
+   single: save a model package
 ```
 
 ## Save ML Programs as Model Packages

--- a/docs-guides/source/convert-to-neural-network.md
+++ b/docs-guides/source/convert-to-neural-network.md
@@ -1,3 +1,9 @@
+```{eval-rst}
+.. index::
+    pair: neural network; convert to
+```
+
+
 # Convert Models to Neural Networks
 
 With versions of Core ML Tools older than 7.0b2, if you didn't specify the model type, or your `minimum_deployment_target` was a version older than iOS15, macOS12, watchOS8, or tvOS15, the model was converted by default to a neural network.

--- a/docs-guides/source/converting-compressed-source-models.md
+++ b/docs-guides/source/converting-compressed-source-models.md
@@ -1,3 +1,8 @@
+```{eval-rst}
+.. index:: 
+    single: convert compressed models
+```
+
 # Converting Compressed Source Models
 
 This section shows how you can indicate to the converter to use the sparse or palettized representations to store the weights. This is required when you bring in a source model whose weights are compressed but still represented in dense `float`format.  This is the case for PyTorch models that are updated and fine-tuned using the [`ct.optimize.torch`](optimizetorch-api-overview) APIs.  

--- a/docs-guides/source/custom-operators.md
+++ b/docs-guides/source/custom-operators.md
@@ -1,3 +1,8 @@
+```{eval-rst}
+.. index::
+    single: custom operators
+```
+
 # Custom Operators
 
 While converting a model to [Core ML](https://developer.apple.com/documentation/coreml), you may encounter an unsupported operation that can't be represented by a [composite operator](composite-operators).

--- a/docs-guides/source/data-dependent-pruning.md
+++ b/docs-guides/source/data-dependent-pruning.md
@@ -1,3 +1,9 @@
+```{eval-rst}
+.. index:: 
+    single: pruning; training-time
+    single: MagnitudePruner
+```
+
 # Training-Time Pruning
 
 The [Training-Time Pruning](https://apple.github.io/coremltools/source/coremltools.optimize.torch.pruning.html#training-time-pruning) API in `coremltools.optimize.torch` builds on top of the [BasePruningMethod](https://pytorch.org/docs/stable/generated/torch.nn.utils.prune.BasePruningMethod.html) API in PyTorch and extends it to:

--- a/docs-guides/source/data-dependent-quantization.md
+++ b/docs-guides/source/data-dependent-quantization.md
@@ -1,3 +1,11 @@
+```{eval-rst}
+.. index:: 
+    single: quantization; training-time
+    single: PyTorch; quantization APIs
+    single: quantization; PyTorch APIs
+    single: LinearQuantizer
+```
+
 # Training-Time Quantization
 
 The [`LinearQuantizer`](https://apple.github.io/coremltools/source/coremltools.optimize.torch.quantization.html#coremltools.optimize.torch.quantization.LinearQuantizer) class implements training-time quantization, also known as quantization-aware training (QAT) as described in the paper [Quantization and Training of Neural Networks for Efficient Integer-Arithmetic-Only Inference](https://arxiv.org/pdf/1712.05877.pdf). [`LinearQuantizer`](https://apple.github.io/coremltools/source/coremltools.optimize.torch.quantization.html#coremltools.optimize.torch.quantization.LinearQuantizer) quantizes both weights and activations, whereas [Post-Training Quantization](data-free-quantization) quantizes only the weights.

--- a/docs-guides/source/data-free-quantization.md
+++ b/docs-guides/source/data-free-quantization.md
@@ -1,3 +1,9 @@
+```{eval-rst}
+.. index:: 
+    single: quantization; post-training
+    single: linear_quantize_weights, OpLinearQuantizerConfig
+```
+
 # Post-Training Quantization
 
 You can linearly quantize the weights of your Core ML model by using the [`linear_quantize_weights`](https://apple.github.io/coremltools/source/coremltools.optimize.coreml.post_training_quantization.html#coremltools.optimize.coreml.linear_quantize_weights) method as follows: 

--- a/docs-guides/source/flexible-inputs.md
+++ b/docs-guides/source/flexible-inputs.md
@@ -1,3 +1,10 @@
+```{eval-rst}
+.. index::
+    single: input shapes
+    single: flexible input shapes
+    single: shapes
+```
+
 # Flexible Input Shapes
 
 While some neural network models accept only fixed-size input, such as an image with a resolution of 224 x 224 pixels, other models require flexible input shapes that are determined at runtime. Examples are language models that work on arbitrary input lengths, and style transfer models that work on multiple resolutions. 
@@ -7,6 +14,11 @@ When converting a model to Core ML using Core ML Tools, you can specify a fixed 
 - [Select from predetermined shapes](#select-from-predetermined-shapes) to limit the input to selected shapes, optimizing performance.
 - [Set a bounded range for each dimension](#set-the-range-for-each-dimension) to define the minimum and maximum for more dynamic shapes. Using a bounded range provides more opportunity for the runtime compiler to make optimizations, which is harder with an unbounded range. 
 - [Enable unbounded ranges](#enable-unbounded-ranges), if necessary, for maximum flexibility.
+
+```{eval-rst}
+.. index::
+    single: enumerated shapes
+```
 
 ## Select From Predetermined Shapes
 
@@ -81,6 +93,11 @@ Core ML preallocates the memory for the default shape, so the first prediction w
 ```{admonition} Enumerated Shapes with Multi-input Models
 
 For a multi-input model, only one of the inputs can be marked with `EnumeratedShapes`; the rest must have fixed single shapes. If you require multiple inputs to be flexible, set the range for each dimension.
+```
+
+```{eval-rst}
+.. index::
+    single: RangeDim
 ```
 
 ## Set the Range for Each Dimension

--- a/docs-guides/source/graph-passes-intro.md
+++ b/docs-guides/source/graph-passes-intro.md
@@ -1,3 +1,9 @@
+```{eval-rst}
+.. index::
+    single: graph passes
+    single: pass_pipeline
+```
+
 # Graph Passes
 
 During conversion, Core ML Tools optimizes the model by applying graph transformations, called _graph passes_, which simplify and canonicalize the representation for a more efficient execution by the Core ML runtime. 

--- a/docs-guides/source/image-inputs.md
+++ b/docs-guides/source/image-inputs.md
@@ -1,3 +1,10 @@
+```{eval-rst}
+.. index:: 
+    single: images; input and output
+    single: MLMultiArray
+    single: ImageType
+```
+
 # Image Input and Output
 
 The Core ML Tools [Unified Conversion API](unified-conversion-api) generates by default a Core ML model with a multidimensional array ([`MLMultiArray`](https://developer.apple.com/documentation/coreml/mlmultiarray)) as the type for input and output. If your model uses images for input, you can instead specify  [`ImageType`](https://apple.github.io/coremltools/source/coremltools.converters.mil.input_types.html#coremltools.converters.mil.input_types.ImageType) for the input. Starting in coremltools version 6, you can also specify `ImageType` for the output.
@@ -239,6 +246,12 @@ Click the **Stylized** button in the preview:
 
 The Xcode preview verifies that the converted model transforms any JPEG image.
 
+```{eval-rst}
+.. index::
+    single: images; set the scalar type
+    single: scalar type for ImageType
+```
+
 ## Set the Scalar Type
 
 For an [`ImageType`](https://apple.github.io/coremltools/source/coremltools.converters.mil.input_types.html#imagetype), Core ML supports 8-bit grayscale and 32-bit color images with 8 bits per component. For an [`MLMultiarray`](https://developer.apple.com/documentation/coreml/mlmultiarray), Core ML supports int 32, double, and float 32 as the scalar types. Starting in iOS 16 and macOS 13, you can also use OneComponent16Half Grayscale images and float 16 multiarrays for inputs and outputs. 
@@ -271,6 +284,12 @@ mlmodel = ct.convert(keras_model,
 ```
 
 If `dtype` is missing, the `TensorType` defaults to float 32.
+
+```{eval-rst}
+.. index::
+    single: images; preprocessing
+    single: preprocessing for images
+```
 
 ## Add Image Preprocessing Options
 

--- a/docs-guides/source/introductory-quickstart.md
+++ b/docs-guides/source/introductory-quickstart.md
@@ -66,6 +66,11 @@ Now that the model is loaded and the class labels are collected, you can convert
 Before converting the model, a good practice for improving device performance is to know in advance the types and shapes, and to consider the model's interface, including the names and types of inputs and outputs. For this example, the application is an image classifier, and therefore the model's input is an `ImageType` of a specified size. When using inputs of an `ImageType`, it is also important to find out how the model expects its input to be preprocessed or normalized.
 ```
 
+```{eval-rst}
+.. index:: 
+    single: ML program; convert image classifier
+```
+
 ## Convert the Model
 
 Use the following code to convert the model to Core ML with an image as the input, and the class labels baked into the model:
@@ -120,6 +125,13 @@ model = ct.convert(
 ```{admonition} ML Programs vs. Neural Networks
 
 To learn the differences between the newer ML Program model type and the neural network model type, see [Comparing ML Programs and Neural Networks](comparing-ml-programs-and-neural-networks).
+```
+
+```{eval-rst}
+.. index:: 
+    single: metadata; TensorFlow model
+    single: TensorFlow; set model metadata
+    single: ML program; set model metadata
 ```
 
 ## Set the Model Metadata
@@ -187,6 +199,12 @@ print(out_dict["classLabel"])
 You may find differences between predictions on macOS and your target platform (such as iOS or watchOS), so you still need to verify on your target platform. For more information on using the predict API, see [Model Prediction](model-prediction).
 ```
 
+```{eval-rst}
+.. index:: 
+    single: ML program; save and load
+    single: model package
+```
+
 ## Save and Load the Model
 
 With the converted [ML program](convert-to-ml-program) model in memory, you can save the model into the [Core ML model package](convert-to-ml-program.md#save-ml-programs-as-model-packages) format by specifying `.mlpackage` with the `save()` method. You can then load the model into another session:
@@ -206,6 +224,12 @@ model.save("MobileNetV2.mlmodel")
                   
 # Load the saved model
 loaded_model = ct.models.MLModel("MobileNetV2.mlmodel")
+```
+
+```{eval-rst}
+.. index:: 
+    single: ML program; use with Xcode
+    single: Xcode; open model
 ```
 
 ## Use the Model with Xcode

--- a/docs-guides/source/libsvm-conversion.md
+++ b/docs-guides/source/libsvm-conversion.md
@@ -1,3 +1,8 @@
+```{eval-rst}
+.. index:: 
+    single: LibSVM
+```
+
 # LibSVM
 
 You can convert a [LibSVM](https://www.csie.ntu.edu.tw/~cjlin/libsvm/) model to the Core ML format using [`libsvm.convert()`](https://apple.github.io/coremltools/source/coremltools.converters.libsvm.html#coremltools.converters.libsvm._libsvm_converter.convert):

--- a/docs-guides/source/load-and-convert-model.md
+++ b/docs-guides/source/load-and-convert-model.md
@@ -1,3 +1,10 @@
+```{eval-rst}
+.. index::
+    single: convert to; workflow
+```
+
+
+
 # Load and Convert Model Workflow
  
 The typical conversion process with the [Unified Conversion API](convert-learning-models) is to load the model to infer its type, and then use the [`convert()`](https://apple.github.io/coremltools/source/coremltools.converters.convert.html#module-coremltools.converters._converters_entry) method to convert it to the Core ML format. Follow these steps:
@@ -64,6 +71,12 @@ For more information, see the [MLModel Overview](mlmodel).
 The [`convert()`](https://apple.github.io/coremltools/source/coremltools.converters.convert.html#module-coremltools.converters._converters_entry) method tries to infer as much as possible from the source network, but some information may not be present, such as input names, types, shapes, and classifier options. For more information see [Conversion Options](conversion-options).
 ```
 
+```{eval-rst}
+.. index:: 
+    single: TensorFlow; convert from
+```
+
+
 ## Convert From TensorFlow 2
 
 TensorFlow 2 models are typically exported as `tf.Model` objects in the SavedModel or HDF5 file formats. For additional TensorFlow formats you can convert, see [TensorFlow 2 Workflow](tensorflow-2).
@@ -116,6 +129,11 @@ mlmodel = ct.convert("mobilenet_v2_1.0_224_frozen.pb",
                     inputs=[ct.TensorType(shape=(1, 224, 224, 3))])
 ```
 
+```{eval-rst}
+.. index:: 
+    single: PyTorch; convert from
+```
+
 ## Convert from PyTorch
 
 You can convert PyTorch models that are either traced or in already the TorchScript format. For example, you can convert a model obtained using [PyTorch's save and load APIs](https://pytorch.org/tutorials/beginner/saving_loading_models.html) to Core ML using the same Unified Conversion API as the previous example:
@@ -138,6 +156,12 @@ mlmodel = ct.convert("torchvision_mobilenet_v2.pt",
 ```
 
 For more details on tracing and scripting to produce PyTorch models for conversion, see [Converting from PyTorch](convert-pytorch).
+
+```{eval-rst}
+.. index:: 
+    single: compute units
+    single: ML program; compute units
+```
 
 
 ## Set the Compute Units

--- a/docs-guides/source/mlmodel-utilities.md
+++ b/docs-guides/source/mlmodel-utilities.md
@@ -1,3 +1,10 @@
+```{eval-rst}
+.. index:: 
+    single: MLModel; utilities
+    single: rename a feature
+```
+
+
 # MLModel Utilities
 
 The following are useful utilities for processing `MLModel` objects. To learn more about MLModel, see [MLModel Overview](mlmodel). For the full list of utilities, see the [API Reference](https://apple.github.io/coremltools/source/coremltools.models.html#module-coremltools.models.utils).

--- a/docs-guides/source/mlmodel.md
+++ b/docs-guides/source/mlmodel.md
@@ -1,3 +1,10 @@
+
+```{eval-rst}
+.. index:: 
+   single: MLModel; overview and spec
+   single: prediction; with MLModel
+```
+
 # MLModel Overview
 
 An MLModel encapsulates a [Core ML](https://developer.apple.com/documentation/coreml) model's prediction methods, configuration, and model description. You can use the `coremltools` package to convert trained models from a variety of training tools into Core ML models. For the full list of model types, see [Core ML Model](https://apple.github.io/coremltools/mlmodel/Format/Model.html).

--- a/docs-guides/source/model-input-and-output-types.md
+++ b/docs-guides/source/model-input-and-output-types.md
@@ -1,3 +1,11 @@
+```{eval-rst}
+.. index:: 
+    single: input type options
+    single: output type options
+    single: MLMultiArray
+    single: ImageType
+```
+
 # Model Input and Output Types
 
 When using the Core ML Tools [Unified Conversion API](unified-conversion-api), you can specify various properties for the model inputs and outputs using the `inputs` and `outputs` parameters for [`convert()`](https://apple.github.io/coremltools/source/coremltools.converters.convert.html#module-coremltools.converters._converters_entry). The following summarizes the key options.
@@ -19,6 +27,11 @@ To convert PyTorch models, you must provide the input shape using the `shape` pa
 
 For TensorFlow models, the shape is automatically picked up from the model. However, it is good practice to provide at least a static shape, which enables the converter to apply graph optimizations and produce a more efficient model. For variable input shapes use [`EnumeratedShapes`](https://apple.github.io/coremltools/source/coremltools.converters.mil.input_types.html?highlight=enumeratedshapes#enumeratedshapes). For details and an example, see [Select from Predetermined Shapes](https://coremltools.readme.io/docs/flexible-inputs#select-from-predetermined-shapes). 
 
+
+```{eval-rst}
+.. index:: dtype
+```
+
 ## Set the dtype
 
 Use the `dtype` parameter with [`TensorType`](https://apple.github.io/coremltools/source/coremltools.converters.mil.input_types.html#tensortype) to override data types (such as float 32, float 16, and integer). The `dtype` parameter can take either a [NumPy](https://numpy.org/) `dtype` (such as `np.float32` and `np.int32`) or an MIL type with `TensorType` (such as `coremltools.converters.mil.mil.types.fp32`).
@@ -35,6 +48,11 @@ mlmodel = ct.convert(
     outputs=[ct.TensorType(dtype=np.float16)],
     minimum_deployment_target=ct.target.iOS16,
 )
+```
+
+```{eval-rst}
+.. index:: 
+    single: PyTorch; set names
 ```
 
 ## Set Names for PyTorch Conversion

--- a/docs-guides/source/model-intermediate-language.md
+++ b/docs-guides/source/model-intermediate-language.md
@@ -1,3 +1,7 @@
+```{eval-rst}
+.. index:: MIL, Model Intermediate Language
+```
+
 # Model Intermediate Language
 
 When converting a model to [Core ML](https://developer.apple.com/documentation/coreml), Core ML Tools first creates an [intermediate representation](https://en.wikipedia.org/wiki/Intermediate_representation) of the model in the Model Intermediate Language (MIL), and then translates the MIL representation to the Core ML protobuf representation.
@@ -71,26 +75,14 @@ A block is a sequence of operations. The above example shows 10 operations in `b
 
 You can translate the MIL representation to the Core ML protobuf representation for either a neural network or an ML program. (For a comparison, see [Comparing ML Programs and Neural Networks](comparing-ml-programs-and-neural-networks).)
 
-To convert to an ML program, use the following code:
-
-```python
-model = ct.convert(prog, convert_to="mlprogram")
-```
-
-To convert to a neural network, use the following:
-
-```python
-model = ct.convert(prog)
-```
-
-For example, you can convert the MIL program from the previous section to a neural network, and then run a prediction with the converted model:
+To convert to an ML program, follow the instructions in [Load and Convert Model Workflow](load-and-convert-model). For example, you can convert the MIL program from the previous section to an ML program, and then run a prediction with the converted model:
 
 ```python
 # Note: This example continues the code from the previous section.
 import coremltools as ct
 import numpy as np
 
-# Convert to CoreML neural network format
+# Convert to ML program
 model = ct.convert(prog)
 
 # Make a prediction with CoreML

--- a/docs-guides/source/model-prediction.md
+++ b/docs-guides/source/model-prediction.md
@@ -1,3 +1,11 @@
+
+```{eval-rst}
+.. index:: 
+   single: prediction; input and output
+   single: prediction; specify compute units
+   single: prediction; image
+```
+
 # Model Prediction
 
 After converting a source model to a Core ML model, you can evaluate the Core ML model by verifying that the predictions made by the Core ML model match the predictions made by the source model. 

--- a/docs-guides/source/model-scripting.md
+++ b/docs-guides/source/model-scripting.md
@@ -1,5 +1,13 @@
 # Model Scripting
 
+```
+.. index:: 
+    single: PyTorch; model scripting
+    single: model scripting
+    single: PyTorch; JIT script
+    single: TorchScript
+```
+
 Model tracing is not appropriate in all cases. If your model includes a data-dependent control flow, such as a loop or conditional, you can experiment with PyTorch's [JIT script](https://pytorch.org/docs/stable/generated/torch.jit.script.html) to _script_ the model by analyzing the code to generate TorchScript.
 
 ```{warning}

--- a/docs-guides/source/model-tracing.md
+++ b/docs-guides/source/model-tracing.md
@@ -1,3 +1,10 @@
+```
+.. index:: 
+    single: PyTorch; model tracing
+    single: model tracing
+    single: TorchScript
+```
+
 # Model Tracing
 
 The easiest way to generate TorchScript for your model is to use PyTorch's [JIT tracer](https://pytorch.org/docs/stable/generated/torch.jit.trace.html). Tracing runs an example input tensor through your model, and captures the operations that are invoked as that input makes its way through the model's layers.

--- a/docs-guides/source/new-conversion-options.md
+++ b/docs-guides/source/new-conversion-options.md
@@ -1,6 +1,17 @@
+```{eval-rst}
+.. index:: conversion options
+```
+
 # New Conversion Options
 
 You can use the [Unified Conversion API](unified-conversion-api) to convert a TensorFlow or PyTorch model to the Core ML model format as either a neural network or an [ML program](convert-to-ml-program). The following are the newest conversion options.
+
+```{eval-rst}
+.. index:: 
+    single: convert_to parameter
+    single: ML program; minimum_deployment_target
+    single: neural network; minimum_deployment_target
+```
 
 ## Convert to ML Program or Neural Network
 
@@ -12,6 +23,12 @@ If neither the `minimum_deployment_target` nor the `convert_to` parameter is spe
 
 To learn about the differences between neural networks and ML programs, see [ML Programs](convert-to-ml-program).
 
+```{eval-rst}
+.. index:: 
+    single: ML program; compute precision
+    single: compute precision
+```
+
 ## Set the Compute Precision for an ML Program
 
 For ML programs, coremltools produces a model with float 16 precision by default. You can override the default precision by using the `compute_precision` parameter. For details, see [Set the ML Program Precision](convert-to-ml-program.md#set-the-ml-program-precision). 
@@ -21,6 +38,12 @@ For ML programs, coremltools produces a model with float 16 precision by default
 The converter picks the default optimized path for fast execution while loading the model. The default setting (`ComputeUnit.ALL`) uses all compute units available, including the Apple Neural Engine (ANE), the CPU, and the graphics processing unit (GPU). 
 
 However, you may find it useful, especially for debugging, to specify the actual compute units when converting or loading a model by using the `compute_units` parameter. For details, see [Set the compute units](load-and-convert-model.md#set-the-compute-units).
+
+```{eval-rst}
+.. index:: 
+    single: input type options
+    single: output type options
+```
 
 ## Input and Output Type Options
 

--- a/docs-guides/source/optimization-overview.md
+++ b/docs-guides/source/optimization-overview.md
@@ -1,3 +1,9 @@
+```{eval-rst}
+.. index:: 
+    single: optimization; overview
+    single: compression; types of
+```
+
 # Overview
 
 Optimization is a rapidly evolving field of machine learning. There are several ways to optimize a deep learning model. For example, you can distill a large model into a smaller model, start from scratch and train a smaller efficient architecture, customize the model architecture for a specific task and hardware, and so on. 

--- a/docs-guides/source/optimization-workflow.md
+++ b/docs-guides/source/optimization-workflow.md
@@ -1,3 +1,8 @@
+```{eval-rst}
+.. index:: 
+    single: optimization; workflow
+```
+
 # Optimization Workflow
 
 Core ML Tools offers two ways to incorporate model compression into your workflow:
@@ -6,6 +11,12 @@ Core ML Tools offers two ways to incorporate model compression into your workflo
 - [_Training-time compression_](optimization-workflow.md#training-time-compression). Use this method with a PyTorch model while in training. It lets you fine-tune with data for higher accuracy.
 
 Since model compression is a lossy operation, in both cases you should evaluate the model on the validation data set and compare it with the uncompressed model to ascertain the loss in accuracy and see if that is acceptable. 
+
+```{eval-rst}
+.. index:: 
+    single: post-training compression
+    single: compression; post-training
+```
 
 ## Post-Training Compression
 
@@ -38,6 +49,12 @@ Benefits of this post-training approach include:
 These benefits make this approach more flexible. You can try different techniques with different configurations relatively quickly, to compare accuracy and performance impacts (such as size and latency). The results can guide you to decide whether to deploy the compressed model resulting from this process, or to explore training-time compression to improve accuracy, which involves fine-tuning with data.
 
 A drawback of this approach is that you may observe a steep decline in accuracy as compared to the amount of compression, depending on the model and the task. That is, for lower amounts of compression, you may observe the accuracy to be close to that of the uncompressed model, but as you choose configurations to increase the compression, the accuracy may decline very sharply.
+
+```{eval-rst}
+.. index:: 
+    single: training-time compression
+    single: compression; training-time
+```
 
 ## Training-Time Compression
 

--- a/docs-guides/source/optimizecoreml-api-overview.md
+++ b/docs-guides/source/optimizecoreml-api-overview.md
@@ -1,3 +1,8 @@
+```{eval-rst}
+.. index:: 
+    single: optimize.coreml
+```
+
 # optimize.coreml API Overview
 
 Use [`coremltools.optimize.coreml`](https://apple.github.io/coremltools/source/coremltools.optimize.coreml.post_training_quantization.html#module-coremltools.optimize.coreml) (post-training compression) to compress weights in the model. Weight compression reduces the space occupied by the model. However, the precision of the intermediate tensors and the compute precision of the ops are not altered — at load time or prediction time, weights are decompressed into float precision, and all computations use float precision.

--- a/docs-guides/source/optimizetorch-api-overview.md
+++ b/docs-guides/source/optimizetorch-api-overview.md
@@ -1,3 +1,8 @@
+```{eval-rst}
+.. index:: 
+    single: optimize.torch
+```
+
 # optimize.torch API Overview
 
 Use [`coremltools.optimize.torch`](https://apple.github.io/coremltools/source/coremltools.optimize.html#training-time-compression) (training-time compression) to train your model in a compression-aware fashion, or start from a pre-trained `float` precision model  and fine-tune it with training data. 

--- a/docs-guides/source/palettization-overview.md
+++ b/docs-guides/source/palettization-overview.md
@@ -1,3 +1,8 @@
+```{eval-rst}
+.. index:: 
+    single: palettization; overview
+```
+
 # Palettization Overview
 
 Palettization, also referred to as weight clustering,  compresses a model by clustering the model's `float` weights, and creating a [lookup table (LUT)](https://en.wikipedia.org/wiki/Lookup_table) of centroids, and then storing the original weight values with indices pointing to the entries in the LUT. 

--- a/docs-guides/source/performance-impact.md
+++ b/docs-guides/source/performance-impact.md
@@ -1,3 +1,8 @@
+```{eval-rst}
+.. index:: 
+    single: optimization; accuracy and performance
+```
+
 # Accuracy and Performance
 
 This section provides a few concrete [examples](performance-impact.md#examples) of the tradeoff between accuracy and performance, as described in [Optimization Workflow](optimization-workflow). The accuracy of the compressed model depends not only on the type of model and the task for which it is trained, but also on the compression ratio. This section helps you understand the impact of compressing models, not just on model size, but also on latency and runtime memory consumption.

--- a/docs-guides/source/post-training-palettization.md
+++ b/docs-guides/source/post-training-palettization.md
@@ -1,3 +1,9 @@
+```{eval-rst}
+.. index:: 
+    single: palettization; post-training
+    single: OpPalettizerConfig, OptimizationConfig
+```
+
 # Post-Training Palettization
 
 The [`palettize_weights`](https://apple.github.io/coremltools/source/coremltools.optimize.coreml.post_training_quantization.html#coremltools.optimize.coreml.palettize_weights) function discretizes the values of all weights in the ML program and constructs the LUT according to the algorithm you specify as `mode` in the [`OpPalettizerConfig`](https://apple.github.io/coremltools/source/coremltools.optimize.coreml.config.html#coremltools.optimize.coreml.OpPalettizerConfig). The float values are then converted to _nbit_ values, and the LUT is saved along side each weight. The `const` ops that were storing weight values are replaced by `constexpr_lut_to_dense` ops.

--- a/docs-guides/source/pruning-a-core-ml-model.md
+++ b/docs-guides/source/pruning-a-core-ml-model.md
@@ -1,3 +1,9 @@
+```{eval-rst}
+.. index:: 
+    single: pruning; post-training
+    single: OpThresholdPrunerConfig, OpMagnitudePrunerConfig
+```
+
 # Post-Training Pruning
 
 To sparsify the weights of a Core ML model, you can use one of two configurations:

--- a/docs-guides/source/pruning-overview.md
+++ b/docs-guides/source/pruning-overview.md
@@ -1,3 +1,8 @@
+```{eval-rst}
+.. index:: 
+    single: pruning; overview
+```
+
 # Pruning Overview
 
 Pruning a model is the process of sparsifying the weight matrices of the  

--- a/docs-guides/source/pytorch-conversion-examples.md
+++ b/docs-guides/source/pytorch-conversion-examples.md
@@ -1,3 +1,8 @@
+```{eval-rst}
+.. index:: 
+    single: PyTorch; convert segmentation model
+```
+
 # Converting a PyTorch Segmentation Model
 
 This example demonstrates how to convert a PyTorch [segmentation model](https://pytorch.org/hub/pytorch_vision_deeplabv3_resnet101/ "DeepLabV3 model with a ResNet-101 backbone") to a Core ML neural network. The model takes an image and outputs a class prediction for each pixel of the image.
@@ -171,6 +176,12 @@ Follow these steps:
 	mlmodel.save("SegmentationModel_no_metadata.mlmodel")
 	```
 
+```{eval-rst}
+.. index:: 
+    single: PyTorch; set model metadata
+    single: metadata; PyTorch model
+```
+
 
 ## Set the Model's Metadata
 
@@ -192,6 +203,12 @@ mlmodel.user_defined_metadata["com.apple.coreml.model.preview.type"] = "imageSeg
 mlmodel.user_defined_metadata['com.apple.coreml.model.preview.params'] = json.dumps(labels_json)
 
 mlmodel.save("SegmentationModel_with_metadata.mlmodel")
+```
+
+```{eval-rst}
+.. index:: 
+    single: Xcode; preview
+    single: preview in Xcode
 ```
 
 ## Open the Model in Xcode

--- a/docs-guides/source/quantization-neural-network.md
+++ b/docs-guides/source/quantization-neural-network.md
@@ -1,3 +1,9 @@
+```{eval-rst}
+.. index:: 
+    single: neural network; compress weights
+    single: quantization; neural network
+```
+
 # Compressing Neural Network Weights
 
 ```{admonition} For Neural Network Format Only

--- a/docs-guides/source/quantization-overview.md
+++ b/docs-guides/source/quantization-overview.md
@@ -1,3 +1,8 @@
+```{eval-rst}
+.. index:: 
+    single: quantization; overview
+```
+
 # Quantization Overview
 
 Quantization refers to the process of reducing the number of bits that represent a number. This process casts values from `float` type to an `integer` type that uses fewer bits.

--- a/docs-guides/source/sci-kit-learn-conversion.md
+++ b/docs-guides/source/sci-kit-learn-conversion.md
@@ -1,3 +1,8 @@
+```{eval-rst}
+.. index:: 
+    single: Scikit-learn
+```
+
 # Scikit-learn
 
 You can convert a [scikit-learn](https://scikit-learn.org/stable/) pipeline, classifier, or regressor to the Core ML format using [`sklearn.convert()`](https://apple.github.io/coremltools/source/coremltools.converters.sklearn.html#coremltools.converters.sklearn._converter.convert):

--- a/docs-guides/source/target-conversion-formats.md
+++ b/docs-guides/source/target-conversion-formats.md
@@ -1,3 +1,10 @@
+```{eval-rst}
+.. index:: 
+   single: TensorFlow; source formats
+   single: PyTorch; source formats
+```
+
+
 # Source and Conversion Formats
 
 Use the `convert()` method of the Core ML Tools [Unified Conversion API](https://apple.github.io/coremltools/index.html) (available from Core ML Tools version 4.0 and newer versions) to convert deep learning models to the Core ML model format in order to deploy them in the [Core ML](https://developer.apple.com/documentation/coreml) framework. 
@@ -27,6 +34,12 @@ Source model formats supported by the [Unified Conversion API](unified-conversio
 - [TorchScript](https://pytorch.org/docs/stable/jit.html) object
 - TorchScript object saved as a `.pt` file
 
+```{eval-rst}
+.. index:: 
+   single: convert to; target format
+   single: neural network; target format
+   single: ML program; target format
+```
 
 ## Target Conversion Formats
 

--- a/docs-guides/source/tensorflow-1-workflow.md
+++ b/docs-guides/source/tensorflow-1-workflow.md
@@ -1,3 +1,10 @@
+```{eval-rst}
+.. index:: 
+    single: TensorFlow 1; convert workflow
+    single: TensorFlow 1; convert from
+```
+
+
 # TensorFlow 1 Workflow
 
 Use the frozen graph format for conversion from TensorFlow 1. After training, always export the model for inference to this format using the `tensorflow.python.tools.freeze_graph` method. TensorFlow 1 pre-trained models are also generally available in the frozen `.pb` file format.
@@ -64,6 +71,11 @@ import coremltools as ct
 
 mlmodel = ct.convert(frozen_graph_file, convert_to="mlprogram")
 mlmodel.save(frozen_graph_file.replace("pb","mlpackage")))
+```
+
+```{eval-rst}
+.. index:: 
+    single: TensorFlow 1; convert pre-trained model
 ```
 
 ## Convert a Pre-trained Model

--- a/docs-guides/source/tensorflow-2.md
+++ b/docs-guides/source/tensorflow-2.md
@@ -1,3 +1,10 @@
+```{eval-rst}
+.. index:: 
+    single: TensorFlow 2; convert workflow
+    single: TensorFlow 2; convert from
+```
+
+
 # TensorFlow 2 Workflow
 
 To convert a [TensorFlow 2](https://www.tensorflow.org/api_docs) model, provide one of following formats to the converter:
@@ -16,6 +23,12 @@ This page demonstrates the following typical workflows:
 
 - [Convert a pre-trained model](#convert-a-pre-trained-model): Downloading a pre-trained model in the `SavedModel` or `.h5` file format, loading it as a `tf.keras.Model`, and then converting the model.
 - [Convert a user-defined model](#convert-a-user-defined-model): Defining a model from scratch, training it, and then converting the model.
+
+
+```{eval-rst}
+.. index:: 
+    single: TensorFlow 2; convert pre-trained model
+```
 
 ## Convert a Pre-trained Model
 
@@ -86,11 +99,21 @@ mlmodel = ct.convert(model, convert_to="mlprogram",
 mlmodel.save("mobilenet.mlpackage")
 ```
 
+```{eval-rst}
+.. index:: 
+    single: TensorFlow 2; convert user-defined model
+```
+
 ## Convert a User-defined Model
 
 The most convenient way to define a model is to use the  `tf.keras` APIs. You can define your model using [sequential](https://www.tensorflow.org/guide/keras/sequential_model "The Sequential model"), [functional](https://www.tensorflow.org/guide/keras/functional "The Functional API") or [subclassing](https://www.tensorflow.org/guide/keras/custom_layers_and_models "Making new Layers and Models via subclassing") APIs, and then convert directly to Core ML. 
 
 Alternatively, you can first save the Keras model to the `HDF5` (`.h5`) or the `SavedModel` file format, and then provide the file path with the `convert()` method. For details about saving the model, see [Save and load Keras models](https://www.tensorflow.org/guide/keras/save_and_serialize "Save and load Keras models").
+
+```{eval-rst}
+.. index:: 
+    single: TensorFlow 2; convert sequential model
+```
 
 ### Convert a Sequential Model
 
@@ -123,6 +146,11 @@ mlmodel = ct.convert(tf_keras_model, convert_to="mlprogram")
 # or save the keras model in HDF5 format and then convert
 tf_keras_model.save('tf_keras_model.h5')
 mlmodel = ct.convert('tf_keras_model.h5', convert_to="mlprogram")
+```
+
+```{eval-rst}
+.. index:: 
+    single: TensorFlow 2; convert a Keras model
 ```
 
 ### Convert a Keras Model With Subclassing
@@ -160,6 +188,11 @@ outputs = CustomDense(10)(inputs)
 model = keras.Model(inputs, outputs)
 
 mlmodel = ct.convert(model, convert_to="mlprogram")
+```
+
+```{eval-rst}
+.. index:: 
+    single: TensorFlow 2; convert concrete function
 ```
 
 ### Convert a TensorFlow Concrete Function

--- a/docs-guides/source/training-time-palettization.md
+++ b/docs-guides/source/training-time-palettization.md
@@ -1,3 +1,9 @@
+```{eval-rst}
+.. index:: 
+    single: palettization; training-time
+    single: DKMPalettizer
+```
+
 # Training-Time Palettization
 
 The [DKMPalettizer](https://apple.github.io/coremltools/source/coremltools.optimize.torch.palettization.html#coremltools.optimize.torch.palettization.DKMPalettizer) class implements a palettization algorithm based on the [DKM (Differentiable K-means)](https://machinelearning.apple.com/research/differentiable-k-means) paper.  The hyper-parameters of the algorithm can be set via the [DKMPalettizerConfig](https://apple.github.io/coremltools/source/coremltools.optimize.torch.palettization.html#coremltools.optimize.torch.palettization.DKMPalettizerConfig) object. 

--- a/docs-guides/source/updatable-nearest-neighbor-classifier.md
+++ b/docs-guides/source/updatable-nearest-neighbor-classifier.md
@@ -1,3 +1,10 @@
+```{eval-rst}
+.. index::
+    single: classifier; nearest neighbor updatable
+    single: updatable nearest neighbor classifier
+    single: nearest neighbor classifier
+```
+
 # Nearest Neighbor Classifier
 
 This topic demonstrates the process of creating an updatable empty k-nearest neighbor model using Core ML Tools.

--- a/docs-guides/source/updatable-neural-network-classifier-on-mnist-dataset.md
+++ b/docs-guides/source/updatable-neural-network-classifier-on-mnist-dataset.md
@@ -1,3 +1,10 @@
+```{eval-rst}
+.. index::
+    single: classifier; neural network updatable
+    single: updatable neural network classifier
+    single: neural network; classifier
+```
+
 # Neural Network Classifier
 
 A neural network is a collection of layers, each containing weights that get used alongside its other inputs to produce an output. To be able to update weights of a layer, we need to mark them as "updatable". 

--- a/docs-guides/source/updatable-tiny-drawing-classifier-pipeline-model.md
+++ b/docs-guides/source/updatable-tiny-drawing-classifier-pipeline-model.md
@@ -1,3 +1,10 @@
+```{eval-rst}
+.. index::
+    single: classifier; pipeline updatable
+    single: updatable pipeline classifier
+    single: pipeline classifier
+```
+
 # Pipeline Classifier
 
 This example creates a model which can be used to train a simple drawing or sketch classifier based on user examples. The model is a pipeline composed of a drawing-embedding model and a nearest-neighbor classifier.

--- a/docs-guides/source/xcode-model-preview-types.md
+++ b/docs-guides/source/xcode-model-preview-types.md
@@ -1,3 +1,9 @@
+```{eval-rst}
+.. index:: 
+    single: Xcode; model preview types
+    single: model preview types in Xcode
+```
+
 # Xcode Model Preview Types
 
 After converting models to the Core ML format, you can set up the Xcode preview of certain models by adding preview metadata and parameters.

--- a/docs-guides/source/xgboost-conversion.md
+++ b/docs-guides/source/xgboost-conversion.md
@@ -1,3 +1,8 @@
+```{eval-rst}
+.. index:: 
+    single: XGBoost
+```
+
 # XGBoost
 
 You can convert a trained [XGBoost](https://en.wikipedia.org/wiki/XGBoost) model to Core ML format using [`xgboost.convert()`](https://apple.github.io/coremltools/source/coremltools.converters.xgboost.html#coremltools.converters.xgboost._tree.convert):


### PR DESCRIPTION
This PR is for the GitHub-hosted public version of `coremltools`; specifically, the `docs-guides` folder. This folder is not visible unless if you have the link to it, and the link is not yet public.

This PR adds index entries to Markdown files using the `{eval-rst}` MyST expression. Index entries are generated automatically with Sphinx.


Branch:
docs-guides-add-index-entries-for-index

---

**Preview**:

- [Using the book theme](https://tonybove-apple.github.io/coremltools/docs-guides)

