### PR TITLE
Docs - Change Links for the Guide to Sphinx Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 [![PyPI Release](https://img.shields.io/pypi/v/coremltools.svg)](#)
 [![Python Versions](https://img.shields.io/pypi/pyversions/coremltools.svg)](#)
 
-[Core ML Tools](https://coremltools.readme.io/docs)
+[Core ML Tools](https://apple.github.io/coremltools/docs-guides/source/overview-coremltools.html)
 =======================
 
 ![Core ML Tools logo](docs/logo.png)
 
-Use *coremltools* to convert machine learning models from third-party libraries to the Core ML format. This Python package contains the supporting tools for converting models from training libraries such as the following:
+Use [Core ML Tools](https://apple.github.io/coremltools/docs-guides/source/overview-coremltools.html) (*coremltools*) to convert machine learning models from third-party libraries to the Core ML format. This Python package contains the supporting tools for converting models from training libraries such as the following:
 
 * [TensorFlow 1.x](https://www.tensorflow.org/versions/r1.15/api_docs/python/tf)
 * [TensorFlow 2.x](https://www.tensorflow.org/api_docs)
@@ -17,7 +17,7 @@ Use *coremltools* to convert machine learning models from third-party libraries 
 	* [XGBoost](https://xgboost.readthedocs.io/en/latest/)
 	* [LibSVM](https://www.csie.ntu.edu.tw/~cjlin/libsvm/)
 
-With coremltools, you can do the following:
+With coremltools, you can:
 
 * Convert trained models to the Core ML format.
 * Read, write, and optimize Core ML models.
@@ -37,10 +37,10 @@ pip install -U coremltools
 
 ## Resources
 
-To install coremltools, see the [“Installation“ page](https://coremltools.readme.io/docs/installation). For more information, see the following:
+To install coremltools, see [Installing Core ML Tools](https://apple.github.io/coremltools/docs-guides/source/installing-coremltools.html). For more information, see the following:
 
 * [Release Notes](https://github.com/apple/coremltools/releases/) 
-* [Guides and examples](https://coremltools.readme.io/) 
+* [Guide and examples](https://apple.github.io/coremltools/docs-guides/index.html) 
 * [API Reference](https://apple.github.io/coremltools/index.html)
 * [Core ML Specification](https://apple.github.io/coremltools/mlmodel/index.html)
 * [Building from Source](BUILDING.md)

--- a/docs-guides/source/how-to-contribute.md
+++ b/docs-guides/source/how-to-contribute.md
@@ -47,10 +47,7 @@ Once you submit an issue, feature request, or question, members of the community
 
 ## Documentation
 
-Help us improve the documentation. Even if you find only a typo, don’t hesitate to report it. To make changes, use one of these methods:
-
-- Click the **SUGGEST EDITS** button in the top right corner of the documentation page, and edit the text.
-- Send a pull request as described in [Contributions](#contributions) and add the **docs** label to it (see [Labels](#labels) for details).
+Help us improve the documentation. Even if you find only a typo, don’t hesitate to report it. To make changes, send a pull request as described in [Contributions](#contributions) and add the **docs** label to it (see [Labels](#labels) for details).
 
 ## Contributions
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -4,7 +4,7 @@ coremltools API Documentation
 This document describes the following:
 
 * [Viewing documentation](#viewing-documentation)
-* [Updating the guides and examples](#updating-the-guides-and-examples)
+* [Updating the guide and examples](#updating-the-guides-and-examples)
 * [How the API Reference is auto-generated](#how-the-api-reference-is-auto-generated)
 * [Updating the API Reference](#updating-the-api-reference)
 * [Generating the top-level RST files](#generating-the-top-level-rst-files)
@@ -16,7 +16,7 @@ This document describes the following:
 For coremltools documentation, see the following:
 
 * Core ML Tools [README](https://github.com/apple/coremltools/blob/main/README.md) file for this repository
-* [Guides and examples](https://coremltools.readme.io/)
+* [Guide and examples](https://apple.github.io/coremltools/docs-guides/)
 * [Release Notes](https://github.com/apple/coremltools/releases/) for the current release and previous releases
 * [API Reference](https://apple.github.io/coremltools/index.html): Documentation describing the coremltools API, auto-generated from _docstrings_ in the source code.
 * [Core ML Format Specification](https://apple.github.io/coremltools/mlmodel/index.html): Documentation describing the Core ML model spec, auto-generated from the proto files located in [`coremltools/mlmodel/format`](https://github.com/apple/coremltools/tree/main/mlmodel/format).
@@ -24,7 +24,7 @@ For coremltools documentation, see the following:
 
 ## Updating the guides and examples
 
-To make editing changes to [Guides and examples](https://coremltools.readme.io/), see [the Documentation section of Contributing](https://coremltools.readme.io/docs/how-to-contribute#documentation).
+To make editing changes to the [Guide and examples](https://apple.github.io/coremltools/docs-guides/index.html), Send a pull request as described in [Contributions](https://apple.github.io/coremltools/docs-guides/source/how-to-contribute.html#contributions) and add the **docs** label to it (see [Labels](https://apple.github.io/coremltools/docs-guides/source/how-to-contribute.html#labels) for details).
 
 
 ## How the API Reference is auto-generated

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ coremltools API
 .. image:: logo.png
    :alt: Core ML Tools logo
 
-This document is the API Reference for Core ML Tools (``coremltools``). For guides, installation instructions, and examples, see the `Guide <https://coremltools.readme.io/docs>`_.
+This document is the API Reference for Core ML Tools (``coremltools``). For guides, installation instructions, and examples, see the `Guide <https://apple.github.io/coremltools/docs-guides/index.html>`_.
 
 .. toctree::
    :maxdepth: 1
@@ -30,7 +30,7 @@ This document is the API Reference for Core ML Tools (``coremltools``). For guid
    :maxdepth: 1
    :caption: Resources
 
-   Guide and Examples <https://coremltools.readme.io/docs>
+   Guide and Examples <https://apple.github.io/coremltools/docs-guides/index.html>
    Core ML Format Specification <https://apple.github.io/coremltools/mlmodel/index.html>
    source/api-versions.rst
    GitHub <https://github.com/apple/coremltools>


### PR DESCRIPTION
This PR is for the GitHub-hosted public version of `coremltools`. 

The PR edits the following for links to the "Guide" (or "guides") and grammar/stylistic changes:

```
modified:   ../README.md
modified:   source/how-to-contribute.md
modified:   ../docs/documentation.md
modified:   ../docs/index.rst
```


Branch:
docs-change-links-for-guide

---

**Previews**:

- [coremltools API Reference](https://tonybove-apple.github.io/coremltools/)

- [Core ML Tools Guide](https://tonybove-apple.github.io/coremltools/docs-guides/) Using the book theme

