### PR TITLE
[ExecuTorch] Support Several Indexing Ops

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -3808,8 +3808,7 @@ def select_scatter(context, node):
 @register_torch_op
 def slice_scatter(context, node):
     inputs = _get_inputs(context, node, min_expected=2)
-    x = inputs[0]
-    updates = inputs[1]
+    x, updates = promote_input_dtypes(inputs[0:2])
     dim = 0 if len(inputs) <= 2 else inputs[2].val
     start = 0 if len(inputs) <= 3 else inputs[3]
     end = x.shape[dim] if len(inputs) <= 4 else mb.minimum(x=inputs[4], y=x.shape[dim])

--- a/coremltools/converters/mil/mil/ops/defs/iOS15/scatter_gather.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS15/scatter_gather.py
@@ -512,9 +512,9 @@ class scatter_nd(Operation):
     ----------
     data: tensor<\*D, T> (Required)
     indices: tensor<\*E, i32> (Required)
-        * E[-1] <= len(D)
-    updates: tensor<\*E, T> (Required)
-        * Must be the shape as ``E[:-1] + data.shape[E[-1]:]``.
+        * indices.shape[-1] <= data.rank
+    updates: tensor<\*F, T> (Required)
+        * Must be the shape as ``indices.shape[:-1] + data.shape[indices.shape[-1]:]``.
     mode: const string (Optional)
         * Default to ``add``.
         * Can be the following modes: ``update``, ``add``, ``sub``, ``mul``,

--- a/coremltools/converters/mil/mil/ops/defs/iOS15/scatter_gather.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS15/scatter_gather.py
@@ -486,26 +486,35 @@ class scatter_nd(Operation):
     Scatter ``updates`` to ``data`` at locations ``indices``.
 
     The ``indices`` is a K-dim tensor, where ``indices[i_0,...,i_{K-2}]`` defines a
-    slice of ``data``, ``K = rank(indices)``, and ``data[indices[i_0, ..., i_{K-2}]]``
-    has rank ``rank(data) - indices.shape[-1]``.
+    slice of ``data``, ``K = rank(indices)``, and ``data[i_0, ..., i_{K-2}]``
+    has rank ``rank(data) - indices.shape[-1]``. Concretely, this means the index is
+    stored in the last dim of ``indices``, e.g. take a ``K == 2`` example
+
+    .. math::
+       indices = [[0, 1],
+                  [0, 2]]
+
+    where ``indices[0]`` / ``[0, 1]`` and ``indices[1]`` / ``[0, 2]`` are
+    two indices that get applied to ``data``
 
     * Example: ``mode == update``: The ``output`` is set to ``data`` initially, and
       the op updates ``output`` as follows:
 
     .. math::
-       output[indices[i_0, ..., i_{K-2}]]= updates[indices[i_0, ..., i_{K-2}]]
+       output[indices[i_0, ..., i_{K-2}]]= updates[i_0, ..., i_{K-2}]
 
     * Example: ``mode == add``. The update rule is:
 
     .. math::
-       output[indices[i_0, ..., i_{K-2}]] += updates[indices[i_0, ..., i_{K-2}]]
+       output[indices[i_0, ..., i_{K-2}]] += updates[i_0, ..., i_{K-2}]
 
     Parameters
     ----------
     data: tensor<\*D, T> (Required)
-    indices: tensor<\*K, i32> (Required)
-    updates: tensor<\*K, T> (Required)
-        * Must be the shape as ``K[:-1]+data.shape[K[-1]:]``.
+    indices: tensor<\*E, i32> (Required)
+        * E[-1] <= len(D)
+    updates: tensor<\*E, T> (Required)
+        * Must be the shape as ``E[:-1] + data.shape[E[-1]:]``.
     mode: const string (Optional)
         * Default to ``add``.
         * Can be the following modes: ``update``, ``add``, ``sub``, ``mul``,

--- a/coremltools/converters/mil/mil/ops/tests/iOS14/test_scatter_gather.py
+++ b/coremltools/converters/mil/mil/ops/tests/iOS14/test_scatter_gather.py
@@ -122,6 +122,7 @@ class TestScatter:
             backend=backend,
         )
 
+
 class TestScatterAlongAxis:
     @pytest.mark.parametrize(
         "compute_unit, backend",
@@ -346,6 +347,7 @@ class TestScatterNd:
             backend=backend,
         )
 
+
 class TestGather:
     @pytest.mark.parametrize(
         "compute_unit, backend",
@@ -513,6 +515,7 @@ class TestGather:
             assert gather_3.sym_val.tolist() == [3, s1, s2]
 
             return x
+
 
 class TestGatherAlongAxis:
     @pytest.mark.parametrize(


### PR DESCRIPTION
Add support for [torch.select_scatter](https://pytorch.org/docs/stable/generated/torch.select_scatter.html) and [torch.slice_scatter](https://pytorch.org/docs/stable/generated/torch.slice_scatter.html), polish existing support for [torch.index_put_](https://github.com/apple/coremltools/blob/dbb0094fd0cb936469e35320bf37e866ef7a1da4/coremltools/converters/mil/frontend/torch/ops.py#L3599-L3600)

Polish existing support for [torch.copy_](https://github.com/apple/coremltools/blob/dbb0094fd0cb936469e35320bf37e866ef7a1da4/coremltools/converters/mil/frontend/torch/ops.py#L5382-L5383) and [torch.view](https://github.com/apple/coremltools/blob/dbb0094fd0cb936469e35320bf37e866ef7a1da4/coremltools/converters/mil/frontend/torch/ops.py#L1632-L1633) along the way

Testing:
1. ✅ [GitLab CI](https://gitlab.com/coremltools1/coremltools/-/commit/25a01733b778c10175b8c4f5a0fbd57895692afd/pipelines)
2. ✅ Locally verified with ExecuTorch tests + torch op unit tests with `frontend=TorchFrontend.EXIR`