### PR TITLE
Docs - Format Docstrings for make_pipeline and Other 7.1 Changes

### DIFF
--- a/coremltools/converters/_converters_entry.py
+++ b/coremltools/converters/_converters_entry.py
@@ -112,7 +112,8 @@ def convert(
                 - Path to a ``.pt`` file
 
             - Torch Exported Models:
-                - A `ExportedProgram <https://pytorch.org/docs/stable/export.html#torch.export.ExportedProgram> ` object with `EDGE` dialect
+                - An `ExportedProgram <https://pytorch.org/docs/stable/export.html#torch.export.ExportedProgram>`_
+                  object with ``EDGE`` dialect.
 
     source : str (optional)
 
@@ -181,12 +182,13 @@ def convert(
                   ``ImageType``, the converted Core ML model will have inputs with
                   the same name.
                 - If ``dtype`` is missing:
-                  * For ``minimum_deployment_target <= ct.target.macOS12``, it defaults to float 32.
-                  * For ``minimum_deployment_target >= ct.target.macOS13``, and with ``compute_precision`` in float 16 precision.
-                    It defaults to float 16.
+                    * For ``minimum_deployment_target <= ct.target.macOS12``, it defaults to float 32.
+                    * For ``minimum_deployment_target >= ct.target.macOS13``, and with ``compute_precision`` in float 16 precision.
+                      It defaults to float 16.
 
             - Torch Exported Models:
-                - The ``inputs`` parameter is not supported. ``inputs`` parameter is inferred from Torch ExportedProgram.
+                - The ``inputs`` parameter is not supported. The ``inputs`` parameter is
+                  inferred from the Torch `ExportedProgram <https://pytorch.org/docs/stable/export.html#torch.export.ExportedProgram>`_.
 
     outputs : list of ``TensorType`` or ``ImageType`` (optional)
 
@@ -230,20 +232,19 @@ def convert(
               If ``dtype`` not specified, the outputs inferred of type float 32
               defaults to float 16.
 
-        * PyTorch:
+        * PyTorch: TorchScript Models
+            - If specified, the length of the list must match the number of
+              outputs returned by the PyTorch model.
+            - If ``name`` is specified, it is applied to the output names of the
+              converted Core ML model.
+            - For ``minimum_deployment_target >= ct.target.macOS13``,
+              and with ``compute_precision`` in float 16 precision.
+            - If ``dtype`` not specified, the outputs inferred of type float 32
+              defaults to float 16.
 
-            - TorchScript Models:
-                - If specified, the length of the list must match the number of
-                outputs returned by the PyTorch model.
-                - If ``name`` is specified, it is applied to the output names of the
-                converted Core ML model.
-                - For ``minimum_deployment_target >= ct.target.macOS13``, and with ``compute_precision`` in float 16 precision.
-                If ``dtype`` not specified, the outputs inferred of type float 32
-                defaults to float 16.
-
-            - Torch Exported Models:
-                - The ``outputs`` parameter is not supported. ``outputs`` parameter is inferred from Torch ExportedProgram.
-
+        * PyTorch: Torch Exported Models:
+            - The ``outputs`` parameter is not supported.
+              The ``outputs`` parameter is inferred from Torch `ExportedProgram <https://pytorch.org/docs/stable/export.html#torch.export.ExportedProgram>`_.
 
     classifier_config : ClassifierConfig class (optional)
         The configuration if the MLModel is intended to be a classifier.

--- a/coremltools/converters/mil/mil/passes/defs/optimize_tensor_operation.py
+++ b/coremltools/converters/mil/mil/passes/defs/optimize_tensor_operation.py
@@ -100,10 +100,10 @@ class fuse_squeeze_expand_dims(AbstractGraphPass):
 class expand_high_rank_reshape_and_transpose(AbstractGraphPass):
     """
     Detect the pattern ``reshape_1-->transpose-->reshape_2``, where ``reshape_1`` has
-    a output tensor with rank >= 6, and the reshape_2 produces a tensor with rank <= 5.
+    an output tensor with ``rank >= 6``, and ``reshape_2`` produces a tensor with ``rank <= 5``.
 
     In general, we can expand this pattern into a sequence of rank 4 ``reshape`` and ``transpose`` ops,
-    which is supported by Core ML runtime.
+    which is supported by the Core ML runtime.
 
     .. code-block::
 

--- a/coremltools/models/utils.py
+++ b/coremltools/models/utils.py
@@ -1065,23 +1065,24 @@ def make_pipeline(
 
     Parameters
     ----------
-    *models
+    *models :
         Two or more instances of ``ct.models.MLModel``.
 
-    compute_units: ``None`` or ``coremltools.ComputeUnit``
+    compute_units :
         The set of processing units that all models in the pipeline can use to make predictions.
+        Can be ``None`` or ``coremltools.ComputeUnit``.
 
-        If None, the ``compute_unit`` will be infered from the ``compute_units`` values of the models.
-        If all models do not have the same ``compute_units`` values, this parameter must be specified.
+        * If ``None``, the ``compute_unit`` will be infered from the ``compute_unit`` values of the models.
+          If all models do not have the same ``compute_unit`` values, this parameter must be specified.
 
-        ``coremltools.ComputeUnit`` is an enum with four possible values:
+        * ``coremltools.ComputeUnit`` is an enum with four possible values:
             - ``coremltools.ComputeUnit.ALL``: Use all compute units available, including the
-                neural engine.
+              neural engine.
             - ``coremltools.ComputeUnit.CPU_ONLY``: Limit the model to only use the CPU.
             - ``coremltools.ComputeUnit.CPU_AND_GPU``: Use both the CPU and GPU,
-                but not the neural engine.
+              but not the neural engine.
             - ``coremltools.ComputeUnit.CPU_AND_NE``: Use both the CPU and neural engine, but
-                not the GPU. Available only for macOS >= 13.0.
+              not the GPU. Available only for macOS >= 13.0.
 
     Returns
     -------


### PR DESCRIPTION
This PR edits the following for grammar/stylistic and formatting changes:

```
modified:   coremltools/converters/_converters_entry.py
modified:   coremltools/converters/mil/mil/passes/defs/optimize_tensor_operation.py
modified:   coremltools/models/utils.py

```


Branch:
docs-format-docstrings-make-pipeline-etc
