### PR TITLE
Add pass for ml-ane-transformers layer_norm

### DIFF
--- a/coremltools/converters/mil/mil/passes/defs/optimize_normalization.py
+++ b/coremltools/converters/mil/mil/passes/defs/optimize_normalization.py
@@ -884,13 +884,11 @@ class fuse_layernorm_or_instancenorm(AbstractGraphPass):
         if root_var.shape is None:
             return False
 
-        # check that root_var feeds into exactly 3 ops
-        if len(list(root_var.child_ops)) != 2:
+        # check that root_var feeds into at least 2 ops
+        if len(list(root_var.child_ops)) < 2:
             return False
-        if root_var.op is not None and not self._check_child_op_types(
-            root_var.op, child_op_types=["reduce_mean", "sub", "mul"]
-        ):
-            return False
+        # Do not enforce that the only child ops are reduce_mean and sub as in other
+        # patterns. There are models where the root op is used after the layer norm.
 
         # check 1st reduce_mean op
         if not self._check_reduce_op(reduce_op):

--- a/coremltools/converters/mil/mil/passes/defs/optimize_normalization.py
+++ b/coremltools/converters/mil/mil/passes/defs/optimize_normalization.py
@@ -884,9 +884,6 @@ class fuse_layernorm_or_instancenorm(AbstractGraphPass):
         ops_to_remove = []
         root_var = reduce_op.x
 
-        if root_var.shape is None:
-            return False
-
         # check that root_var feeds into at least 2 ops
         if len(list(root_var.child_ops)) < 2:
             return False

--- a/coremltools/converters/mil/mil/passes/defs/optimize_normalization.py
+++ b/coremltools/converters/mil/mil/passes/defs/optimize_normalization.py
@@ -24,8 +24,9 @@ class fuse_layernorm_or_instancenorm(AbstractGraphPass):
     """
     A graph optimization pass on PyMIL to detect and fuse several variants of ``layer_norm`` or
     ``instance_norm``. Pattern 1 corresponds to either ``layer_norm`` or ``instance_norm``. Patterns 2-4
-    are ``instance_norm``. You can find these patterns in the methods for this class in the source code.
-    To quickly view the source code, click the **[source]** button at the end of the class definition.
+    are ``instance_norm``. Pattern 5 is ``layer_norm``. You can find these patterns in the methods for
+    this class in the source code. To quickly view the source code, click the **[source]** button at
+    the end of the class definition.
     
     """
 

--- a/coremltools/converters/mil/mil/passes/tests/test_passes.py
+++ b/coremltools/converters/mil/mil/passes/tests/test_passes.py
@@ -7662,6 +7662,109 @@ class TestFuseLayerNormOrInstanceNorm:
             prog, {"x": shape}, expected_output_shapes={block.outputs[0].name: shape}
         )
 
+    @pytest.mark.parametrize("with_affine", [True, False])
+    def test_ane_layer_norm(self, with_affine):
+        """
+        Detect layer norm pattern, found in models based on ml-ane-transformers.
+
+        ``y = (x - mean(x)) * rsqrt(mean((x - mean(x))^2) + eps)``
+        ``y = [(x - mean(x)) * rsqrt(mean((x - mean(x))^2) + eps) + beta] * gamma``
+
+        Note that beta and gamma in these equations are applied in
+        opposite order compared to the MIL.
+
+        Only applies when mean and variance are computed along axes [1]
+        """
+        shape = (3, 5, 1, 6)
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=shape)])
+        def prog(x):
+            x1 = mb.reduce_mean(x=x, axes=[1], keep_dims=True) # mean
+            x2 = mb.sub(x=x, y=x1) # x - mean
+            x3 = mb.mul(x=x2, y=x2) # (x - mean)^2
+            x4 = mb.reduce_mean(x=x3, axes=[1], keep_dims=True) # variance
+            x5 = mb.add(x=x4, y=1e-5) # variance + eps
+            x6 = mb.rsqrt(x=x5) # rsqrt(variance + eps)
+            y = mb.mul(x=x2, y=x6) # (x - mean) * rsqrt(variance + eps)
+
+            if with_affine:
+                y = mb.add(x=y, y=np.random.rand(1,shape[1],1,1))
+                y = mb.mul(x=y, y=np.random.rand(1,shape[1],1,1))
+
+            return y
+
+        prev_prog, prev_block, block = apply_pass_and_basic_check(
+            prog, "common::fuse_layernorm_or_instancenorm"
+        )
+        assert get_op_types_in_program(prev_prog) == [
+            "reduce_mean",
+            "sub",
+            "mul",
+            "reduce_mean",
+            "add",
+            "rsqrt",
+            "mul",
+        ] + (["add", "mul"] if with_affine else [])
+        assert get_op_types_in_program(prog) == ["layer_norm"]
+        assert_model_is_valid(
+            prog, {"x": shape}, expected_output_shapes={block.outputs[0].name: shape}
+        )
+
+    @pytest.mark.parametrize("with_affine", [True, False])
+    def test_ane_layer_norm_with_root_var(self, with_affine):
+        """
+        Detect layer norm pattern, found in models based on ml-ane-transformers.
+
+        Cover cases where the input to the layer norm is used as input to an
+        op that occurs after the layer norm.
+
+        ``y = (x - mean(x)) * rsqrt(mean((x - mean(x))^2) + eps)``
+        ``y = [(x - mean(x)) * rsqrt(mean((x - mean(x))^2) + eps) + beta] * gamma``
+
+        Note that beta and gamma in these equations are applied in
+        opposite order compared to the MIL.
+
+        Only applies when mean and variance are computed along axes [1]
+
+        """
+        shape = (3, 5, 1, 6)
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=shape)])
+        def prog(x):
+            x1 = mb.add(x=x, y=np.random.rand(*shape))
+            x2 = mb.reduce_mean(x=x1, axes=[1], keep_dims=True) # mean
+            x3 = mb.sub(x=x1, y=x2) # x - mean
+            x4 = mb.mul(x=x3, y=x3) # (x - mean)^2
+            x5 = mb.reduce_mean(x=x4, axes=[1], keep_dims=True) # variance
+            x6 = mb.add(x=x5, y=1e-5) # variance + eps
+            x7 = mb.rsqrt(x=x6) # rsqrt(variance + eps)
+            y = mb.mul(x=x3, y=x7) # (x - mean) * rsqrt(variance + eps)
+
+            if with_affine:
+                y = mb.add(x=y, y=np.random.rand(1,shape[1],1,1))
+                y = mb.mul(x=y, y=np.random.rand(1,shape[1],1,1))
+
+            y = mb.add(x=x, y=y) # use x for something after the norm
+            return y
+
+        prev_prog, prev_block, block = apply_pass_and_basic_check(
+            prog, "common::fuse_layernorm_or_instancenorm"
+        )
+        assert get_op_types_in_program(prev_prog) == [
+            "add",
+            "reduce_mean",
+            "sub",
+            "mul",
+            "reduce_mean",
+            "add",
+            "rsqrt",
+            "mul",
+        ] + (["add", "mul"] if with_affine else []) + ["add"]
+        assert get_op_types_in_program(prog) == ["add", "layer_norm", "add"]
+        assert_model_is_valid(
+            prog, {"x": shape}, expected_output_shapes={block.outputs[0].name: shape}
+        )
+
     def test_instance_norm_pattern_1(self):
         """
         Detect instance norm pattern

--- a/coremltools/converters/mil/mil/passes/tests/test_passes.py
+++ b/coremltools/converters/mil/mil/passes/tests/test_passes.py
@@ -7767,9 +7767,12 @@ class TestFuseLayerNormOrInstanceNorm:
 
     @pytest.mark.parametrize(
         "with_affine, reused_name",
-        itertools.product(
-            [True, False],
-            [None, "x2", "x3", "x4", "x8"],
+        itertools.chain(
+            itertools.product(
+                [True, False],
+                [None, "x2", "x3", "x4", "x8"],
+            ),
+            [[True, "x9"]]
         ),
     )
     def test_ane_layer_norm_intermediate_var_reuse(self, with_affine, reused_name):
@@ -7794,7 +7797,8 @@ class TestFuseLayerNormOrInstanceNorm:
             y = x8
 
             if with_affine:
-                y = mb.add(x=y, y=np.random.rand(1,shape[1],1,1))
+                x9 = mb.add(x=y, y=np.random.rand(1,shape[1],1,1))
+                y = x9
                 y = mb.mul(x=y, y=np.random.rand(1,shape[1],1,1))
 
             # All the same shape (3,5,1,6)
@@ -7807,6 +7811,8 @@ class TestFuseLayerNormOrInstanceNorm:
                 reused = x4
             elif reused_name == "x8":
                 reused = x8
+            elif reused_name == "x9":
+                reused = x9
 
             if reused:
                 y = mb.sub(x=reused, y=y) # reuse an intermediate variable

--- a/coremltools/converters/mil/mil/passes/tests/test_passes.py
+++ b/coremltools/converters/mil/mil/passes/tests/test_passes.py
@@ -7688,8 +7688,8 @@ class TestFuseLayerNormOrInstanceNorm:
             y = mb.mul(x=x2, y=x6) # (x - mean) * rsqrt(variance + eps)
 
             if with_affine:
-                y = mb.add(x=y, y=np.random.rand(1,shape[1],1,1))
-                y = mb.mul(x=y, y=np.random.rand(1,shape[1],1,1))
+                y = mb.add(x=y, y=np.random.rand(1, shape[1], 1, 1))
+                y = mb.mul(x=y, y=np.random.rand(1, shape[1], 1, 1))
 
             return y
 
@@ -7741,8 +7741,8 @@ class TestFuseLayerNormOrInstanceNorm:
             y = mb.mul(x=x3, y=x7) # (x - mean) * rsqrt(variance + eps)
 
             if with_affine:
-                y = mb.add(x=y, y=np.random.rand(1,shape[1],1,1))
-                y = mb.mul(x=y, y=np.random.rand(1,shape[1],1,1))
+                y = mb.add(x=y, y=np.random.rand(1, shape[1], 1, 1))
+                y = mb.mul(x=y, y=np.random.rand(1, shape[1], 1, 1))
 
             y = mb.sub(x=x, y=y) # use x for something after the norm
             return y
@@ -7797,9 +7797,9 @@ class TestFuseLayerNormOrInstanceNorm:
             y = x8
 
             if with_affine:
-                x9 = mb.add(x=y, y=np.random.rand(1,shape[1],1,1))
+                x9 = mb.add(x=y, y=np.random.rand(1, shape[1], 1, 1))
                 y = x9
-                y = mb.mul(x=y, y=np.random.rand(1,shape[1],1,1))
+                y = mb.mul(x=y, y=np.random.rand(1, shape[1], 1, 1))
 
             # All the same shape (3,5,1,6)
             reused = None
@@ -7856,7 +7856,7 @@ class TestFuseLayerNormOrInstanceNorm:
             x6 = mb.add(x=x5, y=1e-5) # variance + eps
             x7 = mb.rsqrt(x=x6) # rsqrt(variance + eps)
             x8 = mb.mul(x=x3, y=x7) # (x - mean) * rsqrt(variance + eps)
-            y = mb.add(x=x8, y=np.random.rand(1,shape[1],1,1)) # ambiguous add (maybe beta)
+            y = mb.add(x=x8, y=np.random.rand(1, shape[1], 1, 1)) # ambiguous add (maybe beta)
             return y
 
         prev_prog, prev_block, block = apply_pass_and_basic_check(


### PR DESCRIPTION
The ml-ane-transformers repo provides a reference implementation of a channels-first layer norm [here](https://github.com/apple/ml-ane-transformers/blob/da64000fa56cc85b0859bc17cb16a3d753b8304a/ane_transformers/reference/layer_norm.py). This adds a pass to replace that with an equivalent MIL `layer_norm` op.

This uses less ops (7 or 9 depending on if the elementwise affine is used) and makes the MIL/graph easier to read. I mostly followed the pattern of the other similar passes, happy to make any adjustments!