### PR TITLE
Docs - Update API Reference for v7.0

### DIFF
--- a/coremltools/models/utils.py
+++ b/coremltools/models/utils.py
@@ -1023,6 +1023,9 @@ def compile_model(model: _Union['_ct.models.MLModel', str, _Model_pb2.Model]) ->
 
     str : Path to compiled model directory
 
+    See Also
+    --------
+    coremltools.models.CompiledMLModel
     """
     # Check environment
     if _macos_version() < (10, 13):

--- a/coremltools/models/utils.py
+++ b/coremltools/models/utils.py
@@ -1010,24 +1010,19 @@ def compile_model(model: _Union['_ct.models.MLModel', str, _Model_pb2.Model]) ->
 
     Parameters
     ----------
-
     model: str, Model_pb2 or MLModel
 
-        str - path to model to compile
+        str : Path to model to compile
 
-        Model_pb2 - spec to model to compile
+        Model_pb2 : Spec to model to compile
 
-        MLModel - instantiated Core ML model to compile
+        MLModel : Instantiated Core ML model to compile
 
     Returns
     -------
 
-    str : path to compiled model directory
+    str : Path to compiled model directory
 
-    See Also
-    --------
-
-    ``coremltools.models.CompiledMLModel``
     """
     # Check environment
     if _macos_version() < (10, 13):

--- a/docs/source/coremltools.models.rst
+++ b/docs/source/coremltools.models.rst
@@ -7,6 +7,14 @@ MLModel
 .. automodule:: coremltools.models.model
    :members:
 
+
+Compiled MLModel
+-------------------------------
+
+.. autoclass:: coremltools.models.CompiledMLModel
+   :members:
+
+
 compression\_utils
 -------------------------------------------------
 


### PR DESCRIPTION
This PR is for the GitHub-hosted public version of `coremltools`. 

The PR includes updated API reference docstrings for v7.0. The following was edited to correct an error caught by Sphinx:

```
modified:   coremltools/models/utils.py
```

The following Sphinx error caused `compile_model` to not appear in the documentation:

```
WARNING: error while formatting signature for coremltools.models.utils.compile_model: Handler <function mangle_signature at 0x7fd83060b440> for event 'autodoc-process-signature' threw an exception (exception: Error parsing See Also entry '``coremltools.models.CompiledMLModel``' in the docstring of compile_model in /Users/tonybove/opt/coremltools/coremltools/models/utils.py.)
```

The edits:

- Remove the "See also" reference, as CompiledMLModel did not appear in the documentation.
- Make formatting changes.
- 2nd commit fix so that CompiledMLModel appears in the docs.
- 3rd commit adds back "See also" reference.

Branch:
docs-update-api-ref-for-v7.0

---

[**Click for Preview**](https://tonybove-apple.github.io/coremltools/)


