### PR TITLE
Add clip as alias for clamp

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -5033,7 +5033,7 @@ def ceil(context, node):
     context.add(mb.ceil(x=inputs[0], name=node.name))
 
 
-@register_torch_op
+@register_torch_op(torch_alias=["clip"])
 def clamp(context, node):
     inputs = _get_inputs(context, node, expected=[1,2,3])
     x = inputs[0]


### PR DESCRIPTION
As stated [here](https://pytorch.org/docs/stable/generated/torch.clip.html) `clip` is an alias for the `clamp` operation