### PR TITLE
[ExecuTorch] Handle 3rd Type of Const in EXIR

### DIFF
--- a/coremltools/converters/mil/frontend/torch/exir_utils.py
+++ b/coremltools/converters/mil/frontend/torch/exir_utils.py
@@ -30,12 +30,20 @@ def extract_inputs_from_exir_program(
     Extract "input"s from torch.export.ExportedProgram
 
     EXIR lifts constants also as inputs to easily delegate to different backends,
-    so the extracted "input"s consist of both user input and constants
+    so the extracted "input"s consist of both user inputs and constants
 
     EXIR has 3 types of constants:
     1. parameters (e.g. weight of torch.nn.Linear)
     2. buffers
     3. constants (e.g. torch.tensor([0]) inside a torch.nn.Module)
+
+    Given:
+        exported_program: torch.export.ExportedProgram
+    Return:
+        user_inputs: list of coremltools input tensor specifications
+        lifted_parameters: dictionary mapping names to torch parameter tensors
+        lifted_buffers: dictionary mapping names to torch buffer tensors
+        lifted_constants: dictionary mapping names to torch constant tensors
     """
     # prepare placeholder nodes into a convenient dict
     placeholder_nodes = {}

--- a/coremltools/converters/mil/frontend/torch/exir_utils.py
+++ b/coremltools/converters/mil/frontend/torch/exir_utils.py
@@ -19,7 +19,7 @@ def to_coreml_tensor_type(name: str, tensor: torch.Tensor) -> "ct.TensorType":
 
 
 def extract_inputs_from_exir_program(
-    exported_program
+    exported_program  # torch.export.ExportedProgram
 ) -> Tuple[
     List["ct.TensorType"],
     Dict[str, torch.Tensor],
@@ -37,13 +37,13 @@ def extract_inputs_from_exir_program(
     2. buffers
     3. constants (e.g. torch.tensor([0]) inside a torch.nn.Module)
     """
-    # prepare necessary info as convenient dicts
-    # placeholder nodes
+    # prepare placeholder nodes into a convenient dict
     placeholder_nodes = {}
     for node in exported_program.graph_module.graph.nodes:
         if node.op == "placeholder":
             placeholder_nodes[node.name] = node
-    # parameters
+
+    # prepare parameters into a convenient dict
     parameters = {}
     for name, parameter in zip(
         exported_program.graph_signature.parameters, exported_program.parameters()
@@ -53,7 +53,8 @@ def extract_inputs_from_exir_program(
                 f"Only torch.Tensor parameter handled yet, but got {type(parameter)}"
             )
         parameters[name] = parameter
-    # buffers
+
+    # prepare buffers into a convenient dict
     buffers = {}
     for name, buffer in zip(
         exported_program.graph_signature.buffers, exported_program.buffers()
@@ -64,7 +65,7 @@ def extract_inputs_from_exir_program(
             )
         buffers[name] = buffer
 
-    # loop over input specs and populate output info
+    # loop over input specs and populate results
     user_inputs = []
     lifted_parameters = {}
     lifted_buffers = {}


### PR DESCRIPTION
This PR does 2 things:
1. Address review comments carried over from https://github.com/apple/coremltools/pull/2181
2. Refactor EXIR internal graph construction, since ExecuTorch now have 3 types of consts: parameter, buffer, constant

Testing:
1. ✅ [GitLab CI](https://gitlab.com/coremltools1/coremltools/-/commit/d191ef513fea511e9b1367c6126d51ade10182ea/pipelines)
2. ✅ Locally verified with ExecuTorch tests