### PR TITLE
Refactor clamp_min operation to mb.maximum

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -1412,9 +1412,11 @@ def minimum(context, node):
 
 @register_torch_op
 def clamp_min(context, node):
-    x = _get_inputs(context, node, expected=2)
-    x = mb.clip(x=x[0], alpha=x[1], beta=_np.inf, name=node.name)
-    context.add(x)
+    inputs = _get_inputs(context, node, expected=2)
+    x, y = inputs[0], inputs[1]
+    assert x.dtype == y.dtype
+    out = mb.maximum(x=x, y=y, name=node.name)
+    context.add(out)
 
 
 @register_torch_op

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -5559,6 +5559,45 @@ class TestElementWiseUnary(TorchBaseTest):
         )
 
     @pytest.mark.parametrize(
+        "compute_unit, backend",
+        itertools.product(
+            compute_units,
+            backends,
+        ),
+    )
+    def test_clamp_min_int(self, compute_unit, backend):
+        params_dict = {"min": 0}
+        input_data = torch.randint(low=-5, high=5, size=(2, 3, 4))
+        model = ModuleWrapper(torch.clamp_min, params_dict)
+        self.run_compare_torch(
+            input_data,
+            model,
+            backend=backend,
+            compute_unit=compute_unit,
+            input_as_shape=False,
+            converter_input_type=[TensorType(shape=input_data.shape, dtype=np.int32)],
+        )
+
+    @pytest.mark.parametrize(
+        "compute_unit, backend",
+        itertools.product(
+            compute_units,
+            backends,
+        ),
+    )
+    def test_clamp_min_float(self, compute_unit, backend):
+        params_dict = {"min": 0.0}
+        input_data = torch.randn((2, 3, 4))
+        model = ModuleWrapper(torch.clamp_min, params_dict)
+        self.run_compare_torch(
+            input_data,
+            model,
+            backend=backend,
+            compute_unit=compute_unit,
+            input_as_shape=False,
+        )
+
+    @pytest.mark.parametrize(
         "compute_unit, backend, shape, threshold, minimum_deployment_target",
         itertools.product(
             compute_units,


### PR DESCRIPTION
The previous implementation of clamp_min defaulted to using float values. By switching to use maximum, this issue is resolved:
```python
class Model(nn.Module):
    def forward(self, x):
        return torch.clamp_min(x, 1)

ipt = torch.LongTensor([0, 1, 2])
traced_model = torch.jit.trace(Model().eval(), (ipt))
mlmodel = ct.convert(
    traced_model,
    inputs=[ct.TensorType(name="input", shape=ipt.shape, dtype=types.int32)],
)
mlmodel.save("tmp.mlpackage")
```

This change ensures that the `clamp_min` can handle both float and int32 types.