### PR TITLE
Docs-Guides - Fix gh-pages Version

### DIFF
--- a/docs-guides/conf.py
+++ b/docs-guides/conf.py
@@ -39,6 +39,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
+html_baseurl = './docs-guides'
 html_theme = 'sphinx_book_theme'
 html_title = "Guide to Core ML Tools"
 


### PR DESCRIPTION
This PR is for the GitHub-hosted public version of `coremltools`; specifically, the `docs-guides` folder. This is a fix to set the `base_url` in `conf.py` to be `./docs-guides` so that relative links always work.


Branch:
docs-fix-gh-pages-version
