### PR TITLE
Docs - Sphinx Indent Errors in Rest of API Reference

### DIFF
--- a/coremltools/converters/mil/input_types.py
+++ b/coremltools/converters/mil/input_types.py
@@ -441,7 +441,7 @@ class EnumeratedShapes:
             * The default shape that is used for initiating the model, and set in
               the metadata of the model file.
             * If ``None``, then the first element in ``shapes`` is used.
-			
+
 
         Examples
         --------
@@ -454,7 +454,7 @@ class EnumeratedShapes:
                     (2, 4, 32, 32)
                 ],
                 default=(2, 4, 64, 64)
-			)
+            )
 
             my_core_ml_model = ct.convert(
                 my_model,

--- a/coremltools/converters/mil/input_types.py
+++ b/coremltools/converters/mil/input_types.py
@@ -435,7 +435,7 @@ class EnumeratedShapes:
             * If input provided is not a :py:class:`Shape` object,
               but can be converted to a :py:class:`Shape`,
               the :py:class:`Shape` object would be stored in ``shapes`` instead.
-			
+
 
         default: tuple of int or None
             * The default shape that is used for initiating the model, and set in
@@ -447,19 +447,19 @@ class EnumeratedShapes:
         --------
         .. sourcecode:: python
 
-			sample_shape = ct.EnumeratedShapes(
-				shapes=[
-					(2, 4, 64, 64),
-					(2, 4, 48, 48),
-					(2, 4, 32, 32)
-				],
-				default=(2, 4, 64, 64)
+            sample_shape = ct.EnumeratedShapes(
+               shapes=[
+                    (2, 4, 64, 64),
+                    (2, 4, 48, 48),
+                    (2, 4, 32, 32)
+                ],
+                default=(2, 4, 64, 64)
 			)
 
-			my_core_ml_model = ct.convert(
-				my_model,
-				inputs=[ct.TensorType(name="sample", shape=sample_shape)],
-			)
+            my_core_ml_model = ct.convert(
+                my_model,
+                inputs=[ct.TensorType(name="sample", shape=sample_shape)],
+            )
         """
 
         # lazy import to avoid circular import

--- a/coremltools/converters/mil/input_types.py
+++ b/coremltools/converters/mil/input_types.py
@@ -33,22 +33,21 @@ class ClassifierConfig:
         Parameters
         ----------
         class_labels: str / list of int / list of str
-            If a ``list`` is provided, the ``list`` maps the index of the output of a
-            neural network to labels in a classifier.
-
-            If a ``str`` is provided, the ``str`` points to a file which maps the index
-            to labels in a classifier.
+            * If a ``list`` is provided, the ``list`` maps the index of the output of a
+              neural network to labels in a classifier.
+            * If a ``str`` is provided, the ``str`` points to a file which maps the index
+              to labels in a classifier.
 
         predicted_feature_name: str
             Name of the output feature for the class labels exposed in the
             Core ML neural network classifier. Default: ``'classLabel'``.
 
         predicted_probabilities_output: str
-            If provided, then this is the name of the neural network blob which
-            generates the probabilities for each class label (typically the output
-            of a softmax layer).
+            * If provided, then this is the name of the neural network blob which
+              generates the probabilities for each class label (typically the output
+              of a softmax layer).
+            * If not provided, then the last output layer is assumed.
 
-            If not provided, then the last output layer is assumed.
         """
         self.class_labels = class_labels
         self.predicted_feature_name = predicted_feature_name
@@ -67,8 +66,8 @@ class InputType:
 
         shape: list, tuple, Shape object, EnumeratedShapes object, or None
             The shape(s) that are valid for this input.
-
             If set to ``None``, the shape will be inferred from the model itself.
+
         """
 
         self.name = name
@@ -172,15 +171,16 @@ class TensorType(InputType):
             The ``name`` is required except for a TensorFlow model in which there is
             exactly one input Placeholder.
 
-        shape: (1) list of positive int or RangeDim, or (2) EnumeratedShapes
-            The shape of the input.
+        shape: The shape of the input
+            - List of positive int or :py:class:`RangeDim`, or
+            - :py:class:`EnumeratedShapes`
 
             For TensorFlow:
-              * The ``shape`` is optional. If omitted, the shape is inferred from
-                TensorFlow graph's Placeholder shape.
+               * The ``shape`` is optional. If omitted, the shape is inferred from
+                 TensorFlow graph's Placeholder shape.
 
             For PyTorch:
-              * The ``shape`` is required.
+               * The ``shape`` is required.
 
         dtype: np.generic or mil.type type
             For example, ``np.int32`` or ``coremltools.converters.mil.mil.types.fp32``
@@ -194,7 +194,7 @@ class TensorType(InputType):
                  elements are required to have the same value.
 
               * The ``default_value`` may not be specified if ``shape`` is
-                ``EnumeratedShapes``.
+                :py:class:`EnumeratedShapes`.
 
         Examples
         --------
@@ -339,7 +339,7 @@ class RangeDim:
 class Shape:
     def __init__(self, shape, default=None):
         """
-        The basic shape class to be set in InputType.
+        The basic shape class to be set in :py:class:`InputType`.
 
         Parameters
         ----------
@@ -350,7 +350,7 @@ class Shape:
             The default shape that is used for initiating the model, and set in
             the metadata of the model file.
 
-            If None, then ``shape`` is used.
+            If ``None``, then ``shape`` is used.
         """
         from coremltools.converters.mil.mil import get_new_symbol
 
@@ -430,35 +430,36 @@ class EnumeratedShapes:
 
         Parameters
         ----------
-        shapes: list of Shape objects, or Shape-compatible lists.
-            The valid shapes of the inputs.
-
-            If input provided is not a Shape object, but can be converted to a Shape,
-            the Shape object would be stored in ``shapes`` instead.
+        shapes: list of Shape objects, or Shape-compatible lists
+            * The valid shapes of the inputs.
+            * If input provided is not a :py:class:`Shape` object,
+              but can be converted to a :py:class:`Shape`,
+              the :py:class:`Shape` object would be stored in ``shapes`` instead.
+			
 
         default: tuple of int or None
-            The default shape that is used for initiating the model, and set in
-            the metadata of the model file.
-
-            If None, then the first element in ``shapes`` is used.
+            * The default shape that is used for initiating the model, and set in
+              the metadata of the model file.
+            * If ``None``, then the first element in ``shapes`` is used.
+			
 
         Examples
         --------
         .. sourcecode:: python
 
-        sample_shape = ct.EnumeratedShapes(
-            shapes=[
-                (2, 4, 64, 64),
-                (2, 4, 48, 48),
-                (2, 4, 32, 32)
-            ],
-            default=(2, 4, 64, 64)
-        )
+			sample_shape = ct.EnumeratedShapes(
+				shapes=[
+					(2, 4, 64, 64),
+					(2, 4, 48, 48),
+					(2, 4, 32, 32)
+				],
+				default=(2, 4, 64, 64)
+			)
 
-        my_core_ml_model = ct.convert(
-            my_model,
-            inputs=[ct.TensorType(name="sample", shape=sample_shape)],
-        )
+			my_core_ml_model = ct.convert(
+				my_model,
+				inputs=[ct.TensorType(name="sample", shape=sample_shape)],
+			)
         """
 
         # lazy import to avoid circular import

--- a/coremltools/converters/mil/mil/ops/defs/iOS15/image_resizing.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS15/image_resizing.py
@@ -644,9 +644,7 @@ class affine(Operation):
     the coordinates ``x’`` and ``y’`` with the following equation, and then computing the
     value at the coordinate ``(x’,y’)`` in the input image using either bilinear or
     nearest neighbor interpolation. If the ``(x’, y’)`` point falls outside the input
-    image, then padding information is used to compute the value.
-
-    ::
+    image, then padding information is used to compute the value::
 
         x’ = a0 * x + a1 * y + a2
         y’ = b0 * x + b1 * y + b2
@@ -655,45 +653,41 @@ class affine(Operation):
     Parameters
     ----------
     x: tensor<[B, C, H1, W1], T>
-        * Must be rank ``4``.
+       * Must be rank ``4``.
     transform_matrix: tensor<[D, 6], T>
-        * Must be rank ``2``.
-        * ``D`` can be either ``B`` or 1.
-            * If ``D == B``, there is a separate transform matrix for each batch.
-            * If ``D == 1``, the same matrix is used for all input batches.
-            * For each batch: ``[a0, a1, a2, b0, b1, b2]``.
+       * Must be rank ``2``.
+       * ``D`` can be either ``B`` or 1.
+          * If ``D == B``, there is a separate transform matrix for each batch.
+          * If ``D == 1``, the same matrix is used for all input batches.
+          * For each batch: ``[a0, a1, a2, b0, b1, b2]``.
     output_height: const<i32>
-        * Target output height
+       * Target output height
     output_width: const<i32>
-        * Target output width
+       * Target output width
     sampling_mode: const<str>
-        * Allowed values: ``"bilinear"``
+       * Allowed values: ``"bilinear"``
     padding_mode: const<str>
-        * Allowed values: ``"constant"``.
-        * Note that the following example is 1D case for brevity.
-          The op supports only 2D image input.
-        * If ``padding_mode == "constant"``:
-            * The input image is assumed to be padded with the padding_value.
-            * For example, ``|1, 2, 3| -> |0, 0, 0, 1, 2, 3, 0, 0, 0|``.
+       * Allowed values: ``"constant"``.
+       * Note that the following example is 1D case for brevity. The op supports only 2D image input.
+       * If ``padding_mode == "constant"``:
+          * The input image is assumed to be padded with the padding_value.
+          * For example, ``|1, 2, 3| -> |0, 0, 0, 1, 2, 3, 0, 0, 0|``.
     padding_value: const<T>
-        * Currently non-zero values are not supported.
-        * To be used only when ``padding_mode == "constant"``, ignored in other cases.
+       * Currently non-zero values are not supported.
+       * To be used only when ``padding_mode == "constant"``, ignored in other cases.
     coordinates_mode: const<str>
-        * Allowed values: ``"normalized_minus_one_to_one"``
-        * If ``coordinates_mode == "normalized_minus_one_to_one"``, in-image values are ``[-1, 1]``.
-        * For example, if ``coordinates_mode == "normalized_minus_one_to_one"``,
-          the in range values are ``[-1, 1]``. That is:
-            * ``(-1, -1)``, i.e. ``(w=-1, h=-1)``, corresponds to the top-left pixel.
-            * ``(1, -1)``, i.e. ``(w=1, h=-1)``, corresponds to the top-right pixel.
-            * ``(-1, 1)``, i.e. ``(w=-1, h=1)``, corresponds to the bottom-left pixel.
-            * ``(1, 1)``, i.e. ``(w=1, h=1)``, corresponds to the bottom-right pixel.
+       * Allowed values: ``"normalized_minus_one_to_one"``.
+       * If ``coordinates_mode == "normalized_minus_one_to_one"``, in-image values are ``[-1, 1]``.
+       * For example, if ``coordinates_mode == "normalized_minus_one_to_one"``, the in-range values are ``[-1, 1]``. That is:
+          * ``(-1, -1)``, i.e. ``(w=-1, h=-1)``, corresponds to the top-left pixel.
+          * ``(1, -1)``, i.e. ``(w=1, h=-1)``, corresponds to the top-right pixel.
+          * ``(-1, 1)``, i.e. ``(w=-1, h=1)``, corresponds to the bottom-left pixel.
+          * ``(1, 1)``, i.e. ``(w=1, h=1)``, corresponds to the bottom-right pixel.
     align_corners: const<bool>
-        * Currently ``align_corners=False`` is not supported.
-        * To be used only when ``coordinates_mode != unnormalized``, ignored otherwise.
-        * if ``align_corners == True``, the extrema coordinates correspond
-          to the center of the first and last corner pixels.
-        * if ``align_corners == False``, the extrema coordinates correspond
-          to the edge of the first and last corner pixels.
+       * Currently ``align_corners=False`` is not supported.
+       * To be used only when ``coordinates_mode != unnormalized``, ignored otherwise.
+       * If ``align_corners == True``, the extrema coordinates correspond to the center of the first and last corner pixels.
+       * If ``align_corners == False``, the extrema coordinates correspond to the edge of the first and last corner pixels.
 
     Returns
     -------
@@ -799,20 +793,20 @@ class resample(Operation):
         * Note that the following example is 1D case for brevity.
           The op supports only 2D image input.
         * If ``padding_mode == "constant"``:
-            * The input image is assumed to be padded with the ``padding_value``.
-            * For example: ``|1, 2, 3| -> |0, 0, 0, 1, 2, 3, 0, 0, 0|``
+           * The input image is assumed to be padded with the ``padding_value``.
+           * For example: ``|1, 2, 3| -> |0, 0, 0, 1, 2, 3, 0, 0, 0|``
         * if ``padding_mode == "border"``:
-            * The input image is assumed to be padded with the values replicated
-              from the values at the edge. This is also referred to as the
-              "clamped" or "replication" mode, since the padded values are
-              clamped to the border values.
-            * For example: ``|1, 2, 3| -> |1, 1, 1, 1, 2, 3, 3, 3, 3|``
+           * The input image is assumed to be padded with the values replicated
+             from the values at the edge. This is also referred to as the
+             "clamped" or "replication" mode, since the padded values are
+             clamped to the border values.
+           * For example: ``|1, 2, 3| -> |1, 1, 1, 1, 2, 3, 3, 3, 3|``
         * If ``padding_mode == "reflection"``:
-            * The border values are reflected, *not* including the values at the edge/border.
-            * For example: ``|1, 2, 3| -> |2, 3, 2, 1, 2, 3, 2, 1, 2|``
+           * The border values are reflected, *not* including the values at the edge/border.
+           * For example: ``|1, 2, 3| -> |2, 3, 2, 1, 2, 3, 2, 1, 2|``
         * If ``padding_mode == "symmetric"``:
-            * Values are reflected, including the border/edge values.
-            * For example: ``|1, 2, 3| -> |3, 2, 1 , 1, 2, 3, 3, 2, 1|``
+           * Values are reflected, including the border/edge values.
+           * For example: ``|1, 2, 3| -> |3, 2, 1 , 1, 2, 3, 3, 2, 1|``
     padding_value: const<T>
         * To be used only when ``padding_mode == "constant"``, ignored in other cases.
     coordinates_mode: const<str>
@@ -825,17 +819,14 @@ class resample(Operation):
           the in-image values are ``[-1, 1]``.
         * If ``coordinates_mode == "normalized_zero_to_one"``,
           in-image values are ``[0, 1]``.
-        * For example, if ``coordinates_mode == "normalized_minus_one_to_one"``,
-          the in range values are [-1, 1]. That is:
-            * ``(-1, -1)``, i.e. ``(w=-1, h=-1)``, corresponds to the top-left pixel.
-            * ``(1, -1)``, i.e. ``(w=1, h=-1)``, corresponds to the top-right pixel.
-            * ``(-1, 1)``, i.e. ``(w=-1, h=1)``, corresponds to the bottom-left pixel.
-            * ``(1, 1)``, i.e. ``(w=1, h=1)``, corresponds to the bottom-right pixel.
+        * For example, if ``coordinates_mode == "normalized_minus_one_to_one"``, the in range values are [-1, 1]. That is:
+           * ``(-1, -1)``, i.e. ``(w=-1, h=-1)``, corresponds to the top-left pixel.
+           * ``(1, -1)``, i.e. ``(w=1, h=-1)``, corresponds to the top-right pixel.
+           * ``(-1, 1)``, i.e. ``(w=-1, h=1)``, corresponds to the bottom-left pixel.
+           * ``(1, 1)``, i.e. ``(w=1, h=1)``, corresponds to the bottom-right pixel.
     align_corners: const<bool>
-        * If ``align_corners == True``, the extrema coordinates correspond
-          to the center of the first and last corner pixels.
-        * If ``align_corners == False``, the extrema coordinates correspond
-          to the edge of the first and last corner pixels.
+        * If ``align_corners == True``, the extrema coordinates correspond to the center of the first and last corner pixels.
+        * If ``align_corners == False``, the extrema coordinates correspond to the edge of the first and last corner pixels.
 
     Returns
     -------

--- a/coremltools/converters/mil/mil/ops/defs/iOS16/constexpr_ops.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS16/constexpr_ops.py
@@ -22,8 +22,10 @@ class constexpr_affine_dequantize(Operation):
     The quantized data is stored in the parameter ``quantized_data``.
     The other parameters -- ``scale``, ``zero_point``, and ``axis`` -- describe how
     unquantized values can be extracted from it, using the equation for affine/linear quantization:
-    ::
-                unquantized_data = scale * (quantized_data - zero_point)
+
+    .. sourcecode:: python
+
+        unquantized_data = scale * (quantized_data - zero_point)
 
     Although all of the parameters of this op are constants, this op is not constant folded
     to a single const op at the time of model serialization. The unquantized output will
@@ -38,15 +40,15 @@ class constexpr_affine_dequantize(Operation):
  	   * ``zero_point`` follows similar broadcasting rules and size constraints as ``scale``.
 
     scale: const tensor<DstT, [0..1]> (Required)
-       * ``scale`` can be either a scalar or a vector. If ``scale`` is a vector,
-         for implementation it is broadcast to the following shape:
-           * The rank of ``scale`` becomes the same as the rank of ``quantized_data``.
-           * The constraint: ``size(scale-vector) == quantized_data.shape[axis]``.
-           * For ``i == axis``, ``scale.shape[i] == quantized_data.shape[i]``.
-           * For ``i != axis``, ``scale.shape == 1``.
-         For example, assume ``quantized_data.shape = (2, 3, 4, 5)`` and ``axis = 1``.
-         If ``scale`` is a vector, then ``scale.size`` needs to be equal to
-         ``quantized_data.shape[axis] i.e = 3``, which would be broadcast to ``(1, 3, 1, 1)``.
+       * ``scale`` can be either a scalar or a vector.
+       * If ``scale`` is a vector, for implementation it is broadcast to the following shape:
+          * The rank of ``scale`` becomes the same as the rank of ``quantized_data``.
+          * The constraint: ``size(scale-vector) == quantized_data.shape[axis]``.
+          * For ``i == axis``, ``scale.shape[i] == quantized_data.shape[i]``.
+          * For ``i != axis``, ``scale.shape == 1``.
+            For example, assume ``quantized_data.shape = (2, 3, 4, 5)`` and ``axis = 1``.
+            If ``scale`` is a vector, then ``scale.size`` needs to be equal to
+            ``quantized_data.shape[axis] i.e = 3``, which would be broadcast to ``(1, 3, 1, 1)``.
 
     axis: const tensor<int32, []> (Required)
 
@@ -136,8 +138,10 @@ class constexpr_affine_dequantize(Operation):
 class constexpr_cast(Operation):
     """
     A compile-time operation that returns a constant output value upon casting its constant input.
-    ::
-                Expression: output = constexpr_cast(source_val, output_dtype="fp32")
+
+    .. sourcecode:: python
+
+        Expression: output = constexpr_cast(source_val, output_dtype="fp32")
 
     Parameters
     ----------
@@ -205,7 +209,9 @@ class constexpr_lut_to_dense(Operation):
     bits of the same index are filled in the LSBs of the next byte.
 
     For example:
-    ::
+
+    .. sourcecode:: python
+
         if n_bits = 2, shape = (5,) => M = 2 bytes
 
                     MSB             LSB
@@ -301,14 +307,17 @@ class constexpr_sparse_to_dense(Operation):
     moving up to the most significant bit.
 
     For example:
-    ::
-        shape = (5,) => M = 1 bytes
 
+    .. sourcecode:: python
+
+        shape = (5,) => M = 1 bytes
+        
                    MSB                  LSB
                     |                    |
         mask    =  |x  x  x  0  1  1  0  0 |      <== packed elements
                    |--|--|--|i4|i3|i2|i1|i0|      <== tagged element ids
                    |      byte 0           |      <== tagged bytes
+
 
     Returns
     -------

--- a/coremltools/converters/mil/mil/ops/defs/iOS17/image_resizing.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS17/image_resizing.py
@@ -263,8 +263,7 @@ class resize(Operation):
         * Available mode: ``LINEAR``, ``NEAREST_NEIGHBOR``.
 
     sampling_mode: const<str> (Optional, default="DEFAULT")
-        * Available mode: ``DEFAULT``, ``STRICT_ALIGN_CORNERS``, ``ALIGN_CORNERS``,
-        ``OFFSET_CORNERS``, ``UNALIGN_CORNERS``.
+        * Available mode: ``DEFAULT``, ``STRICT_ALIGN_CORNERS``, ``ALIGN_CORNERS``, ``OFFSET_CORNERS``, ``UNALIGN_CORNERS``.
         * For details about different sampling modes, see iOS 15 :py:class:`~.iOS15.image_resizing.resize_bilinear`.
 
     Returns

--- a/coremltools/converters/mil/mil/ops/defs/iOS17/reduction.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS17/reduction.py
@@ -48,9 +48,10 @@ class reduce_argmax(reduce_arg):
     """
     Computes the indices of the maximum value across dimensions of a tensor.
     In case of ties, the identity of the return value is not guaranteed.
-    The differences between this version and the iOS 15 :py:class:`~.iOS15.reduction.reduce_argmax`:
-      - The output supports uint16 dtype.
-      - New optional input ``output_dtype``.
+
+    The differences between this version and the iOS 15 :py:class:`~.iOS15.reduction.reduce_argmax` are:
+        * The output supports uint16 dtype.
+        * New optional input ``output_dtype``.
 
     Parameters
     ----------
@@ -89,9 +90,10 @@ class reduce_argmin(reduce_arg):
     """
     Computes the indices of the minimum value across dimensions of a tensor.
     In case of ties, the identity of the return value is not guaranteed.
-    The differences between this version and the iOS 15 :py:class:`~.iOS15.reduction.reduce_argmin`:
-      - The output supports uint16 dtype.
-      - New optional input ``output_dtype``.
+
+    The differences between this version and the iOS 15 :py:class:`~.iOS15.reduction.reduce_argmin` are:
+        * The output supports uint16 dtype.
+        * New optional input ``output_dtype``.
 
     Parameters
     ----------

--- a/coremltools/converters/mil/mil/ops/defs/iOS17/scatter_gather.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS17/scatter_gather.py
@@ -40,12 +40,13 @@ class scatter(_scatter_iOS15):
 
         index = iOS17.select(index >= 0, index, index + max_index)
 
-    - New input parameter called ``validate_indices`` has been added to all scatter ops.
-      Its behavior is as follows:
-       - If ``True``, it raises a runtime (possibly also a compile-time) exception for out-of-bound values of
-         the ``indices`` parameter.
-       - If ``False``, absolutely no checking is performed for out-of-bound values of ``indices``
-         either at compile or runtime. Behavior for out-of-bound indices is undefined but memory safe.
+    - New input parameter called ``validate_indices`` has been added to all scatter ops. Its behavior is as follows:
+       - If ``True``, it raises a runtime (possibly also a compile-time) exception
+         for out-of-bound values of the ``indices`` parameter.
+       - If ``False``, absolutely no checking is performed for out-of-bound values
+         of ``indices`` either at compile or runtime. Behavior for out-of-bound indices
+         is undefined but memory safe.
+
 
     Parameters
     ----------
@@ -60,10 +61,11 @@ class scatter(_scatter_iOS15):
         * Can be the following modes: ``add``, ``div``, ``max``, ``min``, ``mul``, ``sub``, ``update``.
         * Default value is ``update``.
     validate_indices: const bool (Optional)
-        * If ``True``, it raises a runtime (possibly also a compile-time) exception for out-of-bound values of
-          the ``indices`` parameter.
-        * If ``False``, absolutely no checking is performed for out-of-bound values of ``indices``
-          either at compile or runtime. Behavior for out-of-bound indices is undefined but memory safe.
+        * If ``True``, it raises a runtime (possibly also a compile-time) exception
+          for out-of-bound values of the ``indices`` parameter.
+        * If ``False``, absolutely no checking is performed for out-of-bound values
+          of ``indices`` either at compile or runtime. Behavior for out-of-bound indices
+          is undefined but memory safe.
         * Default value is ``False``.
 
     Returns
@@ -129,10 +131,11 @@ class scatter_along_axis(_scatter_along_axis_iOS15):
         * Default to ``add``.
         * Can be the following modes: ``add``, ``div``, ``max``, ``min``, ``mul``, ``sub``, ``update``.
     validate_indices: const bool (Optional)
-        * If ``True``, it raises a runtime (possibly also a compile-time) exception for out-of-bound values of
-          the ``indices`` parameter.
-        * If ``False``, absolutely no checking is performed for out-of-bound values of ``indices``
-          either at compile or runtime. Behavior for out-of-bound indices is undefined but memory safe.
+        * If ``True``, it raises a runtime (possibly also a compile-time) exception
+          for out-of-bound values of the ``indices`` parameter.
+        * If ``False``, absolutely no checking is performed for out-of-bound values
+          of ``indices`` either at compile or runtime. Behavior for out-of-bound indices
+          is undefined but memory safe.
         * Default value is ``False``.
 
     Returns
@@ -255,8 +258,7 @@ class gather(_gather_iOS16):
 
          index = iOS17.select(index >= 0, index, index + max_index)
 
-    - New input parameter called ``validate_indices`` has been added to all gather ops.
-      Its behavior is as follows:
+    - New input parameter called ``validate_indices`` has been added to all gather ops. Its behavior is as follows:
        - If ``True``, it raises a runtime (possibly also a compile-time) exception for
          out-of-bound values of the ``indices`` parameter.
        - If ``False``, absolutely no checking is performed for out-of-bound values of ``indices``
@@ -272,10 +274,11 @@ class gather(_gather_iOS16):
     batch_dims: const i32 (Optional. Default=``0``)
         * The number of batch dimensions.
     validate_indices: const bool (Optional)
-        * If ``True``, it raises a runtime (possibly also a compile-time) exception for out-of-bound values of
-          the ``indices`` parameter.
-        * If ``False``, absolutely no checking is performed for out-of-bound values of ``indices``
-          either at compile or runtime. Behavior for out-of-bound indices is undefined but memory safe.
+        * If ``True``, it raises a runtime (possibly also a compile-time) exception
+          for out-of-bound values of the ``indices`` parameter.
+        * If ``False``, absolutely no checking is performed for out-of-bound values
+          of ``indices`` either at compile or runtime. Behavior for out-of-bound indices
+          is undefined but memory safe.
         * Default value is ``False``.
 
     Returns

--- a/coremltools/converters/mil/mil/ops/defs/iOS17/tensor_operation.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS17/tensor_operation.py
@@ -86,11 +86,14 @@ class topk(_topk_iOS16):
     """
     A version of ``topk`` for iOS 17+. The differences between this version and the
     iOS 16 :py:class:`~.iOS16.tensor_operation.topk` are:
-    - New data type support. The newly added data type is:
-        - int8, uint8, int16, unint16 for ``x`` and output.
-        - int8, int16 for ``k``.
-    - Validation restrictions on the optional ``indices`` output: must be either uint16 or int32. Also
-      a new input parameter ``output_indices_dtype`` is added to set the dtype of output ``indices``.
+
+       - New data type support. The newly added data types are:
+          - int8, uint8, int16, unint16 for ``x`` and output.
+          - int8, int16 for ``k``.
+       - Validation restrictions on the optional ``indices`` output must be either
+         uint16 or int32.
+       - A new input parameter ``output_indices_dtype`` has been added
+         to set the dtype of output ``indices``.
 
     Parameters
     ----------

--- a/coremltools/converters/mil/mil/passes/defs/optimize_repeat_ops.py
+++ b/coremltools/converters/mil/mil/passes/defs/optimize_repeat_ops.py
@@ -333,55 +333,60 @@ class cast_optimization(AbstractGraphPass):
     This is a non-algebraic translation which assumes that the upcasting doesn't change the user's intent.
 
     (1) Example for redundant ``cast`` op removal:
-        .. code-block::
+         .. sourcecode:: python
 
             Input graph:
             input(fp16) -> cast(dtype="fp16") -> relu -> out
-
+            
             Output graph:
             input -> relu -> out
 
-        The input and output tensors for the ``cast`` op are both with type of ``fp16``. Hence, it can be removed.
+         The input and output tensors for the ``cast`` op are both with type of ``fp16``.
+         Hence, it can be removed.
 
     (2) Example for two ``cast`` ops fusion:
-        .. code-block::
+         .. sourcecode:: python
 
             Input graph:
             input(int8) -> cast(dtype="fp16") -> cast(dtype="fp32") -> out
-
+            
             Output graph:
             input(int8) -> cast(dtype="fp32") -> out
 
-        The data range and resolution of the above graph are limited by the int8 input, so the fusion is allowed.
+         The data range and resolution of the above graph are limited by the int8 input,
+         so the fusion is allowed.
 
     (3) Negative example for two ``cast`` ops fusion:
-        .. code-block::
+         .. sourcecode:: python
+
             Input graph:
             input(fp32) -> cast(dtype="bool") -> cast(dtype="fp16") -> out
-
+            
             Output graph:
             Same as input graph.
 
-        The above two ``cast`` ops cannot be merged, since after the first cast, the resolution of the numerical output
-        is downcasted to binary (``0, 1``). If we fuse them, the output would be in the range and resolution of ``fp16`` instead.
+         The above two ``cast`` ops cannot be merged, since after the first cast,
+         the resolution of the numerical output is downcasted to binary (``0, 1``).
+         If we fuse them, the output would be in the range and resolution of ``fp16`` instead.
 
-    (3) Another Negative example for two ``cast`` ops fusion:
-        .. code-block::
+    (4) Another Negative example for two ``cast`` ops fusion:
+         .. sourcecode:: python
+
             Input graph:
             input(int32) -> cast(dtype="int8") -> cast(dtype="uint8") -> out
-
+            
             Output graph:
             Same as input graph.
 
-        The above two ``cast`` ops cannot be merged, since in the original graph, by going through two casts,
-        the output numerical range is capped to ``[0, 127]``.
-
-        However, if two ``cast`` ops are reduced to 1 ``cast(dtype="uint8")``, the output numerical would in the range of ``[0, 255]``.
-        The fusion would cause numerical issue for the numbers between ``[128, 255]``, which is prohibited.
+         The above two ``cast`` ops cannot be merged, since in the original graph,
+         by going through two casts, the output numerical range is capped to ``[0, 127]``.
+         However, if two ``cast`` ops are reduced to 1 ``cast(dtype="uint8")``, the output
+         numerical would in the range of ``[0, 255]``. The fusion would cause numerical
+         issue for the numbers between ``[128, 255]``, which is prohibited.
 
     In general, two ``cast`` ops can be merged if the output data range and resolution is not affected.
 
-    For more examples, please see the unittests start with prefix "TestCastOptimization" in test_passes.py
+    For more examples, please see the unittests that start with prefix ``TestCastOptimization`` in ``test_passes.py``.
     """
 
     def apply(self, prog):

--- a/coremltools/models/neural_network/builder.py
+++ b/coremltools/models/neural_network/builder.py
@@ -2326,18 +2326,21 @@ class NeuralNetworkBuilder:
             Weight of the convolution kernels.
 
             * If ``is_deconv`` is False, ``W`` should have
-              shape ``(height, width, kernel_channels, output_channels)``, where:
-                 ``kernel_channel = input_channels / groups``
+              shape ``(height, width, kernel_channels, output_channels)``, where::
+
+                 kernel_channel = input_channels / groups
+
             * If ``is_deconv`` is True, ``W`` should have
-              shape ``(height, width, kernel_channels, output_channels / groups)``, where:
-                 ``kernel_channel = input_channels``
+              shape ``(height, width, kernel_channels, output_channels / groups)``, where::
 
-            If ``W`` is of type ``bytes()`` (quantized), other quantization
-            related arguments must be provided as well (see below).
+                 kernel_channel = input_channels
 
-            For Core ML specification version >=4, ``W`` can be ``None``. In this case,
-            the convolution layer takes 2 inputs, where the 1st input represents
-            the input feature map, and the 2nd input represents the weight blob.
+            * If ``W`` is of type ``bytes()`` (quantized), other quantization-related
+              arguments must be provided as well (see below).
+
+            * For Core ML specification version >=4, ``W`` can be ``None``. In this case,
+              the convolution layer takes 2 inputs, where the 1st input represents
+              the input feature map, and the 2nd input represents the weight blob.
 
         b: numpy.array
             Biases of the convolution kernels. ``b`` should have shape ``(outputChannels, )``.
@@ -2349,15 +2352,13 @@ class NeuralNetworkBuilder:
             - If False, bias is ignored.
 
         is_deconv: boolean
-            Whether the convolution layer is performing a convolution or a
-            transposed convolution (deconvolution).
+            Whether the convolution layer is performing a convolution or a transposed convolution (deconvolution).
 
             - If True, the convolution layer is performing transposed convolution.
             - If False, the convolution layer is performing regular convolution.
 
         output_shape: tuple or None
-            Either ``None`` or a 2-tuple, specifying the output
-            shape ``(output_height, output_width)``.
+            Either ``None`` or a 2-tuple, specifying the output shape ``(output_height, output_width)``.
 
             - Used only when ``is_deconv == True``.
             - When ``is_deconv == False``, this parameter is ignored.
@@ -2370,8 +2371,8 @@ class NeuralNetworkBuilder:
             The output blob name of this layer.
 
         dilation_factors: list of int
-            Dilation factors across height and width directions. Must be a list of two positive integers.
-            Defaults to ``[1, 1]``.
+            Dilation factors across height and width directions. Must be a list of two
+            positive integers. Defaults to ``[1, 1]``.
 
         padding_top, padding_bottom, padding_left, padding_right: int
             Values of height (top, bottom) and width (left, right) padding

--- a/coremltools/optimize/coreml/_post_training_quantization.py
+++ b/coremltools/optimize/coreml/_post_training_quantization.py
@@ -580,8 +580,8 @@ class CoreMLWeightMetaData:
         meta_data = CoreMLWeightMetaData(data)
         print(meta_data)
 
-    Outputs:
-    ::
+    Outputs::
+    
         [
             val: np.ndarray(shape=(2, 2), dtype=float32)
             sparsity: 0.5

--- a/docs/source/coremltools.models.ml_program.rst
+++ b/docs/source/coremltools.models.ml_program.rst
@@ -1,21 +1,6 @@
 
-affine_quantize_weights
-----------------------------------------------------------------
-
 .. automodule:: coremltools.models.ml_program.compression_utils
 
    .. autofunction:: affine_quantize_weights
-
-palettize_weights
-----------------------------------------------------------------
-
-.. automodule:: coremltools.models.ml_program.compression_utils
-
    .. autofunction:: palettize_weights
-
-sparsify_weights
-----------------------------------------------------------------
-
-.. automodule:: coremltools.models.ml_program.compression_utils
-
    .. autofunction:: sparsify_weights

--- a/docs/source/coremltools.optimize.coreml.config.rst
+++ b/docs/source/coremltools.optimize.coreml.config.rst
@@ -1,14 +1,16 @@
 Compression Configuration
 ==========================
+
 .. automodule:: coremltools.optimize.coreml
+   :noindex:
+   
+   .. autoclass:: OpLinearQuantizerConfig
 
-    .. autoclass:: OpLinearQuantizerConfig
+   .. autoclass:: OpThresholdPrunerConfig
 
-    .. autoclass:: OpThresholdPrunerConfig
+   .. autoclass:: OpMagnitudePrunerConfig
 
-    .. autoclass:: OpMagnitudePrunerConfig
+   .. autoclass:: OpPalettizerConfig
 
-    .. autoclass:: OpPalettizerConfig
-
-    .. autoclass:: OptimizationConfig
-        :members: set_global, set_op_type, set_op_name, from_yaml, from_dict
+   .. autoclass:: OptimizationConfig
+      :members: set_global, set_op_type, set_op_name, from_yaml, from_dict


### PR DESCRIPTION
[**Click for Preview**](https://tonybove-apple.github.io/coremltools/)

This PR fixes the following indents and other warnings:

```
/Users/tonybove/opt/coremltools/coremltools/converters/mil/input_types.py:docstring of coremltools.converters.mil.input_types.EnumeratedShapes.__init__:9: WARNING: Definition list ends without a blank line; unexpected unindent.
/Users/tonybove/opt/coremltools/coremltools/converters/mil/input_types.py:docstring of coremltools.converters.mil.input_types.EnumeratedShapes.__init__:11: WARNING: Definition list ends without a blank line; unexpected unindent.
/Users/tonybove/opt/coremltools/coremltools/converters/mil/input_types.py:docstring of coremltools.converters.mil.input_types.EnumeratedShapes.__init__:16: WARNING: Definition list ends without a blank line; unexpected unindent.
/Users/tonybove/opt/coremltools/coremltools/converters/mil/mil/ops/defs/iOS16/constexpr_ops.py:docstring of coremltools.converters.mil.mil.ops.defs.iOS16.constexpr_ops.constexpr_affine_dequantize:9: ERROR: Unexpected indentation.
/Users/tonybove/opt/coremltools/coremltools/converters/mil/mil/ops/defs/iOS16/constexpr_ops.py:docstring of coremltools.converters.mil.mil.ops.defs.iOS16.constexpr_ops.constexpr_affine_dequantize:27: ERROR: Unexpected indentation.
/Users/tonybove/opt/coremltools/coremltools/converters/mil/mil/ops/defs/iOS16/constexpr_ops.py:docstring of coremltools.converters.mil.mil.ops.defs.iOS16.constexpr_ops.constexpr_affine_dequantize:26: WARNING: Block quote ends without a blank line; unexpected unindent.
/Users/tonybove/opt/coremltools/coremltools/converters/mil/mil/ops/defs/iOS16/constexpr_ops.py:docstring of coremltools.converters.mil.mil.ops.defs.iOS16.constexpr_ops.constexpr_cast:4: ERROR: Unexpected indentation.
/Users/tonybove/opt/coremltools/coremltools/converters/mil/mil/ops/defs/iOS16/constexpr_ops.py:docstring of coremltools.converters.mil.mil.ops.defs.iOS16.constexpr_ops.constexpr_lut_to_dense:47: ERROR: Unexpected indentation.
/Users/tonybove/opt/coremltools/coremltools/converters/mil/mil/ops/defs/iOS16/constexpr_ops.py:docstring of coremltools.converters.mil.mil.ops.defs.iOS16.constexpr_ops.constexpr_sparse_to_dense:44: ERROR: Unexpected indentation.
/Users/tonybove/opt/coremltools/coremltools/converters/mil/mil/ops/defs/iOS15/image_resizing.py:docstring of coremltools.converters.mil.mil.ops.defs.iOS15.image_resizing.affine:52: ERROR: Unexpected indentation.
/Users/tonybove/opt/coremltools/coremltools/converters/mil/mil/ops/defs/iOS15/image_resizing.py:docstring of coremltools.converters.mil.mil.ops.defs.iOS15.image_resizing.resample:61: ERROR: Unexpected indentation.
/Users/tonybove/opt/coremltools/coremltools/converters/mil/mil/ops/defs/iOS17/image_resizing.py:docstring of coremltools.converters.mil.mil.ops.defs.iOS17.image_resizing.resize:40: WARNING: Bullet list ends without a blank line; unexpected unindent.
/Users/tonybove/opt/coremltools/coremltools/converters/mil/mil/ops/defs/iOS17/reduction.py:docstring of coremltools.converters.mil.mil.ops.defs.iOS17.reduction.reduce_argmax:5: ERROR: Unexpected indentation.
/Users/tonybove/opt/coremltools/coremltools/converters/mil/mil/ops/defs/iOS17/reduction.py:docstring of coremltools.converters.mil.mil.ops.defs.iOS17.reduction.reduce_argmin:5: ERROR: Unexpected indentation.
/Users/tonybove/opt/coremltools/coremltools/converters/mil/mil/ops/defs/iOS17/scatter_gather.py:docstring of coremltools.converters.mil.mil.ops.defs.iOS17.scatter_gather.gather:18: ERROR: Unexpected indentation.
/Users/tonybove/opt/coremltools/coremltools/converters/mil/mil/ops/defs/iOS17/scatter_gather.py:docstring of coremltools.converters.mil.mil.ops.defs.iOS17.scatter_gather.scatter:16: ERROR: Unexpected indentation.
/Users/tonybove/opt/coremltools/coremltools/converters/mil/mil/ops/defs/iOS17/tensor_operation.py:docstring of coremltools.converters.mil.mil.ops.defs.iOS17.tensor_operation.topk:5: ERROR: Unexpected indentation.
/Users/tonybove/opt/coremltools/coremltools/converters/mil/mil/ops/defs/iOS17/tensor_operation.py:docstring of coremltools.converters.mil.mil.ops.defs.iOS17.tensor_operation.topk:2: WARNING: Block quote ends without a blank line; unexpected unindent.
/Users/tonybove/opt/coremltools/coremltools/models/neural_network/builder.py:docstring of coremltools.models.neural_network.builder.NeuralNetworkBuilder.add_convolution:42: ERROR: Unexpected indentation.
/Users/tonybove/opt/coremltools/coremltools/models/neural_network/builder.py:docstring of coremltools.models.neural_network.builder.NeuralNetworkBuilder.add_convolution:45: ERROR: Unexpected indentation.
/Users/tonybove/opt/coremltools/coremltools/optimize/coreml/_post_training_quantization.py:docstring of coremltools.optimize.coreml._post_training_quantization.CoreMLWeightMetaData:52: ERROR: Unexpected indentation.
/Users/tonybove/opt/coremltools/coremltools/converters/mil/mil/ops/defs/iOS15/image_resizing.py:docstring of coremltools.converters.mil.mil.ops.defs.iOS15.image_resizing.affine:9: WARNING: Could not lex literal_block as "python". Highlighting skipped.
/Users/tonybove/opt/coremltools/coremltools/models/ml_program/compression_utils.py:docstring of coremltools.models.ml_program.compression_utils:1: WARNING: duplicate object description of coremltools.models.ml_program.compression_utils, other instance in source/coremltools.models.ml_program, use :noindex: for one of them
/Users/tonybove/opt/coremltools/coremltools/models/ml_program/compression_utils.py:docstring of coremltools.models.ml_program.compression_utils:1: WARNING: duplicate object description of coremltools.models.ml_program.compression_utils, other instance in source/coremltools.models.ml_program, use :noindex: for one of them
/Users/tonybove/opt/coremltools/coremltools/optimize/coreml/__init__.py:docstring of coremltools.optimize.coreml:1: WARNING: duplicate object description of coremltools.optimize.coreml, other instance in source/coremltools.optimize.coreml.config, use :noindex: for one of them

```

---

[**Click for Preview**](https://tonybove-apple.github.io/coremltools/)

