### PR TITLE
[Optimize] [ExecuTorch] [CoreMLQuantizer] Support `int8` and `uint8` in addition to `qint8` and `quint8`

### DIFF
--- a/coremltools/optimize/torch/quantization/quantization_config.py
+++ b/coremltools/optimize/torch/quantization/quantization_config.py
@@ -189,7 +189,7 @@ class ModuleLinearQuantizerConfig(_ModuleOptimizationConfig):
         converter=_maybe_convert_str_to_dtype,
         validator=[
             _validators.instance_of(_torch.dtype),
-            _validators.in_([_torch.qint8, _torch.quint8, _torch.float32]),
+            _validators.in_([_torch.qint8, _torch.quint8, _torch.int8, _torch.uint8, _torch.float32]),
         ],
     )
     weight_observer: ObserverType = _field(
@@ -206,7 +206,7 @@ class ModuleLinearQuantizerConfig(_ModuleOptimizationConfig):
         converter=_maybe_convert_str_to_dtype,
         validator=[
             _validators.instance_of(_torch.dtype),
-            _validators.in_([_torch.quint8, _torch.float32]),
+            _validators.in_([_torch.quint8, _torch.uint8, _torch.float32]),
         ],
     )
     activation_observer: ObserverType = _field(


### PR DESCRIPTION
Fix #2167 

In our [discussion](https://github.com/pytorch/executorch/pull/2338#discussion_r1520577132) with PyTorch developer, starting from ExecuTorch qdtypes are no longer necessary and will be deprecated.

Currently, in coremltools.optimize.torch, our [quantization config](https://github.com/apple/coremltools/blob/main/coremltools/optimize/torch/quantization/quantization_config.py#L187-L211) are using qdtypes since they were required by the torch.fx path. We should update it to also allow usual dtypes.

Testing: ✅
1. [GitLab CI](https://gitlab.com/coremltools1/coremltools/-/commit/3fbbaa3feea36ca97bbe02226e3c26b9833e99ac/pipelines)
2. Locally verified with [ExecuTorch CoreMLQuantizer PR branch](https://github.com/pytorch/executorch/pull/2338)
