### PR TITLE
Add `numpy_t` as alias of `transpose`

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -788,7 +788,7 @@ def gt(context, node):
     context.add(greater)
 
 
-@register_torch_op(torch_alias=["t"])
+@register_torch_op(torch_alias=["t", "numpy_t"])
 def transpose(context, node):
     assert len(node.outputs) == 1
     inputs = _get_inputs(context, node)


### PR DESCRIPTION
`t` was already an alias, but sometimes the torch op used is `numpy_T`. This happens, for example, when converting the `falcon` family of models in this line: 
https://github.com/huggingface/transformers/blob/9beb2737d758160e845b66742a0c01201e38007f/src/transformers/models/falcon/modeling_falcon.py#L68
