### PR TITLE
Docs - 7.1 Update and avg_pool and add space_to_batch and batch_to_space

### DIFF
--- a/coremltools/converters/mil/mil/ops/defs/iOS15/pool.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS15/pool.py
@@ -101,26 +101,16 @@ class avg_pool(Pooling):
         * ``S == len(D_in)``.
 
     pad_type: const str (Required)
+        Must be one of ``valid``, ``same``, ``custom`` or ``same_lower``.
 
-        Must be one of the following:
-
-            * ``valid``: No padding. This is equivalent to custom pad with
-              ``pad[2*i] == pad[2*i+1] == 0, for i=0,...,len(d_in)-1``.
-            * ``custom``: Specify custom padding in the parameter ``pad``.
-            * ``same``: Input is padded such that out spatial shapes are
-              ``d_out[i] = ceil(d_in[i] / strides[i])``.
-            * ``same_lower``: Similar to ``same`` but the padding
-              will place extra rows/cols on the top/left if the padding amount is odd.
-
-        Specifically, for ``i = 0,..,,len(d_in)-1``, the equivalent paddings are
-        calculated as follows:
-
-            * ``dilated_kernel = (K[i] - 1) * dilate[i] + 1``
-            * If ``dilated_kernel`` is odd,
-              ``padding[2*i] = padding[2*i+1] = floor(dilated_kernel / 2)``
-            * Otherwise:
-              ``padding[2*i] = ceil((dilated_kernel - 1) / 2)``,
-              ``padding[2*i+1] = floor((dilated_kernel - 1) / 2)``
+        * ``valid``: No padding. This is equivalent to custom pad with ``pad[i] = 0, for
+          all i``.
+        * ``same`` : This is equivalent to custom pad with ``pad[2*i] + pad[2*i+1] = kernel_size[i]``.
+        * ``custom``: Specify custom padding in the parameter pad. note that ``same``
+          padding is equivalent to custom padding with
+          ``pad[2*i] + pad[2*i+1] = kernel_size[i]``.
+        * ``same_lower``: Similar to ``same`` but the padding
+          will place extra rows/cols on the top/left if the padding amount is odd.
 
     pad: const<[P],i32> (Optional. Default to all 0s)
         * ``pad`` represents the number of elements to pad before and after each
@@ -145,6 +135,7 @@ class avg_pool(Pooling):
     -------
     tensor<[n, C_out,\*D_out], T>
         * Same rank as ``x``.
+        * ``C_out`` is the number of output channels or depth dimensions.
         * When ``ceil_mode = False``:
             * ``D_out[i] = floor[(D_in[i] + pad[2*i] + pad[2*i+1] - kernel_sizes[i]) /
               strides[i]] +1, for i = 0, .., len(D_in) - 1`` is mathematically the same
@@ -196,24 +187,24 @@ class l2_pool(Pooling):
     ----------
     x: tensor<[n,C_in,*D_in], T> (Required)
         * Only support 1d and 2d pooling.
-        * See ``avg_pool``.
+        * See :py:class:`avg_pool`.
 
     kernel_sizes: const tensor<[K], T> (Required)
-        * See ``avg_pool``.
+        * See :py:class:`avg_pool`.
 
     strides: const tensor<[S],i32> (Optional, default to all 1s)
-        * See ``avg_pool``.
+        * See :py:class:`avg_pool`.
 
     pad_type: const str (Required)
-        * See ``avg_pool``.
+        * See :py:class:`avg_pool`.
 
     pad: const<[P],i32> (Optional, default to all 0s)
-        * See ``avg_pool``.
+        * See :py:class:`avg_pool`.
 
     Returns
     -------
     tensor<[n, C_out,*D_out], T>
-        * See ``avg_pool``.
+        * See :py:class:`avg_pool`.
 
     Attributes
     ----------
@@ -239,27 +230,27 @@ class max_pool(Pooling):
     Parameters
     ----------
     x: tensor<[n,C_in,*D_in], T> (Required)
-        * See ``avg_pool``.
+        * See :py:class:`avg_pool`.
 
     kernel_sizes: const tensor<[K], T> (Required)
-        * See ``avg_pool``.
+        * See :py:class:`avg_pool`.
 
     strides: const tensor<[S],i32> (Optional, default to all 1s)
-        * See ``avg_pool``.
+        * See :py:class:`avg_pool`.
 
     pad_type: const str (Required)
-        * See ``avg_pool``.
+        * See :py:class:`avg_pool`.
 
     pad: const<[P],i32> (Optional, default to all 0s)
-        * See ``avg_pool``.
+        * See :py:class:`avg_pool`.
 
     ceil_mode: const<bool>
-        * see ``avg_pool``.
+        * see :py:class:`avg_pool`.
 
     Returns
     -------
     tensor<[n, C_out,*D_out], T>
-        * See ``avg_pool``.
+        * See :py:class:`avg_pool`.
 
     Attributes
     ----------

--- a/coremltools/converters/mil/mil/ops/defs/iOS15/tensor_transformation.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS15/tensor_transformation.py
@@ -19,7 +19,12 @@ from coremltools.converters.mil.mil import (
 from coremltools.converters.mil.mil.input_type import DefaultInputs, InputSpec, TensorInputType
 from coremltools.converters.mil.mil.operation import SYMBOL, VALUE
 from coremltools.converters.mil.mil.ops.defs._op_reqs import register_op
-from coremltools.converters.mil.mil.ops.defs._utils import solve_slice_by_index_shape
+from coremltools.converters.mil.mil.ops.defs._utils import (
+    get_param_val,
+    get_squeeze_axes,
+    solve_slice_by_index_shape,
+    solve_slice_by_index_slice,
+)
 from coremltools.converters.mil.mil.types.symbolic import (
     any_symbolic,
     any_variadic,
@@ -514,23 +519,16 @@ class slice_by_index(Operation):
             )
 
     def type_inference(self):
-
-        # get tensor and set default value
-        begin = self.begin.val
-        end = self.end.val
-        x_rank = self.x.rank
-        stride = self.stride.val if self.stride is not None else [1] * x_rank
-        begin_mask = (
-            self.begin_mask.val if self.begin_mask is not None else [False] * x_rank
-        )
-        end_mask = self.end_mask.val if self.end_mask is not None else [False] * x_rank
-        squeeze_mask = (
-            self.squeeze_mask.val if self.squeeze_mask is not None else [False] * x_rank
-        )
-
         # solve shape
-        x_shape = self.x.shape
-        ret_shape = solve_slice_by_index_shape(x_shape, begin, end, stride, begin_mask, end_mask, squeeze_mask)
+        ret_shape = solve_slice_by_index_shape(
+            self.x.shape,
+            self.begin.val,
+            self.end.val,
+            get_param_val(self.stride),
+            get_param_val(self.begin_mask),
+            get_param_val(self.end_mask),
+            get_param_val(self.squeeze_mask),
+        )
 
         if len(ret_shape) == 0:
             # Scalar case.
@@ -541,41 +539,21 @@ class slice_by_index(Operation):
     def value_inference(self):
         if self.x.sym_val is None or self.begin.val is None or self.end.val is None:
             return None
-        begin = [int(i) for i in list(self.begin.val[:])]
-        end = [int(i) for i in list(self.end.val[:])]
-        stride = [1] * self.x.rank if self.stride is None else self.stride.val
-        begin_mask = (
-            [False] * self.x.rank if self.begin_mask is None else self.begin_mask.val
-        )
-        end_mask = [False] * self.x.rank if self.end_mask is None else self.end_mask.val
-        squeeze_mask = (
-            [False] * self.x.rank
-            if self.squeeze_mask is None
-            else self.squeeze_mask.val
-        )
 
-        slices = []
-        for idx, mask in enumerate(begin_mask):
-            if mask:
-                begin[idx] = None
-        for idx, mask in enumerate(end_mask):
-            if mask:
-                end[idx] = None
-        squeeze_axes = []
-        for idx, mask in enumerate(squeeze_mask):
-            if mask:
-                end[idx] = None
-                stride[
-                    idx
-                ] = 2147483647  # We slice out only 1 element by setting stride to INF
-                squeeze_axes.append(idx)
-        for idx in range(self.x.rank):
-            slices.append(slice(begin[idx], end[idx], stride[idx]))
-
-        slices = tuple(slices)
+        # solve the data slices and slice tensor
+        slices = solve_slice_by_index_slice(
+            self.x.shape,
+            self.begin.val,
+            self.end.val,
+            get_param_val(self.stride),
+            get_param_val(self.begin_mask),
+            get_param_val(self.end_mask),
+            get_param_val(self.squeeze_mask),
+        )
         res = self.x.sym_val[slices]
 
-        # remove squeezed axes
+        # remove squeeze_axes
+        squeeze_axes = get_squeeze_axes(get_param_val(self.squeeze_mask), self.x.rank)
         if len(squeeze_axes) > 0:
             if len(squeeze_axes) == len(res.shape):
                 if len(res) == 0:
@@ -747,7 +725,7 @@ class space_to_batch(Operation):
     ----------
     x: tensor<[n, C, H, W], T> (Required)
         * Input tensor must have rank ``4``.
-        * The first and the second dimension are batch and channel, respectively.
+        * The first and the second dimension are batch, channel; respectively.
         * The remaining dimensions ``(H, W)`` are treated as "spatial dimensions".
     block_shape: const tensor<[2], i32> (Required)
         * The length of the ``block_shape`` must be ``2``.
@@ -823,11 +801,11 @@ class batch_to_space(Operation):
     ----------
     x: tensor<[n, C, H, W], T> (Required)
         * Input tensor must have rank ``4``.
-        * The first and the second dimension are batch and channel, respectively.
+        * The first and the second dimension are batch, channel; respectively.
         * The remaining dimensions ``(H, W)`` are treated as "spatial dimensions".
     block_shape: const tensor<[2], i32> (Required)
         * The length of the ``block_shape`` must be ``2``.
-        * It defines the shapes of the block in which the spatial dimensions are multiplied
+        * It defines the shapes of the block in which the spatial dimensions are multiplied.
     crops: const tensor<[2, 2], i32> (Required)
         * It must have shape ``(2, 2)``.
         * It defines the amount to crop from each spatial dimension.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,8 +21,8 @@ import pathlib
 project = 'coremltools API Reference'
 copyright = '2021, Apple Inc'
 author = 'Apple Inc'
-release = '7.0'
-version = '7.0'
+release = '7.1'
+version = '7.1'
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/source/coremltools.converters.mil.mil.ops.defs.rst
+++ b/docs/source/coremltools.converters.mil.mil.ops.defs.rst
@@ -376,6 +376,7 @@ tensor\_transformation (iOS 15)
 
 .. automodule:: coremltools.converters.mil.mil.ops.defs.iOS15.tensor_transformation
 
+   .. autoclass:: batch_to_space
    .. autoclass:: depth_to_space
    .. autoclass:: expand_dims
    .. autoclass:: pixel_shuffle
@@ -385,6 +386,7 @@ tensor\_transformation (iOS 15)
    .. autoclass:: slice_by_index
    .. autoclass:: slice_by_size
    .. autoclass:: sliding_windows
+   .. autoclass:: space_to_batch
    .. autoclass:: space_to_depth
    .. autoclass:: squeeze
    .. autoclass:: transpose


### PR DESCRIPTION
This PR edits the following for grammar/stylistic and formatting changes:

```
modified:   coremltools/converters/mil/mil/ops/defs/iOS15/pool.py
modified:   coremltools/converters/mil/mil/ops/defs/iOS15/tensor_transformation.py
```

This PR also adds the `batch_to_space` and `space_to_batch` ops, and changes the version number to 7.1. 

**Note**: All docstring changes merged by others into the 7.1 version of the API will also be generated automatically by `sphinx.ext.autodoc` into HTML for the docs.

```
modified:   docs/conf.py
modified:   docs/source/coremltools.converters.mil.mil.ops.defs.rst
```

Addresses:
- rdar://116005065
- rdar://116248791


Branch:
docs-avg-pool-space-batch-edits


---

[**Click for Preview**](https://tonybove-apple.github.io/coremltools/)

