### PR TITLE
Refine compile_model API

### DIFF
--- a/coremltools/models/utils.py
+++ b/coremltools/models/utils.py
@@ -1011,7 +1011,9 @@ def compile_model(model: _Model_pb2.Model, destination_path: _Optional[str]=None
     Parameters
     ----------
     model: Model_pb2
-        Spec/protobuf to compile
+        Spec/protobuf to compile.
+
+        Note: an mlprogam which uses a blob file is not supported.
 
     destination_path: str
         Path where the compiled model will be saved.
@@ -1064,13 +1066,13 @@ def compile_model(model: _Model_pb2.Model, destination_path: _Optional[str]=None
 
     # Check model parameter
     if isinstance(model, str):
-        raise Exception("To get a compiled model from a saved MLModel, first load the model, "
+        raise TypeError("To get a compiled model from a saved MLModel, first load the model, "
                         " then call \"get_compiled_model_path\".")
     if isinstance(model, _ct.models.MLModel):
-        raise Exception("This model has already been compiled. Call \"get_compiled_model_path\""
+        raise TypeError("This model has already been compiled. Call \"get_compiled_model_path\""
                         " to get the compiled model.")
     if not isinstance(model, _Model_pb2.Model):
-        raise Exception("Unrecognized input for \"model\" parameter. It should be a spec.")
+        raise TypeError("Unrecognized input for \"model\" parameter. It should be a spec.")
 
     # Check file extension of destination_path parameter
     if destination_path is not None and not destination_path.rstrip('/').endswith(".mlmodelc"):

--- a/coremltools/models/utils.py
+++ b/coremltools/models/utils.py
@@ -1011,10 +1011,10 @@ def compile_model(model: _Model_pb2.Model, destination_path: _Optional[str]=None
     Parameters
     ----------
     model: Model_pb2
-        Spec to model to compile
+        Spec/protobuf to compile
 
     destination_path: str
-        Path to where the compiled model will be saved.
+        Path where the compiled model will be saved.
 
     Returns
     -------

--- a/coremltools/test/neural_network/test_compiled_model.py
+++ b/coremltools/test/neural_network/test_compiled_model.py
@@ -93,3 +93,18 @@ class TestCompiledModel:
         for cur_compute_unit in non_default_compute_units:
             compiled_model_path = compile_model(self.spec)
             self._test_compile_model_path(compiled_model_path, compute_units=cur_compute_unit)
+
+
+    def test_destination_path_parameter(self):
+        # Check correct usage
+        with TemporaryDirectory() as temp_dir:
+            dst_path = temp_dir + "/foo.mlmodelc"
+            compiled_model_path = compile_model(self.spec, dst_path)
+            self._test_compile_model_path(compiled_model_path)
+
+        # Check bad input
+        with TemporaryDirectory() as temp_dir:
+            dst_path = temp_dir + "/foo.badFileExtension"
+            with pytest.raises(Exception) as e:
+                compiled_model_path = compile_model(self.spec, dst_path)
+            assert " file extension." in str(e.value)

--- a/coremltools/test/neural_network/test_compiled_model.py
+++ b/coremltools/test/neural_network/test_compiled_model.py
@@ -58,7 +58,7 @@ class TestCompiledModel:
             file_path = save_dir + '/m.mlmodel'
             MLModel(self.spec).save(file_path)
 
-            with pytest.raises(Exception, match=", first load the model, ") as e:
+            with pytest.raises(TypeError, match=", first load the model, "):
                 compiled_model_path = compile_model(file_path)
 
 
@@ -69,7 +69,7 @@ class TestCompiledModel:
 
     def test_mlmodel_input(self):
         ml_model = MLModel(self.spec)
-        with pytest.raises(Exception, match=" model has already been compiled.") as e:
+        with pytest.raises(TypeError, match=" model has already been compiled."):
             compiled_model_path = compile_model(ml_model)
 
 
@@ -103,9 +103,8 @@ class TestCompiledModel:
         # Check bad input
         with TemporaryDirectory() as temp_dir:
             dst_path = temp_dir + "/foo.badFileExtension"
-            with pytest.raises(Exception) as e:
+            with pytest.raises(Exception, match=" file extension."):
                 compiled_model_path = compile_model(self.spec, dst_path)
-            assert " file extension." in str(e.value)
 
 
     def test_save_load_spec(self):

--- a/coremltools/test/neural_network/test_compiled_model.py
+++ b/coremltools/test/neural_network/test_compiled_model.py
@@ -6,6 +6,8 @@
 from shutil import copytree, rmtree
 from tempfile import TemporaryDirectory
 
+import pytest
+
 from coremltools import ComputeUnit
 from coremltools.models import CompiledMLModel, MLModel
 from coremltools.models.utils import compile_model, save_spec
@@ -55,8 +57,10 @@ class TestCompiledModel:
         with TemporaryDirectory() as save_dir:
             spec_file_path = save_dir + '/spec.mlmodel'
             save_spec(self.spec, spec_file_path)
-            compiled_model_path = compile_model(spec_file_path)
-            self._test_compile_model_path(compiled_model_path)
+
+            with pytest.raises(Exception) as e:
+                compiled_model_path = compile_model(spec_file_path)
+            assert ", first load the model, " in str(e.value)
 
 
     def test_spec_input(self):
@@ -66,8 +70,9 @@ class TestCompiledModel:
 
     def test_mlmodel_input(self):
         ml_model = MLModel(self.spec)
-        compiled_model_path = compile_model(ml_model)
-        self._test_compile_model_path(compiled_model_path)
+        with pytest.raises(Exception) as e:
+            compiled_model_path = compile_model(ml_model)
+        assert " model has already been compiled." in str(e.value)
 
 
     def test_from_existing_mlmodel(self):


### PR DESCRIPTION
* For efficiency restrict allowable model types 
* Add instructions for previously allowable types
* Add optional parameter for where to save compiled model

CI: https://gitlab.com/coremltools1/coremltools/-/pipelines/1075605326