### PR TITLE
[PyTorch] Add API to Query if a PyTorch Op is Supported in Core ML

### DIFF
--- a/coremltools/converters/mil/frontend/torch/__init__.py
+++ b/coremltools/converters/mil/frontend/torch/__init__.py
@@ -11,4 +11,4 @@ if _HAS_TORCH:
     from . import ops, quantization_ops
     from .dialect_ops import (torch_tensor_assign, torch_upsample_bilinear,
                               torch_upsample_nearest_neighbor)
-    from .torch_op_registry import register_torch_op
+    from .torch_op_registry import register_torch_op, is_torch_fx_node_supported

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_conversion_api.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_conversion_api.py
@@ -5,6 +5,7 @@
 
 import itertools
 import os
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -19,6 +20,7 @@ from coremltools._deps import (
 )
 from coremltools.converters.mil.frontend.torch.test.testing_utils import _copy_input_data
 from coremltools.converters.mil.frontend.torch.torch_op_registry import (
+    TorchOpsRegistry,
     _TORCH_OPS_REGISTRY,
     register_torch_op,
 )
@@ -263,6 +265,65 @@ class TestTorchOpsRegistry:
 
         # Cleanup the test
         del _TORCH_OPS_REGISTRY.name_to_func_mapping["test_func_dummy"]
+
+
+@pytest.mark.skipif(not _HAS_TORCH, reason=MSG_TORCH_NOT_FOUND)
+class TestFxNodeSupport:
+    @staticmethod
+    def test_simple_case():
+        class Model(torch.nn.Module):
+            def forward(self, a, x, b):
+                y = torch.mm(a, x)
+                z = y + b
+                a.sub_(z)
+                y = torch.mm(a, x)
+                z = y + b
+                return z
+
+        model = Model()
+        model.eval()
+        symbolic_traced = torch.fx.symbolic_trace(model)
+
+        for node in symbolic_traced.graph.nodes:
+            # There are many types of torch fx node,
+            # we only support "call_function" node for now
+            if node.op == "call_function":
+                # All PyTorch ops in the example model are supported, so they should all return true
+                assert ct.converters.mil.frontend.torch.is_torch_fx_node_supported(node)
+            # Other types of torch fx node are not supported
+            else:
+                assert not ct.converters.mil.frontend.torch.is_torch_fx_node_supported(node)
+
+    @staticmethod
+    def test_unsupported_op():
+        class Model(torch.nn.Module):
+            def forward(self, x, y):
+                z = x + y
+                return torch.nn.functional.softmax(z)
+
+        model = Model()
+        model.eval()
+        symbolic_traced = torch.fx.symbolic_trace(model)
+
+        # Mock our torch ops registry, pretending that only "add" is supported
+        with patch.object(
+            TorchOpsRegistry,
+            "__contains__",
+            side_effect=(lambda op_name: op_name == "add"),
+        ):
+            for node in symbolic_traced.graph.nodes:
+                # There are many types of torch fx node,
+                # we only support "call_function" node for now
+                if node.op == "call_function":
+                    # Only "add" is supported
+                    assert (
+                        (node.target.__name__.lower() == "add")
+                        == ct.converters.mil.frontend.torch.is_torch_fx_node_supported(node)
+                    )
+                # Other types of torch fx node are not supported
+                else:
+                    assert not ct.converters.mil.frontend.torch.is_torch_fx_node_supported(node)
+
 
 #################################################################################
 # Note: Starting from here, all of the following tests are also used as examples

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_conversion_api.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_conversion_api.py
@@ -269,6 +269,12 @@ class TestTorchOpsRegistry:
 
 @pytest.mark.skipif(not _HAS_TORCH, reason=MSG_TORCH_NOT_FOUND)
 class TestFxNodeSupport:
+    """
+    The API ``ct.converters.mil.frontend.torch.is_torch_fx_node_supported`` is used
+    by 3rd-party code ExecuTorch: https://github.com/pytorch/executorch/pull/1415,
+    so we cannot break it
+    """
+
     @staticmethod
     def test_simple_case():
         class Model(torch.nn.Module):

--- a/coremltools/converters/mil/frontend/torch/torch_op_registry.py
+++ b/coremltools/converters/mil/frontend/torch/torch_op_registry.py
@@ -157,7 +157,12 @@ def is_torch_fx_node_supported(torch_fx_node: torch.fx.Node) -> bool:
         torch_fx_node_target_name = torch_fx_node.target.__name__.lower()
     # Since we are only dealing with "call_function" node,
     # the contained PyTorch op must be functional, i.e. not in-place
-    assert not torch_fx_node_target_name.endswith("_")
+    assert (
+        not torch_fx_node_target_name.endswith("_")
+    ), (
+        "For now, since CoreML only supports call_function torch fx node, "
+        "all ops should be functional, i.e. there should not be any in-place op"
+    )
     # Target name may or may not contain prefix "aten.":
     #     1. For usual fx node, target is a PyTorch function, i.e. no prefix
     #     2. For executorch exported fx node, target is executorch.exir.dialects.edge._ops.EdgeOp,


### PR DESCRIPTION
## Motivation

In ExecuTorch, a partitioner is demanded to determine which part of the exir graph can be executed on which backend. Currently, ExecuTorch provides `CapabilityBasedPartitioner` API, which proposes possible partitions based on whether a PyTorch op (expressed as a `torch.fx.Node`) can run on the specified backend, in our case, Core ML.

From coremltools point of view, this means whether a single `torch.fx.Node` is convertible to pymil


## API Proposal

Naturally, we can have such a public API that takes a torch.fx.Node as input, then returns boolean output on whether it is convertible to pymil
```
def is_torch_fx_node_supported(torch_fx_node: torch.fx.Node) -> bool:
```
We have the flexibility to add new kwargs as needed in the future, e.g. something like `device=ANE` if we specifically want to know if a PyTorch op can run on ANE.

I’m not 100% sure about where to place this function and where to surface this function. I’m thinking:
* We can place this function either in `coremltools/converters/mil/frontend/torch/torch_op_registry.py`, or `coremltools/converters/mil/frontend/torch/converter.py` 
* Then we can surface this function either to `ct.is_torch_fx_node_supported` or `ct.converters.is_torch_fx_node_supported`

I'm going `coremltools/converters/mil/frontend/torch/torch_op_registry.py` and `ct.is_torch_fx_node_supported` for now, but I’m all ears to suggestions.


## Potential Implementations

As a starting point, we can simply query _TORCH_OP_REGISTRY. This is imperfect, though, since some PyTorch ops can only be converted given certain input configs: e.g. avg_pool2d with divisor_override is inconvertible, which means we may give false promise on such ops, so we may have to cowardly include them in skip_ops


Testing ✅: https://gitlab.com/coremltools1/coremltools/-/commit/3a690359c9d38dbe2eb38d116cd3f327cc0aa301/pipelines
