### PR TITLE
Decrease log level for two common log statements

### DIFF
--- a/coremltools/converters/mil/mil/builder.py
+++ b/coremltools/converters/mil/mil/builder.py
@@ -154,7 +154,7 @@ class Builder:
         Add an op of type `op_cls` (e.g., convolution) to current block.
         """
         kwargs = cls._maybe_set_name(kwargs, op_cls.__name__)
-        logger.info(
+        logger.debug(
             "Adding op '{}' of type {}".format(kwargs["name"], op_cls.__name__)
         )
         before_op = kwargs.get("before_op", None)

--- a/coremltools/converters/mil/mil/passes/pass_pipeline.py
+++ b/coremltools/converters/mil/mil/passes/pass_pipeline.py
@@ -446,7 +446,7 @@ class PassPipelineManager:
             desc=f"Running MIL {pass_pipeline} pipeline",
             unit=" passes",
         ):
-            logger.info(f'Performing pass: "{pass_name}"')
+            logger.debug(f'Performing pass: "{pass_name}"')
             pass_options = pass_pipeline.get_options(pass_name)
             if pass_options is not None:
                 logger.debug(


### PR DESCRIPTION
When the logging level is set to `INFO` (default is `WARNING`), these two statements absolutely flood the logs. In my opinion, both these statements should clearly be debug statements not info statements.