### PR TITLE
[Torch] Sanitize Name Treatment

### DIFF
--- a/coremltools/converters/mil/frontend/torch/converter.py
+++ b/coremltools/converters/mil/frontend/torch/converter.py
@@ -21,7 +21,7 @@ from coremltools.converters.mil.mil.var import Var
 
 from .._utils import get_output_names
 from .internal_graph import InternalTorchIRGraph, InternalTorchIRNode
-from .ops import TorchFrontend, convert_nodes
+from .ops import convert_nodes
 from .quantization_ops import _dequantized_weight
 from .torch_op_registry import _TORCH_OPS_REGISTRY
 from .torchir_passes import (
@@ -32,6 +32,7 @@ from .torchir_passes import (
     transform_inplace_ops,
 )
 from .torchscript_utils import torch_to_mil_types
+from .utils import TorchFrontend
 
 if _HAS_TORCH_EXPORT_API:
     from torch.export import ExportedProgram

--- a/coremltools/converters/mil/frontend/torch/converter.py
+++ b/coremltools/converters/mil/frontend/torch/converter.py
@@ -106,7 +106,7 @@ class QuantizationContext:
             return
 
         for input in node.inputs:
-            # In Edge IR, input can be a literal and thus have no name
+            # In EXIR, input can be a literal and thus have no name
             if not isinstance(input, str) or self.get_quantization_info(input) is None:
                 # Not a quantized tensor
                 continue
@@ -318,7 +318,7 @@ class TorchConverter:
         Arguments:
             loaded_model: It could be one of the following:
                     - In-memory TorchScript model of type torch.jit.ScriptModule
-                    - In-memory EdgeIR program of type ExportedProgram
+                    - In-memory EXIR program of type ExportedProgram
             inputs: Input values and optional names. See kwarg in load.py for full description.
             outputs: List of outputs as ct.InputType. See kwarg in load.py for full description.
             cut_at_symbols: A list of internal symbol name strings. Graph conversion will
@@ -369,8 +369,8 @@ class TorchConverter:
                 p(self.graph)
 
         elif _HAS_TORCH_EXPORT_API and isinstance(loaded_model, ExportedProgram):
-            self.context.frontend = TorchFrontend.EDGEIR
-            self.graph = InternalTorchIRGraph.from_edgeir(edgeir=loaded_model)
+            self.context.frontend = TorchFrontend.EXIR
+            self.graph = InternalTorchIRGraph.from_exir(exir=loaded_model)
             self.params_dict, self.buffer_dict = None, None
         else:
             raise ValueError(

--- a/coremltools/converters/mil/frontend/torch/exir_utils.py
+++ b/coremltools/converters/mil/frontend/torch/exir_utils.py
@@ -19,7 +19,7 @@ def to_coreml_tensor_type(name: str, tensor: Tensor) -> "ct.TensorType":
     return ct.TensorType(name=name, dtype=torch_to_mil_types[tensor.dtype], shape=tensor.shape)
 
 
-def extract_inputs_from_edge_program(exported_program) -> List["ct.TensorType"]:
+def extract_inputs_from_exir_program(exported_program) -> List["ct.TensorType"]:
     module = exported_program.graph_module
     inputs_to_parameters = exported_program.graph_signature.inputs_to_parameters
     inputs_to_buffers = exported_program.graph_signature.inputs_to_buffers

--- a/coremltools/converters/mil/frontend/torch/internal_graph.py
+++ b/coremltools/converters/mil/frontend/torch/internal_graph.py
@@ -10,7 +10,7 @@ from torch.fx.node import Node
 
 from coremltools import _logger as logger
 
-from .edgeir_utils import extract_inputs_from_edge_program
+from .exir_utils import extract_inputs_from_exir_program
 from .torchscript_utils import _expand_and_optimize_ir
 
 _DEFAULT_OP_NAMESPACES = set(["aten", "prim"])
@@ -77,10 +77,10 @@ class InternalTorchIRBlock:
         self.parent = parent
 
     @classmethod
-    def from_edgeir_block(cls, block, parent):
+    def from_exir_block(cls, block, parent):
         raise NotImplementedError(
-            "EdgeIR: Support for Ops containing blocks not implemented yet"
-        )  # TODO: rdar://115846569 ([Executorch] Handle control flow ops from edge ir)
+            "EXIR: Support for Ops containing blocks not implemented yet"
+        )  # TODO: rdar://115846569 ([Executorch] Handle control flow ops from EXIR)
 
     @classmethod
     def from_torchscript_block(cls, block, parent):
@@ -223,7 +223,7 @@ class InternalTorchIRNode:
         return internal_node
 
     @classmethod
-    def from_edgeir_node(cls, node):
+    def from_exir_node(cls, node):
         def get_arguments(alist):
             args = []
             for i in alist:
@@ -420,8 +420,8 @@ class InternalTorchIRGraph:
         return internal_graph, params_dict, buffer_dict
 
     @classmethod
-    def from_edgeir(cls, edgeir):
-        exported_program = edgeir
+    def from_exir(cls, exir):
+        exported_program = exir
 
         nodes = []
         params = {}
@@ -429,7 +429,7 @@ class InternalTorchIRGraph:
         inputs = OrderedDict(
             [
                 (i.name, i)
-                for i in extract_inputs_from_edge_program(exported_program=exported_program)
+                for i in extract_inputs_from_exir_program(exported_program=exported_program)
             ]
         )
 
@@ -456,7 +456,7 @@ class InternalTorchIRGraph:
         outputs = []
         for node in graph.nodes:
             if node.op == "call_function":
-                nodes.append(InternalTorchIRNode.from_edgeir_node(node=node))
+                nodes.append(InternalTorchIRNode.from_exir_node(node=node))
             elif node.op == "placeholder":
                 continue
             elif node.op == "output":

--- a/coremltools/converters/mil/frontend/torch/load.py
+++ b/coremltools/converters/mil/frontend/torch/load.py
@@ -37,7 +37,7 @@ def load(
     spec: It could be one of the following:
         - String path to .pt file containing serialized torchscript model
         - In memory TorchScript model of type torch.jit.ScriptModule
-        - In memory EdgeIR program of type ExportedProgram
+        - In memory EXIR program of type ExportedProgram
     inputs: Can be a singular element or list of elements of the following form
         1. Any subclass of InputType
         2. torch.Tensor (only shape and dtype will be used)

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -8,7 +8,6 @@ import math as _math
 import numbers
 import re
 from collections.abc import Iterable
-from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as _np
@@ -33,6 +32,7 @@ from coremltools.converters.mil.mil.var import ListVar, Var
 
 from .._utils import build_einsum_mil, value_at
 from .torch_op_registry import _TORCH_OPS_REGISTRY, register_torch_op
+from .utils import TorchFrontend
 
 # The pytorch args for many of the below ops were sourced from
 # https://github.com/pytorch/pytorch/blob/d971007c291c0ead1003d12cd553d18ddb582207/torch/csrc/jit/mobile/register_mobile_ops.cpp#L216
@@ -42,11 +42,6 @@ from .torch_op_registry import _TORCH_OPS_REGISTRY, register_torch_op
 PYTORCH_DEFAULT_VALUE = 2**63 - 1
 
 VALUE_CLOSE_TO_INFINITY = 1e+38
-
-
-class TorchFrontend(Enum):
-    TORCHSCRIPT = 1
-    EXIR = 2
 
 
 def _all_outputs_present(context, graph):

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -46,7 +46,7 @@ VALUE_CLOSE_TO_INFINITY = 1e+38
 
 class TorchFrontend(Enum):
     TORCHSCRIPT = 1
-    EDGEIR = 2
+    EXIR = 2
 
 
 def _all_outputs_present(context, graph):
@@ -209,7 +209,7 @@ def _get_inputs(
     def get_bindings(alist) -> List[Any]:
         """
         This utility is needed in order to handle following cases:
-            With EdgeIR,
+            With EXIR,
             - Some of the inputs can be literals (like axis, perms) and thus can be of types: list, int etc.
             - An Input Parameter of an op could be a list/tuple similar to our concat layer
         """
@@ -4167,7 +4167,7 @@ def avg_pool1d(context, node):
         context,
         node,
         expected={TorchFrontend.TORCHSCRIPT : 6},
-        min_expected={TorchFrontend.EDGEIR : 2},
+        min_expected={TorchFrontend.EXIR : 2},
     )
     _avg_pool(context, node, inputs)
 
@@ -4177,7 +4177,7 @@ def avg_pool2d(context, node):
     inputs = _get_inputs(
         context,
         node,
-        min_expected={TorchFrontend.TORCHSCRIPT : 6, TorchFrontend.EDGEIR : 2},
+        min_expected={TorchFrontend.TORCHSCRIPT : 6, TorchFrontend.EXIR : 2},
     )
     divisor_override = None if len(inputs) < 7 else inputs[6]
     if divisor_override is not None:
@@ -4191,7 +4191,7 @@ def avg_pool3d(context, node):
         context,
         node,
         expected={TorchFrontend.TORCHSCRIPT : 7},
-        min_expected={TorchFrontend.EDGEIR : 2},
+        min_expected={TorchFrontend.EXIR : 2},
     )
     divisor_override = inputs[6]
     if divisor_override is not None:
@@ -4299,7 +4299,7 @@ def slice(context, node):
         context,
         node,
         expected={TorchFrontend.TORCHSCRIPT : 5},
-        min_expected={TorchFrontend.EDGEIR : 1},
+        min_expected={TorchFrontend.EXIR : 1},
     )
     x = inputs[0]
     dim = 0 if len(inputs) < 2 else inputs[1].val

--- a/coremltools/converters/mil/frontend/torch/test/test_executorch_e2e.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_executorch_e2e.py
@@ -36,7 +36,7 @@ class TestExecutorch(TorchBaseTest):
         self.run_compare_torch(
             [(3, 2), (3, 2)],
             model,
-            frontend=TorchFrontend.EDGEIR,
+            frontend=TorchFrontend.EXIR,
         )
 
     def test_linear(self):
@@ -52,7 +52,7 @@ class TestExecutorch(TorchBaseTest):
         model.eval()
 
         self.run_compare_torch(
-            [(3, 3)], model, frontend=TorchFrontend.EDGEIR, backend=("mlprogram", "fp16")
+            [(3, 3)], model, frontend=TorchFrontend.EXIR, backend=("mlprogram", "fp16")
         )
 
     def test_add(self):
@@ -71,7 +71,7 @@ class TestExecutorch(TorchBaseTest):
         model.eval()
 
         self.run_compare_torch(
-            [(1,), (1,)], model, frontend=TorchFrontend.EDGEIR, backend=("mlprogram", "fp16")
+            [(1,), (1,)], model, frontend=TorchFrontend.EXIR, backend=("mlprogram", "fp16")
         )
 
     def test_add_mul(self):
@@ -90,7 +90,7 @@ class TestExecutorch(TorchBaseTest):
         self.run_compare_torch(
             [(2, 2), (2, 2), (2, 2)],
             model,
-            frontend=TorchFrontend.EDGEIR,
+            frontend=TorchFrontend.EXIR,
             backend=("mlprogram", "fp16"),
         )
 
@@ -107,7 +107,7 @@ class TestExecutorch(TorchBaseTest):
         model.eval()
 
         self.run_compare_torch(
-            [(2, 2)], model, frontend=TorchFrontend.EDGEIR, backend=("mlprogram", "fp16")
+            [(2, 2)], model, frontend=TorchFrontend.EXIR, backend=("mlprogram", "fp16")
         )
 
     @pytest.mark.xfail(reason="numerical error")
@@ -118,7 +118,7 @@ class TestExecutorch(TorchBaseTest):
         model.eval()
 
         self.run_compare_torch(
-            [(1, 3, 224, 224)], model, frontend=TorchFrontend.EDGEIR, backend=("mlprogram", "fp16")
+            [(1, 3, 224, 224)], model, frontend=TorchFrontend.EXIR, backend=("mlprogram", "fp16")
         )
 
     def test_edsr(self):
@@ -126,7 +126,7 @@ class TestExecutorch(TorchBaseTest):
         model.eval()
 
         self.run_compare_torch(
-            [(1, 3, 224, 224)], model, frontend=TorchFrontend.EDGEIR, backend=("mlprogram", "fp16")
+            [(1, 3, 224, 224)], model, frontend=TorchFrontend.EXIR, backend=("mlprogram", "fp16")
         )
 
     def test_emformer_transcribe(self):
@@ -149,7 +149,7 @@ class TestExecutorch(TorchBaseTest):
         model.eval()
 
         self.run_compare_torch(
-            [(1, 128, 80), (128,)], model, frontend=TorchFrontend.EDGEIR, backend=("mlprogram", "fp16")
+            [(1, 128, 80), (128,)], model, frontend=TorchFrontend.EXIR, backend=("mlprogram", "fp16")
         )
 
     def test_emformer_predict(self):
@@ -175,7 +175,7 @@ class TestExecutorch(TorchBaseTest):
             [torch.zeros([1, 128], dtype=int), torch.tensor([128], dtype=int)],
             model,
             input_as_shape=False,
-            frontend=TorchFrontend.EDGEIR,
+            frontend=TorchFrontend.EXIR,
             backend=("mlprogram", "fp16"),
         )
 
@@ -202,7 +202,7 @@ class TestExecutorch(TorchBaseTest):
         self.run_compare_torch(
             [(1, 128, 1024), (128,), (1, 128, 1024), (128,)],
             model,
-            frontend=TorchFrontend.EDGEIR,
+            frontend=TorchFrontend.EXIR,
             backend=("mlprogram", "fp16"),
         )
 
@@ -221,7 +221,7 @@ class TestExecutorch(TorchBaseTest):
             token,
             model,
             input_as_shape=False,
-            frontend=TorchFrontend.EDGEIR,
+            frontend=TorchFrontend.EXIR,
             backend=("mlprogram", "fp32"),
             rtol=0.005,
         )
@@ -231,7 +231,7 @@ class TestExecutorch(TorchBaseTest):
         model.eval()
 
         self.run_compare_torch(
-            [(1, 3, 224, 224)], model, frontend=TorchFrontend.EDGEIR, backend=("mlprogram", "fp16")
+            [(1, 3, 224, 224)], model, frontend=TorchFrontend.EXIR, backend=("mlprogram", "fp16")
         )
 
     def test_mobilenet_v3(self):
@@ -239,7 +239,7 @@ class TestExecutorch(TorchBaseTest):
         model.eval()
 
         self.run_compare_torch(
-            [(1, 3, 224, 224)], model, frontend=TorchFrontend.EDGEIR, backend=("mlprogram", "fp16")
+            [(1, 3, 224, 224)], model, frontend=TorchFrontend.EXIR, backend=("mlprogram", "fp16")
         )
 
     def test_vit(self):
@@ -247,7 +247,7 @@ class TestExecutorch(TorchBaseTest):
         model.eval()
 
         self.run_compare_torch(
-            [(1, 3, 224, 224)], model, frontend=TorchFrontend.EDGEIR, backend=("mlprogram", "fp16")
+            [(1, 3, 224, 224)], model, frontend=TorchFrontend.EXIR, backend=("mlprogram", "fp16")
         )
 
     def test_wav2letter(self):
@@ -255,7 +255,7 @@ class TestExecutorch(TorchBaseTest):
         model.eval()
 
         self.run_compare_torch(
-            [(10, 1, 700)], model, frontend=TorchFrontend.EDGEIR, backend=("mlprogram", "fp16")
+            [(10, 1, 700)], model, frontend=TorchFrontend.EXIR, backend=("mlprogram", "fp16")
         )
 
     def test_inception_v3(self):
@@ -263,7 +263,7 @@ class TestExecutorch(TorchBaseTest):
         model.eval()
 
         self.run_compare_torch(
-            [(1, 3, 224, 224)], model, frontend=TorchFrontend.EDGEIR, backend=("mlprogram", "fp16")
+            [(1, 3, 224, 224)], model, frontend=TorchFrontend.EXIR, backend=("mlprogram", "fp16")
         )
 
     def test_inception_v4(self):
@@ -271,7 +271,7 @@ class TestExecutorch(TorchBaseTest):
         model.eval()
 
         self.run_compare_torch(
-            [(1, 3, 299, 299)], model, frontend=TorchFrontend.EDGEIR, backend=("mlprogram", "fp16")
+            [(1, 3, 299, 299)], model, frontend=TorchFrontend.EXIR, backend=("mlprogram", "fp16")
         )
 
     def test_resnet18(self):
@@ -279,7 +279,7 @@ class TestExecutorch(TorchBaseTest):
         model.eval()
 
         self.run_compare_torch(
-            [(1, 3, 224, 224)], model, frontend=TorchFrontend.EDGEIR, backend=("mlprogram", "fp16")
+            [(1, 3, 224, 224)], model, frontend=TorchFrontend.EXIR, backend=("mlprogram", "fp16")
         )
 
     def test_resnet50(self):
@@ -287,5 +287,5 @@ class TestExecutorch(TorchBaseTest):
         model.eval()
 
         self.run_compare_torch(
-            [(1, 3, 224, 224)], model, frontend=TorchFrontend.EDGEIR, backend=("mlprogram", "fp16")
+            [(1, 3, 224, 224)], model, frontend=TorchFrontend.EXIR, backend=("mlprogram", "fp16")
         )

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_conversion_api.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_conversion_api.py
@@ -138,7 +138,7 @@ class TestTorchScriptValidation:
 
 
 @pytest.mark.skipif(not _HAS_EXECUTORCH, reason=MSG_EXECUTORCH_NOT_FOUND)
-class TestEdgeIRValidation:
+class TestEXIRValidation:
     @staticmethod
     @pytest.mark.parametrize(
         "backend",

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -53,7 +53,7 @@ if _HAS_TORCH_VISION:
 frontends = [TorchFrontend.TORCHSCRIPT]
 
 if _HAS_EXECUTORCH:
-    frontends.append(TorchFrontend.EDGEIR)
+    frontends.append(TorchFrontend.EXIR)
 
 backends = testing_reqs.backends
 compute_units = testing_reqs.compute_units

--- a/coremltools/converters/mil/frontend/torch/test/testing_utils.py
+++ b/coremltools/converters/mil/frontend/torch/test/testing_utils.py
@@ -15,8 +15,8 @@ from coremltools._deps import _HAS_EXECUTORCH, _HAS_TORCH_EXPORT_API, _IS_MACOS
 from coremltools.converters.mil.mil.types.type_mapping import nptype_from_builtin
 from coremltools.converters.mil.testing_utils import ct_convert, validate_minimum_deployment_target
 
-from ..ops import TorchFrontend
 from ..torchscript_utils import torch_to_mil_types
+from ..utils import TorchFrontend
 
 if _HAS_TORCH_EXPORT_API:
     from torch.export import ExportedProgram

--- a/coremltools/converters/mil/frontend/torch/test/testing_utils.py
+++ b/coremltools/converters/mil/frontend/torch/test/testing_utils.py
@@ -249,7 +249,7 @@ class TorchBaseTest:
             expected_results <iterable, optional>: Expected result from running pytorch model.
             converter_input_type: If not None, then pass it to the "inputs" argument to the
                 ct.convert() call.
-            frontend: Either TorchFrontend.TORCHSCRIPT or TorchFrontend.EDGEIR
+            frontend: Either TorchFrontend.TORCHSCRIPT or TorchFrontend.EXIR
         """
         if minimum_deployment_target is not None:
             validate_minimum_deployment_target(minimum_deployment_target, backend)
@@ -263,7 +263,7 @@ class TorchBaseTest:
                 model_spec = torch.jit.script(model)
             else:
                 model_spec = trace_model(model, _copy_input_data(input_data))
-        elif frontend == TorchFrontend.EDGEIR:
+        elif frontend == TorchFrontend.EXIR:
             input_data_clone = _copy_input_data(input_data)
             if isinstance(input_data_clone, list):
                 input_data_clone = tuple(input_data_clone)
@@ -276,7 +276,7 @@ class TorchBaseTest:
             )
         else:
             raise ValueError(
-                f"Unknown value of frontend. Needs to be either TorchFrontend.TORCHSCRIPT or TorchFrontend.EDGEIR. Provided: {frontend}"
+                f"Unknown value of frontend. Needs to be either TorchFrontend.TORCHSCRIPT or TorchFrontend.EXIR. Provided: {frontend}"
             )
 
         model_spec, mlmodel, coreml_inputs, coreml_results = convert_and_compare(

--- a/coremltools/converters/mil/frontend/torch/torch_op_registry.py
+++ b/coremltools/converters/mil/frontend/torch/torch_op_registry.py
@@ -10,6 +10,8 @@ import torch
 from coremltools import _logger as logger
 from coremltools.models._deprecation import deprecated as _deprecated
 
+from .utils import sanitize_op_kind, unify_inplace_and_functional
+
 
 class TorchOpsRegistry:
     def __init__(self):
@@ -18,17 +20,12 @@ class TorchOpsRegistry:
     def get_func(self, op_lookup: str) -> Callable:
         """
         Given a op type key, return the according translation function.
-        Note that the key is sanitized by removing suffix and prefix ``_`` before query.
-        For instance, ``__add__`` -> ``add``, ``sub_`` -> ``sub``.
+        Note that we will not distinguish in-place and functional,
+        since we mostly use functional CoreML ops to translate.
+        For instance, ``sub_`` -> ``sub``
         """
-        if op_lookup.startswith("__") and op_lookup.endswith("__"):
-            # Some ops may have double underscore, such as `__and__`.
-            op_lookup = op_lookup[2:-2]
-        elif op_lookup.endswith("_"):
-            # This is an "in place" op.
-            # Look up the standard op instead by removing underscore.
-            op_lookup = op_lookup[:-1]
-
+        op_lookup = sanitize_op_kind(op_lookup)
+        op_lookup = unify_inplace_and_functional(op_lookup)
         return self.name_to_func_mapping.get(op_lookup, None)
 
     def register_func(self, func=None, torch_alias=None, override=False):
@@ -149,12 +146,14 @@ def is_torch_fx_node_supported(torch_fx_node: torch.fx.Node) -> bool:
         )
         return False
 
-    # Get the target in torch fx node, and canonicalize it to lower-case string
+    # Get the target in torch fx node, then sanitize its name
     torch_fx_node_target = torch_fx_node.target
     if isinstance(torch_fx_node_target, str):
-        torch_fx_node_target_name = torch_fx_node_target.lower()
+        torch_fx_node_target_name = torch_fx_node_target
     else:
-        torch_fx_node_target_name = torch_fx_node.target.__name__.lower()
+        torch_fx_node_target_name = torch_fx_node.target.__name__
+    torch_fx_node_target_name = sanitize_op_kind(torch_fx_node_target_name)
+
     # Since we are only dealing with "call_function" node,
     # the contained PyTorch op must be functional, i.e. not in-place
     assert (
@@ -163,12 +162,5 @@ def is_torch_fx_node_supported(torch_fx_node: torch.fx.Node) -> bool:
         "For now, since CoreML only supports call_function torch fx node, "
         "all ops should be functional, i.e. there should not be any in-place op"
     )
-    # Target name may or may not contain prefix "aten.":
-    #     1. For usual fx node, target is a PyTorch function, i.e. no prefix
-    #     2. For executorch exported fx node, target is executorch.exir.dialects.edge._ops.EdgeOp,
-    #        whose name has format "aten.xx.yy"
-    _ATEN_NODE_PREFIX = "aten."
-    if torch_fx_node_target_name.startswith(_ATEN_NODE_PREFIX):
-        torch_fx_node_target_name = torch_fx_node_target_name[len(_ATEN_NODE_PREFIX):]
 
     return torch_fx_node_target_name in _TORCH_OPS_REGISTRY

--- a/coremltools/converters/mil/frontend/torch/utils.py
+++ b/coremltools/converters/mil/frontend/torch/utils.py
@@ -14,25 +14,32 @@ class TorchFrontend(Enum):
 
 
 def sanitize_op_kind(op_kind: str) -> str:
-    # We conventionally skip the aten/prim namespaces in our naming
+    """
+    In our torch converter, we register torch ops only by its "canonical" name:
+    1. No namespace prefix if it is the common aten/prim: e.g. ``aten::softmax`` -> ``softmax``
+    2. No double underscore prefix and suffix: e.g. ``__add__`` -> ``add``
+    3. Lower-case characters only: e.g. ``mul.Tensor`` -> ``mul.tensor``
+    """
+    # 1. Skip the aten/prim namespace prefix
     namespace = op_kind.split("::")[0].lower()
     if namespace in _DEFAULT_OP_NAMESPACES:
         op_kind = op_kind.split("::")[-1]
 
-    # Some ops may have double underscore, e.g. `__and__`
-    # We conventionally remove such prefix and suffix, e.g. `__add__` -> `add`
+    # 2. Remove underscore prefix and suffix
     if op_kind.startswith("__") and op_kind.endswith("__"):
         op_kind = op_kind[2:-2]
 
-    # We conventionally use only lower-case characters
+    # 3. Lower case
     return op_kind.lower()
 
 
-# In many cases, CoreML uses only functional ops,
-# so we do not have to distinguish in-place from functional,
-# so we will want to remove the conventional in-place suffix `_` of PyTorch.
-# For instance, `sub_` -> `sub`
 def unify_inplace_and_functional(op_kind: str) -> str:
+    """
+    In many cases, CoreML uses only functional ops,
+    so we do not have to distinguish in-place from functional,
+    so we will want to remove the conventional in-place suffix ``_`` of PyTorch.
+    For instance, ``sub_`` -> ``sub``
+    """
     if op_kind.endswith("_"):
         op_kind = op_kind[:-1]
 

--- a/coremltools/converters/mil/frontend/torch/utils.py
+++ b/coremltools/converters/mil/frontend/torch/utils.py
@@ -1,0 +1,39 @@
+#  Copyright (c) 2024, Apple Inc. All rights reserved.
+#
+#  Use of this source code is governed by a BSD-3-clause license that can be
+#  found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+
+from enum import Enum
+
+_DEFAULT_OP_NAMESPACES = set(["aten", "prim"])
+
+
+class TorchFrontend(Enum):
+    TORCHSCRIPT = 1
+    EXIR = 2
+
+
+def sanitize_op_kind(op_kind: str) -> str:
+    # We conventionally skip the aten/prim namespaces in our naming
+    namespace = op_kind.split("::")[0].lower()
+    if namespace in _DEFAULT_OP_NAMESPACES:
+        op_kind = op_kind.split("::")[-1]
+
+    # Some ops may have double underscore, e.g. `__and__`
+    # We conventionally remove such prefix and suffix, e.g. `__add__` -> `add`
+    if op_kind.startswith("__") and op_kind.endswith("__"):
+        op_kind = op_kind[2:-2]
+
+    # We conventionally use only lower-case characters
+    return op_kind.lower()
+
+
+# In many cases, CoreML uses only functional ops,
+# so we do not have to distinguish in-place from functional,
+# so we will want to remove the conventional in-place suffix `_` of PyTorch.
+# For instance, `sub_` -> `sub`
+def unify_inplace_and_functional(op_kind: str) -> str:
+    if op_kind.endswith("_"):
+        op_kind = op_kind[:-1]
+
+    return op_kind


### PR DESCRIPTION
In CoreMLTools PyTorch converter, there are 2 naming things that should get sanitized:
1. In ExecuTorch conversion support, we are actually supporting aten dialect of ExIR, rather than edge IR. Also, ExIR is a more general terminology that also applies to `torch.export`. As a result, we should rename all "edge IR" to "ExIR"
2. We have multiple name sanitizing logics for such PyTorch prefix and suffix et ceteral (see our [discussion](https://github.com/apple/coremltools/pull/2081#discussion_r1443207870)). It would be a better practice to unify them into a single utility function

💁‍♂️ Tips for reviewers: review commit-by-commit would be easier

Fix issue [2106](https://github.com/apple/coremltools/issues/2106)

Testing ✅ [GitLab CI](https://gitlab.com/coremltools1/coremltools/-/commit/f2d436fb014c6146d8a97bb833e36b3b98375c78/pipelines)