### PR TITLE
[PyTorch 2] Support PyTorch 2 Export Quantization

### DIFF
--- a/coremltools/converters/mil/frontend/torch/internal_graph.py
+++ b/coremltools/converters/mil/frontend/torch/internal_graph.py
@@ -230,11 +230,12 @@ class InternalTorchIRNode:
                 elif isinstance(i, (int, float)):
                     args.append(i)
                 # This is necessitated by backward compatibility:
-                # * TorchScript used to store dtype as integers
+                # * TorchScript used to store dtype as integers/enums
                 # * Subsequently, we built our PyTorch converter based on numbered dtypes
                 # * Now EXIR uses dtype directly...
-                # * Until refactoring our converter for EXIR,
-                #   we have to map dtype to number ourselves to leverage our existing infra
+                # * Until refactoring EXIR converter to be independent from TorchScript converter,
+                #   we have to map dtype to number ourselves
+                #   to leverage the existing TorchScript converter infra
                 elif isinstance(i, torch.dtype):
                     args.append(TORCH_DTYPE_TO_NUM[i])
                 elif i is None:

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -33,11 +33,11 @@ from coremltools.converters.mil.mil.var import ListVar, Var
 from .._utils import build_einsum_mil, value_at
 from .torch_op_registry import _TORCH_OPS_REGISTRY, register_torch_op
 from .utils import (
-    NUM_TO_TORCH_DTYPE,
-    TORCH_DTYPE_TO_NUM,
-    NUMPY_DTYPE_TO_TORCH_NUM,
-    NUM_TO_NUMPY_DTYPE,
     NUM_TO_DTYPE_STRING,
+    NUM_TO_NUMPY_DTYPE,
+    NUM_TO_TORCH_DTYPE,
+    NUMPY_DTYPE_TO_TORCH_NUM,
+    TORCH_DTYPE_TO_NUM,
     TYPE_TO_DTYPE_STRING,
     TorchFrontend,
 )

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -91,7 +91,8 @@ def convert_nodes(context, graph):
 
         logger.info("Converting op {} : {}".format(node.name, op_lookup))
 
-        context.quant_context.maybe_handle_quantized_inputs(node)
+        if context.frontend == TorchFrontend.TORCHSCRIPT:
+            context.quant_context.maybe_handle_quantized_inputs(node)
         context.prepare_for_conversion(node)
 
         add_op(context, node)

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -32,7 +32,15 @@ from coremltools.converters.mil.mil.var import ListVar, Var
 
 from .._utils import build_einsum_mil, value_at
 from .torch_op_registry import _TORCH_OPS_REGISTRY, register_torch_op
-from .utils import TorchFrontend
+from .utils import (
+    NUM_TO_TORCH_DTYPE,
+    TORCH_DTYPE_TO_NUM,
+    NUMPY_DTYPE_TO_TORCH_NUM,
+    NUM_TO_NUMPY_DTYPE,
+    NUM_TO_DTYPE_STRING,
+    TYPE_TO_DTYPE_STRING,
+    TorchFrontend,
+)
 
 # The pytorch args for many of the below ops were sourced from
 # https://github.com/pytorch/pytorch/blob/d971007c291c0ead1003d12cd553d18ddb582207/torch/csrc/jit/mobile/register_mobile_ops.cpp#L216
@@ -123,70 +131,6 @@ def convert_block(context, block, inputs):
     # Return to the previous context frame.
     context.pop()
     return outputs
-
-
-# Some ops will receive a dtype input as an integer
-# which maps to a torch dtype. The below mapping was found by
-# converting test models with different dtypes passed to ones.
-NUM_TO_TORCH_DTYPE = {
-    0: torch.uint8,
-    1: torch.int8,
-    2: torch.int16,
-    3: torch.int32,
-    4: torch.int32,
-    5: torch.float16,
-    6: torch.float32,
-    7: torch.float32,
-    11: torch.bool,
-    12: torch.qint8,
-    13: torch.quint8,
-    14: torch.qint32,
-}
-
-TORCH_DTYPE_TO_NUM = {
-    dtype: val for val, dtype in NUM_TO_TORCH_DTYPE.items()
-}
-
-NUMPY_DTYPE_TO_TORCH_NUM = {
-    _np.uint8: 0,
-    _np.int8: 1,
-    _np.int16: 2,
-    _np.int32: 3,
-    _np.int64: 4,
-    _np.float16: 5,
-    _np.float32: 6,
-    _np.float64: 7,
-    bool: 11,
-}
-
-NUM_TO_NUMPY_DTYPE = {
-    0: _np.uint8,
-    1: _np.int8,
-    2: _np.int16,
-    3: _np.int32,
-    4: _np.int32,
-    5: _np.float16,
-    6: _np.float32,
-    7: _np.float32,
-    11: bool,
-}
-
-NUM_TO_DTYPE_STRING = {
-    2: "int16",
-    3: "int32",
-    4: "int32",
-    5: "fp16",
-    6: "fp32",
-    7: "fp32",
-    11: "bool",
-}
-
-TYPE_TO_DTYPE_STRING = {
-    types.bool: "bool",
-    types.fp16: "fp16",
-    types.fp32: "fp32",
-    types.int32: "int32",
-}
 
 
 def _assert_torch_dtype_num_is_not_complex_number(num):

--- a/coremltools/converters/mil/frontend/torch/quantization_ops.py
+++ b/coremltools/converters/mil/frontend/torch/quantization_ops.py
@@ -10,23 +10,14 @@ from coremltools import _logger as logger
 from coremltools.converters.mil.mil import Builder as mb
 from coremltools.converters.mil.mil import Var, types
 
-from .utils import NUM_TO_TORCH_DTYPE, TorchFrontend
+from .utils import (
+    NUM_TO_TORCH_DTYPE,
+    TORCH_QTYPE_TO_NP_TYPE,
+    TORCH_QTYPE_TO_STR,
+    TorchFrontend,
+)
 from .ops import _create_linear_layer, _get_inputs, promote_input_dtypes
 from .torch_op_registry import register_torch_op
-
-TORCH_QTYPE_TO_NP_TYPE = {
-    _torch.int8: _np.int8,
-    _torch.qint8: _np.int8,
-    _torch.uint8: _np.uint8,
-    _torch.quint8: _np.uint8,
-}
-
-TORCH_QTYPE_TO_STR = {
-    _torch.int8: "int8",
-    _torch.qint8: "int8",
-    _torch.uint8: "uint8",
-    _torch.quint8: "uint8",
-}
 
 
 def _quantize_general(

--- a/coremltools/converters/mil/frontend/torch/test/test_executorch_quantization.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_executorch_quantization.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023, Apple Inc. All rights reserved.
+#  Copyright (c) 2024, Apple Inc. All rights reserved.
 #
 #  Use of this source code is governed by a BSD-3-clause license that can be
 #  found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause

--- a/coremltools/converters/mil/frontend/torch/test/test_executorch_quantization.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_executorch_quantization.py
@@ -1,0 +1,56 @@
+#  Copyright (c) 2023, Apple Inc. All rights reserved.
+#
+#  Use of this source code is governed by a BSD-3-clause license that can be
+#  found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+
+import pytest
+
+import torch
+from torch._export import capture_pre_autograd_graph
+from torch.ao.quantization.quantize_pt2e import convert_pt2e, prepare_pt2e
+from torch.ao.quantization.quantizer.xnnpack_quantizer import (
+    get_symmetric_quantization_config,
+    XNNPACKQuantizer,
+)
+
+import coremltools as ct
+from coremltools._deps import _HAS_EXECUTORCH
+
+if not _HAS_EXECUTORCH:
+    pytest.skip(allow_module_level=True, reason="executorch is required")
+
+from .testing_utils import TorchBaseTest, TorchFrontend
+
+
+class TestExecutorchQuantization(TorchBaseTest):
+    def test_conv_relu(self):
+        SHAPE = (1, 3, 256, 256)
+
+        class Model(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.conv = torch.nn.Conv2d(
+                    in_channels=3, out_channels=16, kernel_size=3, padding=1
+                )
+                self.relu = torch.nn.ReLU()
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                a = self.conv(x)
+                return self.relu(a)
+
+        model = Model()
+
+        example_args = (torch.randn(SHAPE),)
+        pre_autograd_aten_dialect = capture_pre_autograd_graph(model, example_args)
+
+        quantizer = XNNPACKQuantizer().set_global(get_symmetric_quantization_config())
+        prepared_graph = prepare_pt2e(pre_autograd_aten_dialect, quantizer)
+        converted_graph = convert_pt2e(prepared_graph)
+
+        self.run_compare_torch(
+            SHAPE,
+            converted_graph,
+            frontend=TorchFrontend.EXIR,
+            backend=("mlprogram", "fp16"),
+            minimum_deployment_target=ct.target.iOS17,
+        )

--- a/coremltools/converters/mil/frontend/torch/test/test_internal_graph.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_internal_graph.py
@@ -18,6 +18,7 @@ from coremltools.converters.mil.mil import Function, get_new_symbol, types
 from coremltools.converters.mil.testing_utils import random_gen
 
 from .. import ops
+from .. import utils
 from ..converter import TranscriptionContext
 from ..internal_graph import InternalTorchIRNode
 
@@ -1685,7 +1686,7 @@ class TestTorchOps:
         ssa = self._construct_test_graph(
             context, ops.zeros, node, output_name, constants=constants
         )
-        expected_result = torch.zeros(size, dtype=ops.NUM_TO_TORCH_DTYPE[dtype])
+        expected_result = torch.zeros(size, dtype=utils.NUM_TO_TORCH_DTYPE[dtype])
         np.testing.assert_allclose(expected_result, ssa.val)
 
     @pytest.mark.parametrize("input_size", [(1, 2, 3, 4), (1,)])

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -21,7 +21,7 @@ from coremltools._deps import (
     version_lt,
 )
 from coremltools.converters.mil import testing_reqs
-from coremltools.converters.mil.frontend.torch.ops import (
+from coremltools.converters.mil.frontend.torch.utils import (
     NUM_TO_TORCH_DTYPE,
     NUMPY_DTYPE_TO_TORCH_NUM,
 )

--- a/coremltools/converters/mil/frontend/torch/test/testing_utils.py
+++ b/coremltools/converters/mil/frontend/torch/test/testing_utils.py
@@ -10,7 +10,7 @@ import torch.nn as nn
 
 import coremltools as ct
 import coremltools.models.utils as coremltoolsutils
-from coremltools import RangeDim, TensorType
+from coremltools import RangeDim, TensorType, _logger as logger
 from coremltools._deps import _HAS_EXECUTORCH, _HAS_TORCH_EXPORT_API, _IS_MACOS
 from coremltools.converters.mil.mil.types.type_mapping import nptype_from_builtin
 from coremltools.converters.mil.testing_utils import ct_convert, validate_minimum_deployment_target
@@ -263,7 +263,7 @@ class TorchBaseTest:
                 model.eval()
             except NotImplementedError:
                 # Some torch.export stuff, e.g. quantization, has not implemented eval() yet
-                pass
+                logger.warning("PyTorch EXIR converter received a model without .eval method")
             input_data_clone = _copy_input_data(input_data)
             if isinstance(input_data_clone, list):
                 input_data_clone = tuple(input_data_clone)

--- a/coremltools/converters/mil/frontend/torch/test/testing_utils.py
+++ b/coremltools/converters/mil/frontend/torch/test/testing_utils.py
@@ -249,16 +249,21 @@ class TorchBaseTest:
         if minimum_deployment_target is not None:
             validate_minimum_deployment_target(minimum_deployment_target, backend)
 
-        model.eval()
         if input_as_shape:
             input_data = generate_input_data(input_data, rand_range, torch_device)
 
         if frontend == TorchFrontend.TORCHSCRIPT:
+            model.eval()
             if use_scripting:
                 model_spec = torch.jit.script(model)
             else:
                 model_spec = trace_model(model, _copy_input_data(input_data))
         elif frontend == TorchFrontend.EXIR:
+            try:
+                model.eval()
+            except NotImplementedError:
+                # Some torch.export stuff, e.g. quantization, has not implemented eval() yet
+                pass
             input_data_clone = _copy_input_data(input_data)
             if isinstance(input_data_clone, list):
                 input_data_clone = tuple(input_data_clone)

--- a/coremltools/converters/mil/frontend/torch/utils.py
+++ b/coremltools/converters/mil/frontend/torch/utils.py
@@ -5,6 +5,66 @@
 
 from enum import Enum
 
+import numpy as np
+import torch
+
+from coremltools.converters.mil.mil import types
+
+# Some ops will receive a dtype input as an integer
+# which maps to a torch dtype. The below mapping was found by
+# converting test models with different dtypes passed to ones.
+NUM_TO_TORCH_DTYPE = {
+    0: torch.uint8,
+    1: torch.int8,
+    2: torch.int16,
+    3: torch.int32,
+    4: torch.int32,
+    5: torch.float16,
+    6: torch.float32,
+    7: torch.float32,
+    11: torch.bool,
+    12: torch.qint8,
+    13: torch.quint8,
+    14: torch.qint32,
+}
+
+TORCH_DTYPE_TO_NUM = {
+    dtype: val for val, dtype in NUM_TO_TORCH_DTYPE.items()
+}
+
+NUMPY_DTYPE_TO_TORCH_NUM = {
+    np.uint8: 0,
+    np.int8: 1,
+    np.int16: 2,
+    np.int32: 3,
+    np.int64: 4,
+    np.float16: 5,
+    np.float32: 6,
+    np.float64: 7,
+    bool: 11,
+}
+
+NUM_TO_NUMPY_DTYPE = {
+    val: dtype for dtype, val in NUMPY_DTYPE_TO_TORCH_NUM.items()
+}
+
+NUM_TO_DTYPE_STRING = {
+    2: "int16",
+    3: "int32",
+    4: "int32",
+    5: "fp16",
+    6: "fp32",
+    7: "fp32",
+    11: "bool",
+}
+
+TYPE_TO_DTYPE_STRING = {
+    types.bool: "bool",
+    types.fp16: "fp16",
+    types.fp32: "fp32",
+    types.int32: "int32",
+}
+
 
 class TorchFrontend(Enum):
     TORCHSCRIPT = 1

--- a/coremltools/converters/mil/frontend/torch/utils.py
+++ b/coremltools/converters/mil/frontend/torch/utils.py
@@ -65,6 +65,20 @@ TYPE_TO_DTYPE_STRING = {
     types.int32: "int32",
 }
 
+TORCH_QTYPE_TO_NP_TYPE = {
+    torch.int8: np.int8,
+    torch.qint8: np.int8,
+    torch.uint8: np.uint8,
+    torch.quint8: np.uint8,
+}
+
+TORCH_QTYPE_TO_STR = {
+    torch.int8: "int8",
+    torch.qint8: "int8",
+    torch.uint8: "uint8",
+    torch.quint8: "uint8",
+}
+
 
 class TorchFrontend(Enum):
     TORCHSCRIPT = 1


### PR DESCRIPTION
In PyTorch 2 Export, a new exportable [quantization API](https://pytorch.org/docs/stable/quantization.html#prototype-pytorch-2-export-quantization) is introduced
```
        model = Model()

        example_args = (torch.randn(SHAPE),)
        pre_autograd_aten_dialect = capture_pre_autograd_graph(model, example_args)

        quantizer = XNNPACKQuantizer().set_global(get_symmetric_quantization_config())
        prepared_graph = prepare_pt2e(pre_autograd_aten_dialect, quantizer)
        converted_graph = convert_pt2e(prepared_graph)
```
Let us support it in CoreMLTools!

Major changes:
1. Move "torch dtype to number" mapping to lower level [utils.py](https://github.com/apple/coremltools/pull/2138/commits/f83e402df78faf80489694c29313aa16404fecb5#diff-7bb298f719e574ebb257f4ad398bec92fb0dca827ffb9371ba1bfd1b8c7751a0), since now it will not only be used in op translation, but also graph construction
2. During graph construction from EXIR, map torch dtype to number. This implementation is for backward compatibility purpose, see comment in [internal_graph.py](https://github.com/apple/coremltools/pull/2138/commits/bf6e55a1e97bc78667d5d3533a5e7c860232ddb8#diff-792db03404924ffd712913f7e4cafdb712b221c807786496ceef9254d6ee13f6)

~~Testing: ✅ [GitLab CI](https://gitlab.com/coremltools1/coremltools/-/commit/bf6e55a1e97bc78667d5d3533a5e7c860232ddb8/pipelines)~~
Testing: ✅ [GitLab CI](https://gitlab.com/coremltools1/coremltools/-/commit/d0a0394ae2cdeea87d939ac3183c2708350b58c7/pipelines)
