### PR TITLE
Docs-Guides - Neural Engine (NE) and Other Edits

### DIFF
--- a/docs-guides/index.rst
+++ b/docs-guides/index.rst
@@ -24,7 +24,6 @@ This guide includes instructions and examples. For details about using the API c
    :caption: API Reference
 
    coremltools API Reference <https://apple.github.io/coremltools/index.html>
-   source/unified-conversion-api.md
    Core ML Model Format <https://apple.github.io/coremltools/mlmodel/index.html>
 
 .. toctree::
@@ -43,6 +42,7 @@ This guide includes instructions and examples. For details about using the API c
    :maxdepth: 1
    :caption: Unified Conversion
 
+   source/unified-conversion-api.md
    source/convert-learning-models.rst
    source/convert-tensorflow.rst
    source/convert-pytorch.rst

--- a/docs-guides/index.rst
+++ b/docs-guides/index.rst
@@ -21,23 +21,23 @@ This guide includes instructions and examples. For details about using the API c
 
 .. toctree::
    :maxdepth: 1
+   :caption: API Reference
+
+   coremltools API Reference <https://apple.github.io/coremltools/index.html>
+   source/unified-conversion-api.md
+   Core ML Model Format <https://apple.github.io/coremltools/mlmodel/index.html>
+
+.. toctree::
+   :maxdepth: 1
    :caption: Overview
 
    source/overview-coremltools.md
+   source/installing-coremltools.md
+   source/introductory-quickstart.md
    source/new-features.md
    source/faqs.md
    source/coremltools-examples.md
    source/how-to-contribute.md
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Essentials
-
-   source/installing-coremltools.md
-   source/introductory-quickstart.md
-   source/unified-conversion-api.md
-   coremltools API Reference <https://apple.github.io/coremltools/index.html>
-   Core ML Model Format <https://apple.github.io/coremltools/mlmodel/index.html>
 
 .. toctree::
    :maxdepth: 1

--- a/docs-guides/source/faqs.md
+++ b/docs-guides/source/faqs.md
@@ -12,7 +12,7 @@ This page offers frequently asked questions (FAQs):
 - [Are TensorFlow or PyTorch the only starting points to make a deep learning Core ML model?](#starting-a-deep-learning-core-ml-model)
 - [How do I handle the unsupported op error "convert function for op not implemented"?](#handling-an-unsupported-op)
 - [Can I choose custom names for the input and outputs of the model during conversion?](#choosing-custom-names-for-input-and-outputs)
-- [If I change my fixed-shape model to use flexible inputs, will it still run on the Apple Neural Network (ANE)?](#ane-with-flexible-input-shapes)
+- [If I change my fixed-shape model to use flexible inputs, will it still run on the  Neural Engine?](#neural-engine-with-flexible-input-shapes)
 - [Why use `ct.optimize.torch` rather than PyTorch's default quantization?](#why-optimizetorch-is-better-than-pytorchs-default-quantization)
 
 ***
@@ -159,9 +159,9 @@ output_names = [out.name for out in spec.description.output]
 
 You can update these names by using the [`rename_feature`](mlmodel-utilities.md#rename-a-feature) API.
 
-## ANE With Flexible Input Shapes
+## Neural Engine With Flexible Input Shapes
 
-When converting a fixed-shape model (which already runs on the ANE) to use flexible inputs, you should specify a flexible input shape with a set of predetermined shapes using [`EnumeratedShapes`](https://apple.github.io/coremltools/source/coremltools.converters.mil.input_types.html#enumeratedshapes). The converted model will run on the ANE, unless the conversion introduces dynamic layers not supported on the ANE, such as converting a static reshape to a fully dynamic reshape.
+When converting a fixed-shape model that already runs on the Neural Engine (NE) to use flexible inputs, you should specify a flexible input shape with a set of predetermined shapes using [`EnumeratedShapes`](https://apple.github.io/coremltools/source/coremltools.converters.mil.input_types.html#enumeratedshapes). The converted model will run on the NE, unless the conversion introduces dynamic layers not supported on the NE, such as converting a static reshape to a fully dynamic reshape.
 
 With `EnumeratedShapes` the model can be optimized for the finite set of input shapes on the device during compilation. You can provide up to 128 different shapes. If you need more flexibility for inputs, consider setting the range for each dimension.
 

--- a/docs-guides/source/load-and-convert-model.md
+++ b/docs-guides/source/load-and-convert-model.md
@@ -166,16 +166,16 @@ For more details on tracing and scripting to produce PyTorch models for conversi
 
 ## Set the Compute Units
 
-Normally you convert a model by using [`convert()`](https://apple.github.io/coremltools/source/coremltools.converters.convert.html#module-coremltools.converters._converters_entry) without using the `compute_units` parameter. In most cases you don’t need it, because the converter picks the default optimized path for fast execution while loading the model. The default setting (`ComputeUnit.ALL`) uses all compute units available, including the Apple Neural Engine (ANE), the CPU, and the graphics processing unit (GPU). Whether you are using [ML programs](convert-to-ml-program) or [neural networks](convert-to-neural-network), the defaults for conversion and prediction are picked to execute the model in the most performant way, as described in [Typed Execution](typed-execution).
+Normally you convert a model by using [`convert()`](https://apple.github.io/coremltools/source/coremltools.converters.convert.html#module-coremltools.converters._converters_entry) without using the `compute_units` parameter. In most cases you don’t need it, because the converter picks the default optimized path for fast execution while loading the model. The default setting (`ComputeUnit.ALL`) uses all compute units available, including the Neural Engine (NE), the CPU, and the graphics processing unit (GPU). Whether you are using [ML programs](convert-to-ml-program) or [neural networks](convert-to-neural-network), the defaults for conversion and prediction are picked to execute the model in the most performant way, as described in [Typed Execution](typed-execution).
 
 However, you may find it useful, especially for debugging, to specify the actual compute units when converting or loading a model by using the `compute_units` parameter. The parameter is based on the [MLComputeUnits](https://developer.apple.com/documentation/coreml/mlcomputeunits) enumeration in the Swift developer language — compute units are employed when [loading a Core ML model](https://developer.apple.com/documentation/coreml/mlmodel/3600218-load), taking in MLmodelConfiguration which includes compute units. Therefore, both the [MLModel](https://apple.github.io/coremltools/source/coremltools.models.html#module-coremltools.models.model) class and  [`convert()`](https://apple.github.io/coremltools/source/coremltools.converters.convert.html#module-coremltools.converters._converters_entry) provide the `compute_units` parameter. 
 
 The `compute_units` parameter can have the following values:
 
 - `coremltools.ComputeUnit.CPU_ONLY`: Limit the model to use only the CPU.
-- `coremltools.ComputeUnit.CPU_AND_GPU`: Use both the CPU and GPU, but not the ANE.
-- `coremltools.ComputeUnit.CPU_AND_NE`: Use both the CPU and ANE, but not the GPU.
-- `coremltools.ComputeUnit.ALL`: The default setting uses all compute units available, including the ANE, CPU, and GPU.
+- `coremltools.ComputeUnit.CPU_AND_GPU`: Use both the CPU and GPU, but not the NE.
+- `coremltools.ComputeUnit.CPU_AND_NE`: Use both the CPU and NE, but not the GPU.
+- `coremltools.ComputeUnit.ALL`: The default setting uses all compute units available, including the NE, CPU, and GPU.
 
 For example, the following converts the model and sets the `compute_units` to CPU only:
 

--- a/docs-guides/source/model-prediction.md
+++ b/docs-guides/source/model-prediction.md
@@ -50,7 +50,7 @@ To learn how to work with images and achieve better performance and more conveni
 
 ## Specifying Compute Units
 
-If you don't specify compute units when converting or loading a model, all compute units available on the device are used for execution including the Apple Neural Engine (ANE), the CPU, and the graphics processing unit (GPU). 
+If you don't specify compute units when converting or loading a model, all compute units available on the device are used for execution including the Neural Engine (NE), the CPU, and the graphics processing unit (GPU). 
 
 You can control which compute unit the model runs on by setting the `compute_units` argument when converting a model (with [`coremltools.convert()`](https://apple.github.io/coremltools/source/coremltools.converters.convert.html#coremltools.converters._converters_entry.convert)) or loading a model (with [`coremltools.models.MLModel`](https://apple.github.io/coremltools/source/coremltools.models.html#module-coremltools.models.model)). Calling [`predict()`](https://apple.github.io/coremltools/source/coremltools.models.html#coremltools.models.model.MLModel.predict) on the converted or loaded model restricts the model to use only the specific compute units for execution. 
 

--- a/docs-guides/source/new-conversion-options.md
+++ b/docs-guides/source/new-conversion-options.md
@@ -35,7 +35,7 @@ For ML programs, coremltools produces a model with float 16 precision by default
 
 ## Pick the Compute Units for Execution
 
-The converter picks the default optimized path for fast execution while loading the model. The default setting (`ComputeUnit.ALL`) uses all compute units available, including the Apple Neural Engine (ANE), the CPU, and the graphics processing unit (GPU). 
+The converter picks the default optimized path for fast execution while loading the model. The default setting (`ComputeUnit.ALL`) uses all compute units available, including the  Neural Engine (NE), the CPU, and the graphics processing unit (GPU). 
 
 However, you may find it useful, especially for debugging, to specify the actual compute units when converting or loading a model by using the `compute_units` parameter. For details, see [Set the compute units](load-and-convert-model.md#set-the-compute-units).
 

--- a/docs-guides/source/overview-coremltools.md
+++ b/docs-guides/source/overview-coremltools.md
@@ -1,6 +1,8 @@
 # What Is Core ML Tools?
 
-The [coremltools](https://github.com/apple/coremltools "apple/coremltools") Python package is the primary way to convert third-party models to Core ML. [Core ML](https://developer.apple.com/documentation/coreml "Core ML Framework") is an Apple framework to integrate machine learning models into your app. 
+The [`coremltools`](https://github.com/apple/coremltools "apple/coremltools") Python package is the primary way to convert third-party models to Core ML. [Core ML](https://developer.apple.com/documentation/coreml "Core ML Framework") is an Apple framework to integrate machine learning models into your app. 
+
+For details about using the `coremltools` API classes and methods, see the [coremltools API Reference](https://apple.github.io/coremltools/index.html).
 
 Use Core ML Tools to convert models from third-party training libraries such as [TensorFlow](https://www.tensorflow.org "TensorFlow") and [PyTorch](https://pytorch.org "PyTorch") to the [Core ML model package format](https://developer.apple.com/documentation/coreml/core_ml_api/updating_a_model_file_to_a_model_package). You can then use Core ML to integrate the models into your app.
 
@@ -20,11 +22,12 @@ With Core ML Tools you can:
 
 Core ML provides a unified representation for all models. Your app uses Core ML APIs and user data to make predictions, and to fine-tune models, all on the user’s device. Running a model strictly on the user’s device removes any need for a network connection, which helps keep the user’s data private and your app responsive.
 
-Core ML optimizes on-device performance by leveraging the CPU, GPU, and Apple Neural Engine (ANE) while minimizing its memory footprint and power consumption.
+Core ML optimizes on-device performance by leveraging the CPU, GPU, and Neural Engine (NE) while minimizing its memory footprint and power consumption.
 
 
 ## Additional Resources
 
+- The [coremltools API Reference](https://apple.github.io/coremltools/index.html) provides details about using the `coremltools` API classes and methods.
 - The [Machine Learning](https://developer.apple.com/machine-learning/ "Machine Learning") page provides educational material, tutorials, guides, and documentation for Apple developers.
 - The [ML & Vision session videos](https://developer.apple.com/videos/frameworks/machine-learning-and-vision "ML & Vision session videos from the World Wide Developer Conference") from the World Wide Developer Conference are a great place to start if you are new to machine learning technology and Core ML.
 - The [Core ML documentation](https://developer.apple.com/documentation/coreml "Core ML documentation") walks you through the first steps in developing an app with a machine learning model.

--- a/docs-guides/source/typed-execution-example.md
+++ b/docs-guides/source/typed-execution-example.md
@@ -2,7 +2,7 @@
 
 The following example demonstrates the recommended workflow when using [ML Programs](convert-to-ml-program) with [Typed Execution](typed-execution). The workflow consists of the following steps:
 
-1. Convert the model to a float 16 typed Core ML model, which is eligible to execute on a combination of the ANE, GPU and CPU.
+1. Convert the model to a float 16 typed Core ML model, which is eligible to execute on a combination of the Neural Engine (NE), GPU and CPU.
 
 2. Check the accuracy of the Core ML model with the source model on a set of input examples, using an error metric that is suitable for that model.
 
@@ -227,5 +227,5 @@ Testing the match between the models visually.
 
 As expected it is hard to spot any difference! With an SNR of 70dB, the float 16 typed Core ML model is sufficient. Since the output is a new stylized image, it does not need to exactly match that of the original model, as long as it represents the style faithfully.
 
-While the float 16 version of the model performs well with this image, the best practice would be to check a set of validation images. If their SNRs are also high, you would deploy the float 16 version model, as it can execute on the ANE as well as the GPU and CPU.
+While the float 16 version of the model performs well with this image, the best practice would be to check a set of validation images. If their SNRs are also high, you would deploy the float 16 version model, as it can execute on the NE as well as the GPU and CPU.
 

--- a/docs-guides/source/typed-execution.md
+++ b/docs-guides/source/typed-execution.md
@@ -46,7 +46,7 @@ A sample Core ML model description, as shown in Xcode. The input and output of t
 A neural network does not define the types of intermediate tensors that are produced by one layer and consumed by another.
 ```
 
-The Core ML runtime dynamically partitions the network graph into sections for the Apple Neural Engine (ANE), GPU, and CPU, and each unit executes its section of the network using its native type to maximize its performance and the model’s overall performance. The GPU and ANE use float 16 precision, and the CPU uses float 32. The execution precision varies based on the hardware and software versions, since the partitioning of the graph varies with hardware and software. 
+The Core ML runtime dynamically partitions the network graph into sections for the Neural Engine (NE), GPU, and CPU, and each unit executes its section of the network using its native type to maximize its performance and the model’s overall performance. The GPU and NE use float 16 precision, and the CPU uses float 32. The execution precision varies based on the hardware and software versions, since the partitioning of the graph varies with hardware and software. 
 
 You have some control over numeric precision by configuring the set of allowed compute units when converting the model (such as `All`, `CPU&GPU`, or `CPUOnly`), as shown in following chart:
 
@@ -74,7 +74,7 @@ For example, for float 32 precision, the only guaranteed path is to use `CPUOnly
 In an ML program, the types of all the intermediate tensors are specified in the model itself.
 ```
 
-An ML program uses the same automatic partitioning scheme that neural networks use to distribute work to the ANE, GPU, and CPU. However, the types of the tensors add an additional constraint. The runtime respects the explicit types as the minimum precision, and will not reduce the precision. 
+An ML program uses the same automatic partitioning scheme that neural networks use to distribute work to the NE, GPU, and CPU. However, the types of the tensors add an additional constraint. The runtime respects the explicit types as the minimum precision, and will not reduce the precision. 
 
 For example, a float 32 typed model will only ever run with float 32 precision. A float 16 typed model may run with float 32 precision as well, depending on the availability of the float 16 version of the op, which in turn may depend on the hardware and software versions. With an ML program, the precision and compute engine are independent of each other.
 
@@ -91,7 +91,7 @@ The ML program runtime supports an expanded set of precisions on the backend eng
 
 By default, an ML program produced by the converter is typed in float 16 precision, and run with the default configuration that uses all compute units (similar to the default neural network).
 
-For models sensitive to precision, you can set the precision to float 32 during conversion by using the `compute_precision=coremltools.precision.FLOAT32` flag with the [`convert()`](https://apple.github.io/coremltools/source/coremltools.converters.convert.html#module-coremltools.converters._converters_entry) method. Such a model is guaranteed to run with float 32 precision on all hardware and software versions. Unlike a neural network, the float 32 typed ML program will run on a CPU as well as the GPU. Only the ANE is barred as a compute unit when a model is typed with float 32 precision. 
+For models sensitive to precision, you can set the precision to float 32 during conversion by using the `compute_precision=coremltools.precision.FLOAT32` flag with the [`convert()`](https://apple.github.io/coremltools/source/coremltools.converters.convert.html#module-coremltools.converters._converters_entry) method. Such a model is guaranteed to run with float 32 precision on all hardware and software versions. Unlike a neural network, the float 32 typed ML program will run on a CPU as well as the GPU. Only the NE is barred as a compute unit when a model is typed with float 32 precision. 
 
 With an ML program, you can even mix and match precision support within a single compute unit, such as the CPU or GPU. If you need float 32 precision for specific layers instead of the entire model, you can selectively preserve float 32 tensor types by using the `compute_precision=ct.transform.Float16ComputePrecision()` transform during model conversion.
 


### PR DESCRIPTION
This PR is for the GitHub-hosted public version of `coremltools`; specifically, the `docs-guides` folder. 

This PR edits various files to fix the following:

- ANE should be "NE" (Apple Neural Engine should be Neural Engine) throughout.
- API reference links:
	- Move up in the navigation column to new API section at top.
	- Include Core ML Model Format with new API section at top.
	- Move Getting Started and Installing into Overview section.
	- Move Core ML Tools API Overview into Unified Conversion section.
	- Remove Essentials section title.
	- Add to Additional Resources section of What Is Core ML Tools.

```
	modified:   index.rst
	modified:   source/faqs.md
	modified:   source/load-and-convert-model.md
	modified:   source/model-prediction.md
	modified:   source/new-conversion-options.md
	modified:   source/overview-coremltools.md
	modified:   source/typed-execution-example.md
	modified:   source/typed-execution.md
```

Branch:
docs-guides-ane-ne-other-edits

---

**Previews**:

- [coremltools API Reference](https://tonybove-apple.github.io/coremltools/)

- [Core ML Tools Guide](https://tonybove-apple.github.io/coremltools/docs-guides/) Using the book theme

