### PR TITLE
[ExecuTorch] Migrate Torch Model Export Workflow from "Capture" to "Export"

### DIFF
--- a/coremltools/converters/mil/frontend/torch/exir_utils.py
+++ b/coremltools/converters/mil/frontend/torch/exir_utils.py
@@ -13,7 +13,6 @@ import coremltools as ct
 from .torchscript_utils import torch_to_mil_types
 
 
-
 def to_coreml_tensor_type(name: str, tensor: Tensor) -> "ct.TensorType":
     # TODO: rdar://115845948 ([Executorch] Handle inputs of shapes with dynamic dimensions)
     return ct.TensorType(name=name, dtype=torch_to_mil_types[tensor.dtype], shape=tensor.shape)

--- a/coremltools/converters/mil/frontend/torch/internal_graph.py
+++ b/coremltools/converters/mil/frontend/torch/internal_graph.py
@@ -445,8 +445,8 @@ class InternalTorchIRGraph:
         graph = graph_module.graph
 
         outputs = []
-        for node_without_typing in graph.nodes:
-            node: torch.fx.Node = node_without_typing
+        for node in graph.nodes:
+            node: torch.fx.Node
             if node.op == "call_function":
                 nodes.append(InternalTorchIRNode.from_exir_node(node=node))
             elif node.op == "get_attr":

--- a/coremltools/converters/mil/frontend/torch/internal_graph.py
+++ b/coremltools/converters/mil/frontend/torch/internal_graph.py
@@ -6,7 +6,9 @@
 from collections import OrderedDict
 
 import torch
-from torch.fx.node import Node
+import torch.fx
+import torch.fx.immutable_collections
+import torch.export
 
 from coremltools import _logger as logger
 
@@ -221,7 +223,7 @@ class InternalTorchIRNode:
         def get_arguments(alist):
             args = []
             for i in alist:
-                if isinstance(i, Node):
+                if isinstance(i, torch.fx.Node):
                     args.append(i.name)
                 elif isinstance(i, torch.fx.immutable_collections.immutable_list):
                     args.append(get_arguments(i))
@@ -408,7 +410,7 @@ class InternalTorchIRGraph:
         return internal_graph, params_dict, buffer_dict
 
     @classmethod
-    def from_exir(cls, exir):
+    def from_exir(cls, exir: torch.export.ExportedProgram):
         exported_program = exir
 
         nodes = []
@@ -439,12 +441,23 @@ class InternalTorchIRGraph:
 
             params[name if name not in parameters_to_inputs else parameters_to_inputs[name]] = value
 
-        graph = exported_program.graph
+        graph_module = exported_program.graph_module
+        graph = graph_module.graph
 
         outputs = []
-        for node in graph.nodes:
+        for node_without_typing in graph.nodes:
+            node: torch.fx.Node = node_without_typing
             if node.op == "call_function":
                 nodes.append(InternalTorchIRNode.from_exir_node(node=node))
+            elif node.op == "get_attr":
+                name = node.target
+                attr = graph_module.__getattr__(name)
+                # Only handle simple tensor attribute for now
+                # There may be unconvertible advanced attributes,
+                # e.g. higher-level callables such as "call_delegate"
+                if not isinstance(attr, torch.Tensor):
+                    raise NotImplementedError("Only torch.Tensor attr handled yet")
+                params[name] = attr.detach().cpu().numpy()
             elif node.op == "placeholder":
                 continue
             elif node.op == "output":

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -867,7 +867,7 @@ def pixel_unshuffle(context, node):
     context.add(perm)
 
 
-@register_torch_op(torch_alias=["bmm", "mm", "mm.default"])
+@register_torch_op(torch_alias=["bmm", "mm"])
 def matmul(context, node):
     inputs = _get_inputs(context, node, expected=2)
     if inputs[1].val is not None and \
@@ -879,7 +879,7 @@ def matmul(context, node):
     context.add(res)
 
 
-@register_torch_op(torch_alias=["add.tensor"])
+@register_torch_op
 def add(context, node):
     add_inputs = _get_inputs(context, node)
     assert len(node.outputs) == 1
@@ -1475,7 +1475,7 @@ def maximum(context, node):
     context.add(out)
 
 
-@register_torch_op(torch_alias = ["div.tensor", "div.tensor_mode"])
+@register_torch_op
 def div(context, node):
     inputs = _get_inputs(context, node, expected=[2, 3])
     x = mb.cast(x=inputs[0], dtype="fp32")
@@ -1526,7 +1526,7 @@ def true_divide(context, node):
     context.add(res)
 
 
-@register_torch_op(torch_alias=["mul.tensor", "mul.scalar"])
+@register_torch_op
 def mul(context, node):
     inputs = _get_inputs(context, node, expected=2)
     x, y = promote_input_dtypes(inputs)
@@ -1545,7 +1545,7 @@ def pow(context, node):
     context.add(res)
 
 
-@register_torch_op(torch_alias=["sub.tensor", "rsub"])
+@register_torch_op(torch_alias=["rsub"])
 def sub(context, node):
     inputs = _get_inputs(context, node, expected=[2, 3])
     assert len(node.outputs) == 1
@@ -3748,7 +3748,7 @@ def index_put(context, node):
     context.add(result)
 
 
-@register_torch_op(torch_alias=["index.tensor"])
+@register_torch_op
 def index(context, node):
     inputs = _get_inputs(context, node, expected=2)
     x = inputs[0]
@@ -4283,7 +4283,7 @@ def gelu(context, node):
     context.add(res)
 
 
-@register_torch_op(torch_alias=["_slice", "slice_copy.tensor"])
+@register_torch_op(torch_alias=["_slice", "slice_copy"])
 def slice(context, node):
     inputs = _get_inputs(
         context,

--- a/coremltools/converters/mil/frontend/torch/utils.py
+++ b/coremltools/converters/mil/frontend/torch/utils.py
@@ -30,14 +30,14 @@ def sanitize_op_kind(op_kind: str) -> str:
         deliminator: str,
     ) -> str:
         split = op_kind.split(deliminator)
-        start = 1 if split[0] in {"aten", "prim"} else 0
+        start = 1 if split[0] in {"aten", "prim"} and len(split) > 1 else 0
         stop = -1 if split[-1] in {
             "default",
             "tensor",
             "tensor_mode",
             "scalar",
             "tensor_scalar",
-        } else len(split)
+        } and len(split) - start > 1 else len(split)
         op_kind = deliminator.join(split[start : stop])
         return op_kind
 

--- a/coremltools/converters/mil/frontend/torch/utils.py
+++ b/coremltools/converters/mil/frontend/torch/utils.py
@@ -24,15 +24,11 @@ def sanitize_op_kind(op_kind: str) -> str:
            ``slice_copy.tensor`` -> ``slice_copy``
            ``mul.scalar`` -> ``mul``
     """
-    # 1. Lower case
-    op_kind = op_kind.lower()
 
-    # 2. Remove underscore prefix and suffix
-    if op_kind.startswith("__") and op_kind.endswith("__"):
-        op_kind = op_kind[2:-2]
-
-    # 3. Skip the aten/prim namespace prefix, and default/tensor/scalar suffix
-    def skip_default_prefix_and_suffix_with_deliminator(op_kind: str, deliminator: str) -> str:
+    def skip_default_prefix_and_suffix_with_deliminator(
+        op_kind: str,
+        deliminator: str,
+    ) -> str:
         split = op_kind.split(deliminator)
         start = 1 if split[0] in {"aten", "prim"} else 0
         stop = -1 if split[-1] in {
@@ -45,6 +41,14 @@ def sanitize_op_kind(op_kind: str) -> str:
         op_kind = deliminator.join(split[start : stop])
         return op_kind
 
+    # 1. Lower case
+    op_kind = op_kind.lower()
+
+    # 2. Remove underscore prefix and suffix
+    if op_kind.startswith("__") and op_kind.endswith("__"):
+        op_kind = op_kind[2:-2]
+
+    # 3. Skip the aten/prim namespace prefix, and default/tensor/scalar suffix
     op_kind = skip_default_prefix_and_suffix_with_deliminator(op_kind, "::")
     op_kind = skip_default_prefix_and_suffix_with_deliminator(op_kind, ".")
 


### PR DESCRIPTION
Currently, we export torch model to Apple devices starting from `executorch.exir.capture`
```
exir_program_edge = executorch.exir.capture(torch_model, example_inputs).to_edge(...).exported_program

coreml_model = coremltools.convert(exir_program_edge, ...)
```
However, `executorch.exir.capture` [doc string](https://github.com/pytorch/executorch/blob/release/0.1/exir/capture/_capture.py#L86-L97) declares its deprecation and suggests PyTorch 2.0 standard `torch.export.export` API. So, in this PR, we migrate our export workflow to `torch.export.export`
```
exir_program_aten = torch.export.export(torch_model, example_inputs)
exir_program_edge = executorch.exir.to_edge(exir_program_aten).exported_program()

coreml_model = coremltools.convert(exir_program_edge, ...)
```

Testing: ✅ [GitLab CI](https://gitlab.com/coremltools1/coremltools/-/commit/1bcd3252b5ab312f130b775287240559cf334a47/pipelines)