### PR TITLE
Docs-Guides - Update to 7.1 and Fix Typo

### DIFF
--- a/docs-guides/source/faqs.md
+++ b/docs-guides/source/faqs.md
@@ -174,5 +174,5 @@ You can use PyTorch's quantization APIs directly, and then convert the model to 
 
 ## Use a compiled model for faster initialization
 
-If your model initialization in python takes a long time, use a *compiled* Core ML model ([CompiledMLModel](https://apple.github.io/coremltools/source/coremltools.models.html#coremltools.models.CompiledMLModel)) rather than  [MLModel](https://apple.github.io/coremltools/source/coremltools.models.html#coremltools.models.model.MLModel) for making predictions. For large models, using a compiled model can save considerable time in initializing the model. For details, see [Using Compiled Python Models for Prediction](model-prediction.md#using-compiled-python-models-for-prediction).
+If your model initialization in Python takes a long time, use a *compiled* Core ML model ([CompiledMLModel](https://apple.github.io/coremltools/source/coremltools.models.html#coremltools.models.CompiledMLModel)) rather than  [MLModel](https://apple.github.io/coremltools/source/coremltools.models.html#coremltools.models.model.MLModel) for making predictions. For large models, using a compiled model can save considerable time in initializing the model. For details, see [Using Compiled Python Models for Prediction](model-prediction.md#using-compiled-python-models-for-prediction).
 

--- a/docs-guides/source/installing-coremltools.md
+++ b/docs-guides/source/installing-coremltools.md
@@ -9,7 +9,7 @@ Support for Python 2 has been deprecated since [Core ML Tools 4.1](https://githu
 The supported MacOS versions are as follows:
 
 - Core ML Tools 4.1 supports macOS 10.13 and newer.
-- Core ML Tools 5 and 6 support macOS 10.15 and newer.
+- Core ML Tools 5, 6, and 7 support macOS 10.15 and newer.
 ```
 
 ## Prerequisites
@@ -86,7 +86,7 @@ source coremltools-venv/bin/activate
 
 ## Install Core ML Tools
 
-Use the following command to install or upgrade to [version 7.0](https://github.com/apple/coremltools) of Core ML Tools:
+Use the following command to install or upgrade to [version 7.1](https://github.com/apple/coremltools) of Core ML Tools:
 
 ```shell
 pip install -U coremltools


### PR DESCRIPTION
This PR updates the installation and other mentions of the version number to 7.1, and fixes a typo.

```
modified:   source/faqs.md
modified:   source/installing-coremltools.md

```

Branch:
docs-guides-update-7.1-typos

---

**Preview**:

- [Core ML Tools Guide](https://tonybove-apple.github.io/coremltools/docs-guides/)

