### PR TITLE
Docs-Guides - Edit Index Entry Sections

### DIFF
--- a/docs-guides/source/convert-nlp-model.md
+++ b/docs-guides/source/convert-nlp-model.md
@@ -1,6 +1,6 @@
 # Converting a Natural Language Processing Model
 
-```
+```{eval-rst}
 .. index:: 
     single: PyTorch; combine tracing and scripting
     single: PyTorch; convert natural language proocessing model

--- a/docs-guides/source/model-scripting.md
+++ b/docs-guides/source/model-scripting.md
@@ -1,6 +1,6 @@
 # Model Scripting
 
-```
+```{eval-rst}
 .. index:: 
     single: PyTorch; model scripting
     single: model scripting

--- a/docs-guides/source/model-tracing.md
+++ b/docs-guides/source/model-tracing.md
@@ -1,4 +1,4 @@
-```
+```{eval-rst}
 .. index:: 
     single: PyTorch; model tracing
     single: model tracing

--- a/docs-guides/source/palettization-overview.md
+++ b/docs-guides/source/palettization-overview.md
@@ -28,6 +28,6 @@ Since palettization reduces the size of each weight value, the amount of data to
 
 ```{admonition} Feature Availability
 
-Palettized weight representations for Core ML `mlprogram` models is available in `iOS16`/`macOS13`/`watchOS9`/`tvOS16` and newer deployment target formats.
+Palettized weight representation for Core ML `mlprogram` models is available in `iOS16`/`macOS13`/`watchOS9`/`tvOS16` and newer deployment target formats.
 ```
 

--- a/docs-guides/source/post-training-palettization.md
+++ b/docs-guides/source/post-training-palettization.md
@@ -38,7 +38,8 @@ For more details on the parameters available in the config, see the following in
 - [`OptimizationConfig`](https://apple.github.io/coremltools/source/coremltools.optimize.coreml.config.html#coremltools.optimize.coreml.OptimizationConfig)
 - [`palettize_weights`](https://apple.github.io/coremltools/source/coremltools.optimize.coreml.post_training_quantization.html#coremltools.optimize.coreml.palettize_weights)
 
-```{admonition} Post-Training Palettization Works Well for `nbits = 6, 8`
+
+```{admonition} Post-Training Palettization Works Well for nbits = 6, 8
 
 Results are model and task dependent, but in most cases, palettizing with [`optimize.coreml.palettize_weights`](https://apple.github.io/coremltools/source/coremltools.optimize.coreml.post_training_quantization.html#coremltools.optimize.coreml.palettize_weights) preserves the accuracy to a good degree for 6-bit or 8-bit settings. With lower settings, you will likely see a sharp drop in accuracy, in which case consider using [Training-Time Palettization](training-time-palettization) with `nbits = 2, 4`.
 

--- a/docs-guides/source/updatable-nearest-neighbor-classifier.md
+++ b/docs-guides/source/updatable-nearest-neighbor-classifier.md
@@ -18,12 +18,12 @@ This topic demonstrates the process of creating an updatable empty k-nearest nei
 
 	from coremltools.models.nearest_neighbors import KNearestNeighborsClassifierBuilder
 	builder = KNearestNeighborsClassifierBuilder(input_name='input',
-												 output_name='output',
-												 number_of_dimensions=number_of_dimensions,
-												 default_class_label='defaultLabel',
-												 number_of_neighbors=3,
-												 weighting_scheme='inverse_distance',
-												 index_type='linear')
+					 output_name='output',
+					 number_of_dimensions=number_of_dimensions,
+					 default_class_label='defaultLabel',
+					 number_of_neighbors=3,
+					 weighting_scheme='inverse_distance',
+					 index_type='linear')
 
 	builder.author = 'Core ML Tools Example'
 	builder.license = 'MIT'


### PR DESCRIPTION
This PR is for the GitHub-hosted public version of `coremltools`; specifically, the `docs-guides` folder. 

This PR edits various files to fix index entry codes so that they work, and also fixes a grammatical error.


```
modified:   source/convert-nlp-model.md
modified:   source/model-scripting.md
modified:   source/model-tracing.md
modified:   source/palettization-overview.md
modified:   source/post-training-palettization.md
modified:   source/updatable-nearest-neighbor-classifier.md
```

Branch:
docs-guides-edit-index-entry-sections

---

**Preview**:

- [Using the book theme](https://tonybove-apple.github.io/coremltools/docs-guides)

