### PR TITLE
Mlmodel Docs - Update Model.proto and Model.rst

### DIFF
--- a/mlmodel/docs/Format/Model.rst
+++ b/mlmodel/docs/Format/Model.rst
@@ -6,6 +6,7 @@ and can be any one of the following types:
 
 Neural Networks
   - ``NeuralNetwork``
+  - ``mlprogram``
 
 Regressors
   - ``GLMRegressor``

--- a/mlmodel/docs/Format/Model.rst
+++ b/mlmodel/docs/Format/Model.rst
@@ -5,8 +5,8 @@ A Core ML model consists of a specification version and a model description,
 and can be any one of the following types:
 
 Neural Networks
+  - ``MILSpec.Program``
   - ``NeuralNetwork``
-  - ``mlprogram``
 
 Regressors
   - ``GLMRegressor``

--- a/mlmodel/docs/index.rst
+++ b/mlmodel/docs/index.rst
@@ -1,5 +1,5 @@
 .. Core ML Format Reference documentation master file, created by
-   sphinx-quickstart on Mon Jun 28 11:26:31 2021.
+   sphinx-quickstart on Mon Jun 28 11:26:31 2021. Edited Jan. 3 2024.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
@@ -8,7 +8,7 @@ Core ML Model Format Specification
 ##################################
 
 This document contains the protobuf message definitions
-that comprise the Core ML model document (``.mlmodel``) format. The top-level
+that comprise the Core ML model format. The top-level
 message is `Model`, which is defined in :file:`Model.proto`.
 Other message types describe data structures, feature types,
 feature engineering model types, and predictive model types.

--- a/mlmodel/format/Model.proto
+++ b/mlmodel/format/Model.proto
@@ -9,7 +9,8 @@
  * and can be any one of the following types:
  *
  * Neural Networks
- *   - `NeuralNetwork`
+ *   - ``NeuralNetwork``
+ *   - ``mlprogram``
  *
  * Regressors
  *   - ``GLMRegressor``
@@ -19,42 +20,42 @@
  *   - ``BayesianProbitRegressor``
  *
  * Classifiers
- *   - `NeuralNetworkClassifier`
- *   - `TreeEnsembleClassifier`
- *   - `GLMClassifier`
- *   - `SupportVectorClassifier`
- *   - `KNearestNeighborsClassifier`
+ *   - ``NeuralNetworkClassifier``
+ *   - ``TreeEnsembleClassifier``
+ *   - ``GLMClassifier``
+ *   - ``SupportVectorClassifier``
+ *   - ``KNearestNeighborsClassifier``
  *
  * Other models
- *   - `CustomModel`
- *   - `TextClassifier`
- *   - `WordTagger`
- *   - `Gazetteer`
- *   - `WordEmbedding`
- *   - `VisionFeaturePrint`
- *   - `LinkedModel`
- *   - `SoundAnalysisPreprocessing`
- *   - `ItemSimilarityRecommender`
- *   - `ClassConfidenceThresholding`
+ *   - ``CustomModel``
+ *   - ``TextClassifier``
+ *   - ``WordTagger``
+ *   - ``Gazetteer``
+ *   - ``WordEmbedding``
+ *   - ``VisionFeaturePrint``
+ *   - ``LinkedModel``
+ *   - ``SoundAnalysisPreprocessing``
+ *   - ``ItemSimilarityRecommender``
+ *   - ``ClassConfidenceThresholding``
  *
  * Feature Engineering
- *   - `Imputer`
- *   - `Scaler`
- *   - `Normalizer`
- *   - `OneHotEncoder`
- *   - `CategoricalMapping`
- *   - `FeatureVectorizer`
- *   - `DictVectorizer`
- *   - `ArrayFeatureExtractor`
- *   - `NonMaximumSuppression`
+ *   - ``Imputer``
+ *   - ``Scaler``
+ *   - ``Normalizer``
+ *   - ``OneHotEncoder``
+ *   - ``CategoricalMapping``
+ *   - ``FeatureVectorizer``
+ *   - ``DictVectorizer``
+ *   - ``ArrayFeatureExtractor``
+ *   - ``NonMaximumSuppression``
  *
  * Pipelines
- *   - `PipelineClassifier`
- *   - `PipelineRegressor`
- *   - `Pipeline`
+ *   - ``PipelineClassifier``
+ *   - ``PipelineRegressor``
+ *   - ``Pipeline``
  *
  * Simple Mathematical Functions
- *   - `Identity`
+ *   - ``Identity``
  */
 
 syntax = "proto3";
@@ -95,7 +96,7 @@ import public "ClassConfidenceThresholding.proto";
 package CoreML.Specification;
 
 /*
- * A pipeline consisting of one or more models.
+ * A pipeline consists of one or more models.
  */
 message Pipeline {
     repeated Model models = 1;
@@ -121,7 +122,7 @@ message PipelineRegressor {
 }
 
 /*
- * A feature description,
+ * A feature description 
  * consisting of a name, short description, and type.
  */
 message FeatureDescription {

--- a/mlmodel/format/Model.proto
+++ b/mlmodel/format/Model.proto
@@ -9,8 +9,8 @@
  * and can be any one of the following types:
  *
  * Neural Networks
+ *   - ``MILSpec.Program``
  *   - ``NeuralNetwork``
- *   - ``mlprogram``
  *
  * Regressors
  *   - ``GLMRegressor``


### PR DESCRIPTION
This PR updates [Core ML Model Format Specification](https://apple.github.io/coremltools/mlmodel/index.html) pages; specifically:

Update `Model.proto` and `Model.rst` to include `mlprogram`,  and also edit the introductory paragraph.

---

**Preview**:

- [Core ML Model Format Specification](https://tonybove-apple.github.io/coremltools/mlmodel/)

