### PR TITLE
[ExecuTorch] Fix keys in the delegate mapping json file.

### DIFF
--- a/coremltools/models/model.py
+++ b/coremltools/models/model.py
@@ -524,10 +524,10 @@ class MLModel:
                 )
                 if len(debug_handle_to_ops_mapping) > 0:
                     debug_handle_to_ops_mapping_as_json = json.dumps(
-                        [
-                            {_METADATA_VERSION: self.user_defined_metadata[_METADATA_VERSION]},
-                            debug_handle_to_ops_mapping,
-                        ]
+                        {
+                            "version" : self.user_defined_metadata[_METADATA_VERSION],
+                            "mapping" : debug_handle_to_ops_mapping,
+                        }
                     )
                     saved_debug_handle_to_ops_mapping_path = _os.path.join(
                         save_path, "executorch_debug_handle_mapping.json"

--- a/coremltools/test/modelpackage/test_modelpackage.py
+++ b/coremltools/test/modelpackage/test_modelpackage.py
@@ -315,13 +315,14 @@ class TestMLModel:
         coreml_model = coremltools.convert(
             exir_program_edge, compute_precision=coremltools.precision.FLOAT32
         )
-        debug_handle_mapping = [
-            {_METADATA_VERSION: coreml_model.user_defined_metadata[_METADATA_VERSION]},
-            {
+        debug_handle_mapping = {
+            "version" : coreml_model.user_defined_metadata[_METADATA_VERSION],
+            "mapping" : {
                 str(k): v
                 for k, v in coreml_model._mil_program.construct_debug_handle_to_ops_mapping().items()
             },
-        ]
+        }
+
 
         with tempfile.TemporaryDirectory(suffix=".mlpackage") as package0:
             coreml_model.save(package0)


### PR DESCRIPTION
The root of the saved delegate mapping JSON file is a list, the client has to iterate the list to find the relevant object. The change updated the root object to a dictionary with `version` and `mapping` as the keys.