### PR TITLE
Make Quantizer Compatible with PyTorch 2.4

### DIFF
--- a/coremltools/optimize/torch/quantization/_coreml_quantizer_utils.py
+++ b/coremltools/optimize/torch/quantization/_coreml_quantizer_utils.py
@@ -13,13 +13,9 @@ import torch as _torch
 import torch.nn.functional as _F
 _IS_TORCH_OLDER_THAN_2_4 = tuple(map(int, _torch.__version__.split(".")[:2])) < (2, 4)
 if _IS_TORCH_OLDER_THAN_2_4:
-    from torch.ao.quantization.pt2e.utils import (
-        get_aten_graph_module as _get_aten_graph_module,
-    )
+    from torch.ao.quantization.pt2e.utils import get_aten_graph_module
 else:
-    from torch.ao.quantization.pt2e.utils import (
-        _get_aten_graph_module_for_pattern as _get_aten_graph_module,
-    )
+    from torch.ao.quantization.pt2e.utils import _get_aten_graph_module_for_pattern
 from torch.ao.quantization.quantizer.quantizer import (
     FixedQParamsQuantizationSpec as _FixedQParamsQuantizationSpec,
 )
@@ -74,6 +70,15 @@ _supported_activations_no_inplace = (_F.gelu, _F.sigmoid, _F.logsigmoid, _F.tanh
 
 # Map of dimension to convolution function
 _conv_fn_map = {1: _F.conv1d, 2: _F.conv2d, 3: _F.conv3d}
+
+
+def _get_aten_graph_module(
+    pattern: _torch.nn.Module, example_inputs: _Tuple[_torch.Tensor], is_cuda: bool = False
+):
+    if _IS_TORCH_OLDER_THAN_2_4:
+        return get_aten_graph_module(pattern.forward, example_inputs, is_cuda)
+    else:
+        return _get_aten_graph_module_for_pattern(pattern, example_inputs, is_cuda)
 
 
 def _adjust_activation_qspec(
@@ -203,29 +208,23 @@ def _get_weighted_mod_pattern(
     _supported_activations_no_inplace
     """
 
-    def pattern(input, weight, bias):
-        mod_out = mod_fn(input, weight, bias)
-        output = mod_out
-        node_dict = {
-            "input": input,
-            "mod": mod_out,
-            "weight": weight,
-            "bias": bias,
-        }
-        if act_fn is not None:
-            # Only add output if activation function is applied to model output
-            output = act_fn(output, inplace=True) if act_in_place else act_fn(output)
-            node_dict["output"] = output
-        return output, node_dict
+    class Pattern(_torch.nn.Module):
+        def forward(self, input, weight, bias):
+            mod_out = mod_fn(input, weight, bias)
+            output = mod_out
+            node_dict = {
+                "input": input,
+                "mod": mod_out,
+                "weight": weight,
+                "bias": bias,
+            }
+            if act_fn is not None:
+                # Only add output if activation function is applied to model output
+                output = act_fn(output, inplace=True) if act_in_place else act_fn(output)
+                node_dict["output"] = output
+            return output, node_dict
 
-    if _IS_TORCH_OLDER_THAN_2_4:
-        return _get_aten_graph_module(pattern, example_inputs, is_cuda=False)
-    else:
-        class Pattern(_torch.nn.Module):
-            def forward(self, input, weight, bias):
-                return pattern(input, weight, bias)
-
-        return _get_aten_graph_module(Pattern(), example_inputs, is_cuda=False)
+    return _get_aten_graph_module(Pattern(), example_inputs)
 
 
 def _get_weighted_mod_bn_pattern(
@@ -246,29 +245,23 @@ def _get_weighted_mod_bn_pattern(
     _supported_activations_no_inplace
     """
 
-    def pattern(input, weight, bias, bn_weight, bn_bias, bn_run_mean, bn_run_var):
-        mod_out = mod_fn(input, weight, bias)
-        output = _F.batch_norm(
-            mod_out, bn_run_mean, bn_run_var, bn_weight, bn_bias, training=True
-        )
-        if act_fn is not None:
-            output = act_fn(output, inplace=True) if act_in_place else act_fn(output)
-        return output, {
-            "input": input,
-            "mod": mod_out,
-            "weight": weight,
-            "bias": bias,
-            "output": output,
-        }
+    class Pattern(_torch.nn.Module):
+        def forward(self, input, weight, bias, bn_weight, bn_bias, bn_run_mean, bn_run_var):
+            mod_out = mod_fn(input, weight, bias)
+            output = _F.batch_norm(
+                mod_out, bn_run_mean, bn_run_var, bn_weight, bn_bias, training=True
+            )
+            if act_fn is not None:
+                output = act_fn(output, inplace=True) if act_in_place else act_fn(output)
+            return output, {
+                "input": input,
+                "mod": mod_out,
+                "weight": weight,
+                "bias": bias,
+                "output": output,
+            }
 
-    if _IS_TORCH_OLDER_THAN_2_4:
-        return _get_aten_graph_module(pattern, example_inputs, is_cuda=False)
-    else:
-        class Pattern(_torch.nn.Module):
-            def forward(self, input, weight, bias, bn_weight, bn_bias, bn_run_mean, bn_run_var):
-                return pattern(input, weight, bias, bn_weight, bn_bias, bn_run_mean, bn_run_var)
-
-        return _get_aten_graph_module(Pattern(), example_inputs, is_cuda=False)
+    return _get_aten_graph_module(Pattern(), example_inputs)
 
 
 def get_binary_op_act_pattern(
@@ -292,26 +285,20 @@ def get_binary_op_act_pattern(
     _supported_activations_no_inplace
     """
 
-    def pattern(input_1, input_2):
-        binary_op_out = binary_op(input_1, input_2)
-        node_dict = {
-            "binary_op": binary_op_out,
-        }
-        output = binary_op_out
-        if act_fn is not None:
-            output = act_fn(output, inplace=True) if act_in_place else act_fn(output)
-            node_dict["output"] = output
-        return output, node_dict
+    class Pattern(_torch.nn.Module):
+        def forward(self, input_1, input_2):
+            binary_op_out = binary_op(input_1, input_2)
+            node_dict = {
+                "binary_op": binary_op_out,
+            }
+            output = binary_op_out
+            if act_fn is not None:
+                output = act_fn(output, inplace=True) if act_in_place else act_fn(output)
+                node_dict["output"] = output
+            return output, node_dict
 
     example_inputs = (_torch.randn(1), _torch.randn(1))
-    if _IS_TORCH_OLDER_THAN_2_4:
-        return _get_aten_graph_module(pattern, example_inputs, is_cuda=False)
-    else:
-        class Pattern(_torch.nn.Module):
-            def forward(self, input_1, input_2):
-                return pattern(input_1, input_2)
-
-        return _get_aten_graph_module(Pattern(), example_inputs, is_cuda=False)
+    return _get_aten_graph_module(Pattern(), example_inputs)
 
 
 def get_conv_pattern(


### PR DESCRIPTION
PyTorch 2.4 has a [BC-breaking change](https://github.com/pytorch/pytorch/pull/121937/files#diff-20f3c0609d8e134d4450985674a7d720b1f59df511a3b695d16b0aabcc5ba523L23-R23) that wrecks ExecuTorch Core ML quantizer, which is using [PyTorch 2.3 API](https://github.com/pytorch/pytorch/blob/release/2.3/torch/ao/quantization/pt2e/utils.py#L23)

In this PR, we adapt our code to use different APIs given different PyTorch versions

Testing:
1. [GitLab CI](https://gitlab.com/coremltools1/coremltools/-/commit/014fa1b40186e178bb04d41c5a8d4ed5c68ba9c9/pipelines) ~~✅ [GitLab CI](https://gitlab.com/coremltools1/coremltools/-/commit/59c90bba68d4efc7c8dc27da1e5b38cb01e315f0/pipelines)~~
2. ✅ Locally verified with PyTorch 2.4.0.dev20240324

PS: To install nightly PyTorch
```
pip install --pre torch==2.4.0.dev20240324 -i https://download.pytorch.org/whl/nightly/cpu
```