### PR TITLE
Resolve AttributeError in cast for Float Types in Non-Tensor Contexts

### DIFF
--- a/coremltools/converters/mil/mil/ops/defs/iOS15/elementwise_unary.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS15/elementwise_unary.py
@@ -890,4 +890,7 @@ class cast(Operation):
                 return np.array(result)
             return None
 
-        return string_to_nptype(dtype_val)(input_var.val)
+        if hasattr(input_var.val, "astype"):
+            return input_var.val.astype(dtype=string_to_nptype(dtype_val))
+        else:
+            return string_to_nptype(dtype_val)(input_var.val)

--- a/coremltools/converters/mil/mil/ops/defs/iOS15/elementwise_unary.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS15/elementwise_unary.py
@@ -890,7 +890,7 @@ class cast(Operation):
                 return np.array(result)
             return None
 
-        if not types.is_tensor(input_var.sym_type):
-            return input_var.val.astype(dtype=string_to_nptype(dtype_val))
-        else:
+        if isinstance(input_var.val, float) or types.is_tensor(input_var.sym_type):
             return np.array(input_var.val).astype(dtype=string_to_nptype(dtype_val))
+        else:
+            return input_var.val.astype(dtype=string_to_nptype(dtype_val))

--- a/coremltools/converters/mil/mil/ops/defs/iOS15/elementwise_unary.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS15/elementwise_unary.py
@@ -890,7 +890,4 @@ class cast(Operation):
                 return np.array(result)
             return None
 
-        if isinstance(input_var.val, float) or types.is_tensor(input_var.sym_type):
-            return np.array(input_var.val).astype(dtype=string_to_nptype(dtype_val))
-        else:
-            return input_var.val.astype(dtype=string_to_nptype(dtype_val))
+        return string_to_nptype(dtype_val)(input_var.val)

--- a/coremltools/converters/mil/mil/ops/tests/iOS15/test_elementwise_unary.py
+++ b/coremltools/converters/mil/mil/ops/tests/iOS15/test_elementwise_unary.py
@@ -3,7 +3,9 @@
 #  Use of this source code is governed by a BSD-3-clause license that can be
 #  found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
+import itertools
 import numpy as np
+import pytest
 from coremltools.converters.mil.mil.ops.defs.iOS15 import elementwise_unary
 
 
@@ -15,8 +17,24 @@ class MockInputVar:
 
 
 class TestCast:
-    def test_cast_float_without_tensor(self):
-        input_var = MockInputVar(val=1.0, sym_type=None)
-        output = elementwise_unary.cast.get_cast_value(input_var, "fp32")
-        expected_output = np.array(1.0, dtype=np.float32)
+    NUMPY_DTYPE_TO_STRING = {
+        np.int32: "int32",
+        np.float16: "fp16",
+        np.float32: "fp32",
+        np.bool_: "bool",
+    }
+
+    @pytest.mark.parametrize(
+        "value, dtype",
+        itertools.product(
+            [2.0, (0.0, 1.0)],
+            [np.int32, np.float16, np.float32, np.bool_],
+        ),
+    )
+    def test_cast(self, value, dtype):
+        input_var = MockInputVar(val=value, sym_type=None)
+        output = elementwise_unary.cast.get_cast_value(
+            input_var, self.NUMPY_DTYPE_TO_STRING[dtype]
+        )
+        expected_output = dtype(value)
         np.testing.assert_array_equal(output, expected_output)

--- a/coremltools/converters/mil/mil/ops/tests/iOS15/test_elementwise_unary.py
+++ b/coremltools/converters/mil/mil/ops/tests/iOS15/test_elementwise_unary.py
@@ -1,0 +1,22 @@
+#  Copyright (c) 2023, Apple Inc. All rights reserved.
+#
+#  Use of this source code is governed by a BSD-3-clause license that can be
+#  found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+
+import numpy as np
+from coremltools.converters.mil.mil.ops.defs.iOS15 import elementwise_unary
+
+
+# Mock class to simulate the input_var behavior
+class MockInputVar:
+    def __init__(self, val, sym_type):
+        self.val = val
+        self.sym_type = sym_type
+
+
+class TestCast:
+    def test_cast_float_without_tensor(self):
+        input_var = MockInputVar(val=1.0, sym_type=None)
+        output = elementwise_unary.cast.get_cast_value(input_var, "fp32")
+        expected_output = np.array(1.0, dtype=np.float32)
+        np.testing.assert_array_equal(output, expected_output)


### PR DESCRIPTION
# Overview
This pull request addresses a specific issue encountered in the `coremltools` library, particularly within the `cast` operation of `elementwise_unary.py`. The primary aim is to resolve an `AttributeError` that arises when a `float` object is passed to the `cast` function and the `input_var.sym_type` is not a tensor.

# Issue Description
The error encountered is as follows:
```
File "/Users/chinchangyang/miniconda3/envs/lczero-training-py3.11/lib/python3.11/site-packages/coremltools/converters/mil/mil/ops/defs/iOS15/elementwise_unary.py", line 894, in get_cast_value
    return input_var.val.astype(dtype=string_to_nptype(dtype_val))
           ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'float' object has no attribute 'astype'
```
This occurs in scenarios where the `cast` operation attempts to call the `.astype()` method on a `float` object. The current implementation only converts `input_var.val` to a NumPy array before casting if `input_var.sym_type` is a tensor, which leads to an issue when `input_var.val` is a float but `input_var.sym_type` is not a tensor.

# Proposed Solution
The proposed solution involves modifying the conditional logic within the `cast` operation to ensure that if `input_var.val` is a float, it is first converted to a NumPy array regardless of the tensor status of `input_var.sym_type`. This approach prevents the `AttributeError` by ensuring the presence of the `.astype()` method which is available on NumPy arrays but not on primitive float objects.

# Implementation Details
The specific changes made are as follows:
- The conditional check `if not types.is_tensor(input_var.sym_type)` is replaced with `if isinstance(input_var.val, float) or types.is_tensor(input_var.sym_type)`.
- This modification ensures that for all float values and tensor types, `input_var.val` is first converted into a NumPy array before performing the type cast.
- The existing functionality for non-float types and non-tensor `input_var.sym_type` remains unchanged.

# Tests and Validation
- Resolved the `AttributeError` encountered in **Test 2: 512x19 (FAILED)**:
https://github.com/LeelaChessZero/lczero-training/pull/222.
- Passed test fast.

Looking forward to the community's feedback and suggestions on this proposed fix.