### PR TITLE
Removing distutils for 3.12 compatibility

### DIFF
--- a/coremltools/_deps/__init__.py
+++ b/coremltools/_deps/__init__.py
@@ -11,7 +11,7 @@ import platform as _platform
 import re as _re
 import sys as _sys
 
-from packaging import version, Version
+from packaging.version import Version
 
 from coremltools import _logger as logger
 
@@ -205,8 +205,8 @@ def version_ge(module, target_version):
     >>> import torch # v1.5.0
     >>> version_ge(torch, '1.6.0') # False
     """
-    return version.parse(module.__version__) >= version.parse(target_version)
+    return Version(module.__version__) >= Version(target_version)
 
 def version_lt(module, target_version):
     """See version_ge"""
-    return version.parse(module.__version__) < version.parse(target_version)
+    return Version(module.__version__) < Version(target_version)

--- a/coremltools/_deps/__init__.py
+++ b/coremltools/_deps/__init__.py
@@ -10,9 +10,8 @@ optional includes
 import platform as _platform
 import re as _re
 import sys as _sys
-from distutils.version import StrictVersion as _StrictVersion
 
-from packaging import version
+from packaging import version, Version
 
 from coremltools import _logger as logger
 
@@ -28,11 +27,11 @@ def _get_version(version):
     # matching 1.6.1, and 1.6.1rc, 1.6.1.dev
     version_regex = r"^\d+\.\d+\.\d+"
     version = _re.search(version_regex, str(version)).group(0)
-    return _StrictVersion(version)
+    return Version(version)
 
 
 def _warn_if_above_max_supported_version(package_name, package_version, max_supported_version):
-    if _get_version(package_version) > _StrictVersion(max_supported_version):
+    if _get_version(package_version) > Version(max_supported_version):
         logger.warning(
             "%s version %s has not been tested with coremltools. You may run into unexpected errors. "
             "%s %s is the most recent version that has been tested."
@@ -62,16 +61,16 @@ def __get_sklearn_version(version):
     # matching 0.15b, 0.16bf, etc
     version_regex = r"^\d+\.\d+"
     version = _re.search(version_regex, str(version)).group(0)
-    return _StrictVersion(version)
+    return Version(version)
 
 
 try:
     import sklearn
 
     _SKLEARN_VERSION = __get_sklearn_version(sklearn.__version__)
-    if _SKLEARN_VERSION < _StrictVersion(
+    if _SKLEARN_VERSION < Version(
         _SKLEARN_MIN_VERSION
-    ) or _SKLEARN_VERSION > _StrictVersion(_SKLEARN_MAX_VERSION):
+    ) or _SKLEARN_VERSION > Version(_SKLEARN_MAX_VERSION):
         _HAS_SKLEARN = False
         logger.warning(
             (
@@ -117,14 +116,14 @@ try:
     tf_ver = _get_version(tensorflow.__version__)
 
     # TensorFlow
-    if tf_ver < _StrictVersion("2.0.0"):
+    if tf_ver < Version("2.0.0"):
         _HAS_TF_1 = True
 
-    if tf_ver >= _StrictVersion("2.0.0"):
+    if tf_ver >= Version("2.0.0"):
         _HAS_TF_2 = True
 
     if _HAS_TF_1:
-        if tf_ver < _StrictVersion(_TF_1_MIN_VERSION):
+        if tf_ver < Version(_TF_1_MIN_VERSION):
             logger.warning(
                 (
                     "TensorFlow version %s is not supported. Minimum required version: %s ."
@@ -134,7 +133,7 @@ try:
             )
         _warn_if_above_max_supported_version("TensorFlow", tensorflow.__version__, _TF_1_MAX_VERSION)
     elif _HAS_TF_2:
-        if tf_ver < _StrictVersion(_TF_2_MIN_VERSION):
+        if tf_ver < Version(_TF_2_MIN_VERSION):
             logger.warning(
                 (
                     "TensorFlow version %s is not supported. Minimum required version: %s ."
@@ -160,7 +159,7 @@ try:
     import torch
     _warn_if_above_max_supported_version("Torch", torch.__version__, _TORCH_MAX_VERSION)
 
-    if _get_version(torch.__version__) >= _StrictVersion("2.1.0"):
+    if _get_version(torch.__version__) >= Version("2.1.0"):
         _HAS_TORCH_EXPORT_API = True
 
 except:

--- a/coremltools/converters/mil/frontend/tensorflow/load.py
+++ b/coremltools/converters/mil/frontend/tensorflow/load.py
@@ -8,7 +8,7 @@ import os
 from tempfile import mktemp
 
 import tensorflow as tf
-from packaging import Version
+from packaging.version import Version
 from tqdm import tqdm as _tqdm
 
 from coremltools import _logger as logger

--- a/coremltools/converters/mil/frontend/tensorflow/load.py
+++ b/coremltools/converters/mil/frontend/tensorflow/load.py
@@ -5,10 +5,10 @@
 
 import gc
 import os
-from distutils.version import StrictVersion as _StrictVersion
 from tempfile import mktemp
 
 import tensorflow as tf
+from packaging import Version
 from tqdm import tqdm as _tqdm
 
 from coremltools import _logger as logger
@@ -107,7 +107,7 @@ class TFLoader:
         logger.debug(msg.format(outputs))
         outputs = outputs if isinstance(outputs, list) else [outputs]
         outputs = [i.split(":")[0] for i in outputs]
-        if _get_version(tf.__version__) < _StrictVersion("1.13.1"):
+        if _get_version(tf.__version__) < Version("1.13.1"):
             return tf.graph_util.extract_sub_graph(graph_def, outputs)
         else:
             return tf.compat.v1.graph_util.extract_sub_graph(graph_def, outputs)
@@ -148,7 +148,7 @@ class TF1Loader(TFLoader):
             if not os.path.exists(str(self.model)):
                 raise ValueError('Input model "{}" does not exist'.format(self.model))
             elif os.path.isfile(str(self.model)) and self.model.endswith(".pb"):
-                if _get_version(tf.__version__) < _StrictVersion("1.13.1"):
+                if _get_version(tf.__version__) < Version("1.13.1"):
                     with open(self.model, "rb") as f:
                         gd = tf.GraphDef()
                         gd.ParseFromString(f.read())
@@ -249,7 +249,7 @@ class TF1Loader(TFLoader):
 
         # get model outputs
         output_node_names = []
-        if _get_version(tf.__version__) < _StrictVersion("1.13.1"):
+        if _get_version(tf.__version__) < Version("1.13.1"):
             sess = tf.Session()
         else:
             sess = tf.compat.v1.Session()
@@ -263,7 +263,7 @@ class TF1Loader(TFLoader):
 
         # get frozen graph
         output_graph = mktemp()
-        tf.compat.v1.reset_default_graph() if _get_version(tf.__version__) >= _StrictVersion("1.13.1") else tf.reset_default_graph()
+        tf.compat.v1.reset_default_graph() if _get_version(tf.__version__) >= Version("1.13.1") else tf.reset_default_graph()
         freeze_graph.freeze_graph(
             input_graph=None,
             input_saver=None,
@@ -282,7 +282,7 @@ class TF1Loader(TFLoader):
             saved_model_tags=",".join(saved_model_tags),
         )
 
-        if _get_version(tf.__version__) < _StrictVersion("1.13.1"):
+        if _get_version(tf.__version__) < Version("1.13.1"):
             graph_def = tf.GraphDef()
             with open(output_graph, "rb") as f:
                 graph_def.ParseFromString(f.read())

--- a/coremltools/converters/mil/frontend/tensorflow/test/test_ops.py
+++ b/coremltools/converters/mil/frontend/tensorflow/test/test_ops.py
@@ -9,11 +9,11 @@ import os
 import platform
 import shutil
 import tempfile
-from distutils.version import StrictVersion
 from typing import Optional
 
 import numpy as np
 import pytest
+from packaging import Version
 
 import coremltools as ct
 from coremltools import RangeDim, TensorType
@@ -2324,7 +2324,7 @@ class TestElementWiseUnary(TensorFlowBaseTest):
         if compute_unit != ct.ComputeUnit.CPU_ONLY and mode in self._FP16_UNSUPPORTED:
             return
 
-        if _get_version(tf.__version__) == StrictVersion(PREBUILT_TF1_WHEEL_VERSION):
+        if _get_version(tf.__version__) == Version(PREBUILT_TF1_WHEEL_VERSION):
             if mode in _PREBUILD_WHEEL_SEGFAULTING_MODE:
                 # we should re-enable these tests after this radar rdar://100735561 ([CI] Build a more stable TF1 Rosetta wheel for the lightning CI) is fixed
                 pytest.skip("Prebuilt wheel segfaulting on several functions.")

--- a/coremltools/converters/mil/frontend/tensorflow/test/test_ops.py
+++ b/coremltools/converters/mil/frontend/tensorflow/test/test_ops.py
@@ -13,7 +13,7 @@ from typing import Optional
 
 import numpy as np
 import pytest
-from packaging import Version
+from packaging.version import Version
 
 import coremltools as ct
 from coremltools import RangeDim, TensorType

--- a/coremltools/converters/mil/frontend/tensorflow/tf_graph_pass/constant_propagation.py
+++ b/coremltools/converters/mil/frontend/tensorflow/tf_graph_pass/constant_propagation.py
@@ -6,7 +6,7 @@
 import gc
 
 import tensorflow as tf
-from packaging import Version
+from packaging.version import Version
 
 from coremltools import _logger as logger
 from coremltools._deps import _get_version

--- a/coremltools/converters/mil/frontend/tensorflow/tf_graph_pass/constant_propagation.py
+++ b/coremltools/converters/mil/frontend/tensorflow/tf_graph_pass/constant_propagation.py
@@ -4,9 +4,9 @@
 #  found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
 import gc
-from distutils.version import StrictVersion as _StrictVersion
 
 import tensorflow as tf
+from packaging import Version
 
 from coremltools import _logger as logger
 from coremltools._deps import _get_version
@@ -72,7 +72,7 @@ def _constant_propagation(fn, new_graph, constant_nodes, constant_node_num_outpu
                 # We're only making one call to `sess.run()` in order to compute constant values.
                 # In this context, the default optimization settings make everything dramatically
                 # slower and more memory-intensive.
-                if _get_version(tf.__version__) < _StrictVersion("1.13.1"):
+                if _get_version(tf.__version__) < Version("1.13.1"):
                     session_config = tf.ConfigProto()
                     session_config.graph_options.optimizer_options.opt_level = (
                         tf.OptimizerOptions.L0

--- a/coremltools/converters/mil/frontend/tensorflow2/load.py
+++ b/coremltools/converters/mil/frontend/tensorflow2/load.py
@@ -6,7 +6,7 @@
 import os.path as _os_path
 
 import tensorflow as _tf
-from packaging import Version
+from packaging.version import Version
 from tensorflow.lite.python.util import \
     get_grappler_config as _get_grappler_config
 from tensorflow.lite.python.util import \

--- a/coremltools/converters/mil/frontend/tensorflow2/load.py
+++ b/coremltools/converters/mil/frontend/tensorflow2/load.py
@@ -4,9 +4,9 @@
 #  found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
 import os.path as _os_path
-from distutils.version import StrictVersion as _StrictVersion
 
 import tensorflow as _tf
+from packaging import Version
 from tensorflow.lite.python.util import \
     get_grappler_config as _get_grappler_config
 from tensorflow.lite.python.util import \
@@ -322,7 +322,7 @@ class TF2Loader(TFLoader):
         if len(cfs) != 1:
             raise NotImplementedError("Only a single concrete function is supported.")
 
-        if _get_version(_tf.__version__) >= _StrictVersion("2.2.0"):
+        if _get_version(_tf.__version__) >= Version("2.2.0"):
             frozen_fn = _convert_variables_to_constants_v2(cfs[0], lower_control_flow=False, aggressive_inlining=True)
         else:
             frozen_fn = _convert_variables_to_constants_v2(cfs[0], lower_control_flow=False)

--- a/coremltools/converters/mil/frontend/tensorflow2/test/test_v2_ops_tf_keras.py
+++ b/coremltools/converters/mil/frontend/tensorflow2/test/test_v2_ops_tf_keras.py
@@ -6,10 +6,10 @@
 import itertools
 import platform
 import random
-from distutils.version import StrictVersion as _StrictVersion
 
 import numpy as np
 import pytest
+from packaging import Version
 
 import coremltools as ct
 from coremltools._deps import _get_version
@@ -258,10 +258,10 @@ class TestConvolution(TensorFlowBaseTest):
         batch_size,
         groups,
     ):
-        if _get_version(_tf.__version__) < _StrictVersion("2.5.0") and groups != 1:
+        if _get_version(_tf.__version__) < Version("2.5.0") and groups != 1:
             pytest.skip("TF supports groupwise convolution only for version > tf.2.5.0-rc3")
 
-        if _get_version(_tf.__version__) > _StrictVersion("2.8.0") and groups != 1:
+        if _get_version(_tf.__version__) > Version("2.8.0") and groups != 1:
             pytest.xfail("rdar://100814590 ([TF] [Infra] TF 2.10.0 Uses Unimplemented "
                          "PartitionedCall op for Groupwise Convolution)")
 
@@ -1765,7 +1765,7 @@ class TestUpSampling(TensorFlowBaseTest):
 
 class TestGelu(TensorFlowBaseTest):
     @pytest.mark.skipif(
-        _get_version(_tf.__version__) < _StrictVersion("2.4.0"),
+        _get_version(_tf.__version__) < Version("2.4.0"),
         reason="Gelu is a new layer for tf 2.4.0 and above."
     )
     @pytest.mark.parametrize(

--- a/coremltools/converters/mil/frontend/tensorflow2/test/test_v2_ops_tf_keras.py
+++ b/coremltools/converters/mil/frontend/tensorflow2/test/test_v2_ops_tf_keras.py
@@ -9,7 +9,7 @@ import random
 
 import numpy as np
 import pytest
-from packaging import Version
+from packaging.version import Version
 
 import coremltools as ct
 from coremltools._deps import _get_version

--- a/coremltools/converters/sklearn/_gradient_boosting_regressor.py
+++ b/coremltools/converters/sklearn/_gradient_boosting_regressor.py
@@ -3,7 +3,7 @@
 # Use of this source code is governed by a BSD-3-clause license that can be
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
-from distutils.version import StrictVersion
+from packaging import Version
 
 from ..._deps import _HAS_SKLEARN, _SKLEARN_VERSION
 from ...models import MLModel as _MLModel
@@ -62,7 +62,7 @@ def convert(model, input_features, output_features):
         base_prediction = model.init_.quantile
     else:
         # >= 0.22 GradientBoostingRegressor deprecated "mean" in favor of "constant_" attribute
-        if _SKLEARN_VERSION < StrictVersion("0.22"):
+        if _SKLEARN_VERSION < Version("0.22"):
             base_prediction = model.init_.mean
         else:
             base_prediction = model.init_.constant_

--- a/coremltools/converters/sklearn/_gradient_boosting_regressor.py
+++ b/coremltools/converters/sklearn/_gradient_boosting_regressor.py
@@ -3,7 +3,7 @@
 # Use of this source code is governed by a BSD-3-clause license that can be
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
-from packaging import Version
+from packaging.version import Version
 
 from ..._deps import _HAS_SKLEARN, _SKLEARN_VERSION
 from ...models import MLModel as _MLModel

--- a/coremltools/converters/sklearn/_imputer.py
+++ b/coremltools/converters/sklearn/_imputer.py
@@ -3,7 +3,7 @@
 # Use of this source code is governed by a BSD-3-clause license that can be
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
-from distutils.version import StrictVersion
+from packaging import Version
 
 from ... import SPECIFICATION_VERSION
 from ..._deps import _HAS_SKLEARN, _SKLEARN_VERSION
@@ -70,7 +70,7 @@ def convert(model, input_features, output_features):
 
     # model.axis deprecated in SimpleImputer >= 0.22. which now imputes only
     # along columns as desired here.
-    if _SKLEARN_VERSION < StrictVersion("0.22"):
+    if _SKLEARN_VERSION < Version("0.22"):
         if model.axis != 0:
             raise ValueError("Imputation is only supported along axis = 0.")
 

--- a/coremltools/converters/sklearn/_imputer.py
+++ b/coremltools/converters/sklearn/_imputer.py
@@ -3,7 +3,7 @@
 # Use of this source code is governed by a BSD-3-clause license that can be
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
-from packaging import Version
+from packaging.version import Version
 
 from ... import SPECIFICATION_VERSION
 from ..._deps import _HAS_SKLEARN, _SKLEARN_VERSION

--- a/coremltools/converters/sklearn/_one_hot_encoder.py
+++ b/coremltools/converters/sklearn/_one_hot_encoder.py
@@ -16,7 +16,7 @@ from ...proto import OneHotEncoder_pb2 as _OHE_pb2
 from . import _sklearn_util
 
 if _HAS_SKLEARN:
-    from packaging import Version
+    from packaging.version import Version
     from sklearn.preprocessing import OneHotEncoder
 
     sklearn_class = OneHotEncoder

--- a/coremltools/converters/sklearn/_one_hot_encoder.py
+++ b/coremltools/converters/sklearn/_one_hot_encoder.py
@@ -16,8 +16,7 @@ from ...proto import OneHotEncoder_pb2 as _OHE_pb2
 from . import _sklearn_util
 
 if _HAS_SKLEARN:
-    from distutils.version import StrictVersion
-
+    from packaging import Version
     from sklearn.preprocessing import OneHotEncoder
 
     sklearn_class = OneHotEncoder
@@ -52,7 +51,7 @@ def convert(model, input_features, output_features):
 
     # Make sure the model is fitted.
     _sklearn_util.check_expected_type(model, OneHotEncoder)
-    if _SKLEARN_VERSION >= StrictVersion("0.22"):
+    if _SKLEARN_VERSION >= Version("0.22"):
         _sklearn_util.check_fitted(model, lambda m: hasattr(m, "categories_"))
         _sklearn_util.check_fitted(model, lambda m: hasattr(m, "n_features_in_"))
     else:
@@ -71,7 +70,7 @@ def convert(model, input_features, output_features):
     expected_output_dimension = update_dimension(model, input_dimension)
     assert output_features[0][1] == datatypes.Array(expected_output_dimension)
 
-    if _SKLEARN_VERSION >= StrictVersion("0.22"):
+    if _SKLEARN_VERSION >= Version("0.22"):
         model.categorical_features = "all"
         model.active_features_ = range(expected_output_dimension)
         model.feature_indices_ = [0]
@@ -224,7 +223,7 @@ def update_dimension(model, input_dimension):
             "scikit-learn not found. scikit-learn conversion API is disabled."
         )
 
-    if _SKLEARN_VERSION >= StrictVersion("0.22"):
+    if _SKLEARN_VERSION >= Version("0.22"):
         _sklearn_util.check_fitted(model, lambda m: hasattr(m, "categories_"))
         _sklearn_util.check_fitted(model, lambda m: hasattr(m, "n_features_in_"))
         return sum(model._n_features_outs)
@@ -248,7 +247,7 @@ def get_input_dimension(model):
             "scikit-learn not found. scikit-learn conversion API is disabled."
         )
 
-    if _SKLEARN_VERSION >= StrictVersion("0.22"):
+    if _SKLEARN_VERSION >= Version("0.22"):
         _sklearn_util.check_fitted(model, lambda m: hasattr(m, "categories_"))
         _sklearn_util.check_fitted(model, lambda m: hasattr(m, "n_features_in_"))
         return model.n_features_in_

--- a/coremltools/optimize/torch/_utils/version_utils.py
+++ b/coremltools/optimize/torch/_utils/version_utils.py
@@ -4,11 +4,11 @@
 #  found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
 import torch as _torch
-from packaging.version import version
+from packaging.version import Version
 
 
 def version_ge(module, target_version):
-    return version.parse(module.__version__) >= version.parse(target_version)
+    return Version(module.__version__) >= Version(target_version)
 
 
 def get_torch_version():

--- a/coremltools/optimize/torch/_utils/version_utils.py
+++ b/coremltools/optimize/torch/_utils/version_utils.py
@@ -4,7 +4,7 @@
 #  found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
 import torch as _torch
-from packaging import version
+from packaging.version import version
 
 
 def version_ge(module, target_version):

--- a/coremltools/test/optimize/torch/utils.py
+++ b/coremltools/test/optimize/torch/utils.py
@@ -6,7 +6,7 @@
 import pathlib
 import sys
 
-from packaging.version import version
+from packaging.version import Version
 
 
 def _python_version():
@@ -44,12 +44,12 @@ def version_ge(module, target_version):
     >>> import torch # v1.5.0
     >>> version_ge(torch, '1.6.0') # False
     """
-    return version.parse(module.__version__) >= version.parse(target_version)
+    return Version(module.__version__) >= Version(target_version)
 
 
 def version_lt(module, target_version):
     """See version_ge"""
-    return version.parse(module.__version__) < version.parse(target_version)
+    return Version(module.__version__) < Version(target_version)
 
 
 def test_data_path():

--- a/coremltools/test/optimize/torch/utils.py
+++ b/coremltools/test/optimize/torch/utils.py
@@ -6,7 +6,7 @@
 import pathlib
 import sys
 
-from packaging import version
+from packaging.version import version
 
 
 def _python_version():

--- a/coremltools/test/sklearn_tests/test_NuSVC.py
+++ b/coremltools/test/sklearn_tests/test_NuSVC.py
@@ -23,7 +23,7 @@ if _HAS_LIBSVM:
     from coremltools.converters import libsvm
 
 if _HAS_SKLEARN:
-    from packaging import Version
+    from packaging.version import Version
     from sklearn.preprocessing import OneHotEncoder
     from sklearn.svm import NuSVC
 

--- a/coremltools/test/sklearn_tests/test_NuSVC.py
+++ b/coremltools/test/sklearn_tests/test_NuSVC.py
@@ -23,8 +23,7 @@ if _HAS_LIBSVM:
     from coremltools.converters import libsvm
 
 if _HAS_SKLEARN:
-    from distutils.version import StrictVersion
-
+    from packaging import Version
     from sklearn.preprocessing import OneHotEncoder
     from sklearn.svm import NuSVC
 
@@ -56,7 +55,7 @@ class NuSvcScikitTest(unittest.TestCase):
         # sklearn version > 0.22 NuSVC introduced finiteness checks that fail for
         # the 'sigmoid' and one 'poly' kernel test cases. Avoid those.
         # See https://github.com/scikit-learn/scikit-learn/issues/17925
-        if _SKLEARN_VERSION <= StrictVersion("0.22"):
+        if _SKLEARN_VERSION <= Version("0.22"):
             kernel_parameters += [
                 {"kernel": "poly", "degree": 0, "gamma": 0.9, "coef0": 2},
                 {"kernel": "sigmoid"},

--- a/coremltools/test/sklearn_tests/test_categorical_imputer.py
+++ b/coremltools/test/sklearn_tests/test_categorical_imputer.py
@@ -4,9 +4,9 @@
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
 import unittest
-from distutils.version import StrictVersion
 
 import numpy as np
+from packaging import Version
 
 from coremltools._deps import _HAS_SKLEARN, _SKLEARN_VERSION
 
@@ -41,7 +41,7 @@ class ImputerTestCase(unittest.TestCase):
         scikit_data = load_boston()
         # axis parameter deprecated in SimpleImputer >= 0.22. which now imputes
         # only along columns as desired here.
-        if _SKLEARN_VERSION >= StrictVersion("0.22"):
+        if _SKLEARN_VERSION >= Version("0.22"):
             scikit_model = Imputer(strategy="most_frequent")
         else:
             scikit_model = Imputer(strategy="most_frequent", axis=0)

--- a/coremltools/test/sklearn_tests/test_categorical_imputer.py
+++ b/coremltools/test/sklearn_tests/test_categorical_imputer.py
@@ -6,7 +6,7 @@
 import unittest
 
 import numpy as np
-from packaging import Version
+from packaging.version import Version
 
 from coremltools._deps import _HAS_SKLEARN, _SKLEARN_VERSION
 

--- a/coremltools/test/sklearn_tests/test_composite_pipelines.py
+++ b/coremltools/test/sklearn_tests/test_composite_pipelines.py
@@ -4,9 +4,9 @@
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
 import unittest
-from distutils.version import StrictVersion
 
 import pandas as pd
+from packaging import Version
 
 from coremltools._deps import _HAS_SKLEARN, _SKLEARN_VERSION
 from coremltools.converters.sklearn import convert
@@ -24,7 +24,7 @@ if _HAS_SKLEARN:
 class GradientBoostingRegressorBostonHousingScikitNumericTest(unittest.TestCase):
 
     @unittest.skipIf(not _HAS_SKLEARN, "Missing sklearn. Skipping tests.")
-    @unittest.skipIf(_SKLEARN_VERSION >= StrictVersion("0.22"),
+    @unittest.skipIf(_SKLEARN_VERSION >= Version("0.22"),
         "categorical_features parameter to OneHotEncoder() deprecated after SciKit Learn 0.22."
     )
     def test_boston_OHE_plus_normalizer(self):
@@ -49,7 +49,7 @@ class GradientBoostingRegressorBostonHousingScikitNumericTest(unittest.TestCase)
             result = evaluate_transformer(spec, input_data, output_data)
             assert result["num_errors"] == 0
 
-    @unittest.skipIf(_SKLEARN_VERSION >= StrictVersion("0.22"),
+    @unittest.skipIf(_SKLEARN_VERSION >= Version("0.22"),
         "categorical_features parameter to OneHotEncoder() deprecated after SciKit Learn 0.22."
     )
     def _test_boston_OHE_plus_trees(self, loss='ls'):

--- a/coremltools/test/sklearn_tests/test_composite_pipelines.py
+++ b/coremltools/test/sklearn_tests/test_composite_pipelines.py
@@ -6,7 +6,7 @@
 import unittest
 
 import pandas as pd
-from packaging import Version
+from packaging.version import Version
 
 from coremltools._deps import _HAS_SKLEARN, _SKLEARN_VERSION
 from coremltools.converters.sklearn import convert

--- a/coremltools/test/sklearn_tests/test_imputer.py
+++ b/coremltools/test/sklearn_tests/test_imputer.py
@@ -4,10 +4,10 @@
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
 import unittest
-from distutils.version import StrictVersion
 
 import numpy as np
 import numpy.random as rn
+from packaging import Version
 
 from coremltools._deps import _HAS_SKLEARN, _SKLEARN_VERSION
 from coremltools.models.utils import (_is_macos, _macos_version,
@@ -55,7 +55,7 @@ class NumericalImputerTestCase(unittest.TestCase):
         for strategy in ["mean", "median", "most_frequent"]:
             for missing_value in [0, "NaN", -999]:
                 # SimpleImputer >=0.22 does not accept missing values encoded as NaN.
-                if _SKLEARN_VERSION >= StrictVersion("0.22"):
+                if _SKLEARN_VERSION >= Version("0.22"):
                     if missing_value == "NaN":
                         continue
 

--- a/coremltools/test/sklearn_tests/test_imputer.py
+++ b/coremltools/test/sklearn_tests/test_imputer.py
@@ -7,7 +7,7 @@ import unittest
 
 import numpy as np
 import numpy.random as rn
-from packaging import Version
+from packaging.version import Version
 
 from coremltools._deps import _HAS_SKLEARN, _SKLEARN_VERSION
 from coremltools.models.utils import (_is_macos, _macos_version,

--- a/coremltools/test/sklearn_tests/test_one_hot_encoder.py
+++ b/coremltools/test/sklearn_tests/test_one_hot_encoder.py
@@ -7,7 +7,7 @@ import unittest
 from copy import copy
 
 import numpy as np
-from packaging import Version
+from packaging.version import Version
 
 from coremltools._deps import _HAS_SKLEARN, _SKLEARN_VERSION
 from coremltools.models.utils import (_is_macos, _macos_version,

--- a/coremltools/test/sklearn_tests/test_one_hot_encoder.py
+++ b/coremltools/test/sklearn_tests/test_one_hot_encoder.py
@@ -5,9 +5,9 @@
 
 import unittest
 from copy import copy
-from distutils.version import StrictVersion
 
 import numpy as np
+from packaging import Version
 
 from coremltools._deps import _HAS_SKLEARN, _SKLEARN_VERSION
 from coremltools.models.utils import (_is_macos, _macos_version,
@@ -92,7 +92,7 @@ class OneHotEncoderScikitTest(unittest.TestCase):
         _is_macos() and _macos_version() >= (10, 13), "Only supported on macOS 10.13+"
     )
     def test_conversion_one_column_of_several(self):
-        if _SKLEARN_VERSION >= StrictVersion("0.22"):
+        if _SKLEARN_VERSION >= Version("0.22"):
             scikit_model = OneHotEncoder()
         else:
             scikit_model = OneHotEncoder(categorical_features=[0])
@@ -119,7 +119,7 @@ class OneHotEncoderScikitTest(unittest.TestCase):
     @unittest.skipUnless(
         _is_macos() and _macos_version() >= (10, 13), "Only supported on macOS 10.13+"
     )
-    @unittest.skipIf(_SKLEARN_VERSION >= StrictVersion("0.22"),
+    @unittest.skipIf(_SKLEARN_VERSION >= Version("0.22"),
         "categorical_features parameter to OneHotEncoder() deprecated after SciKit Learn 0.22."
     )
     def test_boston_OHE(self):
@@ -144,7 +144,7 @@ class OneHotEncoderScikitTest(unittest.TestCase):
     @unittest.skipUnless(
         _is_macos() and _macos_version() >= (10, 13), "Only supported on macOS 10.13+"
     )
-    @unittest.skipIf(_SKLEARN_VERSION >= StrictVersion("0.22"),
+    @unittest.skipIf(_SKLEARN_VERSION >= Version("0.22"),
         "categorical_features parameter to OneHotEncoder() deprecated after SciKit Learn 0.22."
     )
     def test_boston_OHE_pipeline(self):
@@ -176,7 +176,7 @@ class OneHotEncoderScikitTest(unittest.TestCase):
     @unittest.skipUnless(
         _is_macos() and _macos_version() >= (10, 13), "Only supported on macOS 10.13+"
     )
-    @unittest.skipIf(_SKLEARN_VERSION >= StrictVersion("0.22"),
+    @unittest.skipIf(_SKLEARN_VERSION >= Version("0.22"),
         "categorical_features parameter to OneHotEncoder() deprecated after SciKit Learn 0.22."
     )
     def test_random_sparse_data(self):

--- a/coremltools/test/sklearn_tests/test_random_forest_classifier_numeric.py
+++ b/coremltools/test/sklearn_tests/test_random_forest_classifier_numeric.py
@@ -9,7 +9,7 @@ import unittest
 import numpy as np
 import pandas as pd
 import pytest
-from packaging import Version
+from packaging.version import Version
 
 from coremltools._deps import _HAS_SKLEARN, _SKLEARN_VERSION
 from coremltools.models.utils import (_is_macos, _macos_version,

--- a/coremltools/test/sklearn_tests/test_random_forest_classifier_numeric.py
+++ b/coremltools/test/sklearn_tests/test_random_forest_classifier_numeric.py
@@ -5,11 +5,11 @@
 
 import itertools
 import unittest
-from distutils.version import StrictVersion
 
 import numpy as np
 import pandas as pd
 import pytest
+from packaging import Version
 
 from coremltools._deps import _HAS_SKLEARN, _SKLEARN_VERSION
 from coremltools.models.utils import (_is_macos, _macos_version,
@@ -82,7 +82,7 @@ class RandomForestBinaryClassifierBostonHousingScikitNumericTest(
             max_leaf_nodes=[None, 20],
         )
 
-        if _SKLEARN_VERSION >= StrictVersion("0.19"):
+        if _SKLEARN_VERSION >= Version("0.19"):
             options["min_impurity_decrease"] = [1e-07, 0.1]
 
         # Make a cartesian product of all options
@@ -129,7 +129,7 @@ class RandomForestMultiClassClassificationBostonHousingScikitNumericTest(
             max_leaf_nodes=[None, 20],
         )
 
-        if _SKLEARN_VERSION >= StrictVersion("0.19"):
+        if _SKLEARN_VERSION >= Version("0.19"):
             options["min_impurity_decrease"] = [1e-07, 0.1]
 
         # Make a cartesian product of all options

--- a/coremltools/test/xgboost_tests/test_decision_tree_classifier_numeric.py
+++ b/coremltools/test/xgboost_tests/test_decision_tree_classifier_numeric.py
@@ -9,7 +9,7 @@ import unittest
 import numpy as np
 import pandas as pd
 import pytest
-from packaging import Version
+from packaging.version import Version
 
 from coremltools._deps import _HAS_SKLEARN, _SKLEARN_VERSION
 from coremltools.models.utils import (_is_macos, _macos_version,

--- a/coremltools/test/xgboost_tests/test_decision_tree_classifier_numeric.py
+++ b/coremltools/test/xgboost_tests/test_decision_tree_classifier_numeric.py
@@ -5,11 +5,11 @@
 
 import itertools
 import unittest
-from distutils.version import StrictVersion
 
 import numpy as np
 import pandas as pd
 import pytest
+from packaging import Version
 
 from coremltools._deps import _HAS_SKLEARN, _SKLEARN_VERSION
 from coremltools.models.utils import (_is_macos, _macos_version,
@@ -78,7 +78,7 @@ class DecisionTreeBinaryClassificationBostonHousingScikitNumericTest(
             max_features=[None, 1, 5],
             max_leaf_nodes=[None, 20],
         )
-        if _SKLEARN_VERSION < StrictVersion("0.22"): # 'presort' option deprecated >=0.22
+        if _SKLEARN_VERSION < Version("0.22"): # 'presort' option deprecated >=0.22
             options["presort"] = [False, True]
 
         # Make a cartesian product of all options
@@ -125,7 +125,7 @@ class DecisionTreeMultiClassClassificationBostonHousingScikitNumericTest(
             max_features=[None, 1, 5],
             max_leaf_nodes=[None, 20],
         )
-        if _SKLEARN_VERSION < StrictVersion("0.22"): # 'presort' option deprecated >=0.22
+        if _SKLEARN_VERSION < Version("0.22"): # 'presort' option deprecated >=0.22
             options["presort"] = [False, True]
 
         # Make a cartesian product of all options

--- a/coremltools/test/xgboost_tests/test_decision_tree_regression_numeric.py
+++ b/coremltools/test/xgboost_tests/test_decision_tree_regression_numeric.py
@@ -8,7 +8,7 @@ import unittest
 
 import pandas as pd
 import pytest
-from packaging import Version
+from packaging.version import Version
 
 from coremltools._deps import _HAS_SKLEARN, _SKLEARN_VERSION
 from coremltools.models.utils import (_is_macos, _macos_version,

--- a/coremltools/test/xgboost_tests/test_decision_tree_regression_numeric.py
+++ b/coremltools/test/xgboost_tests/test_decision_tree_regression_numeric.py
@@ -5,10 +5,10 @@
 
 import itertools
 import unittest
-from distutils.version import StrictVersion
 
 import pandas as pd
 import pytest
+from packaging import Version
 
 from coremltools._deps import _HAS_SKLEARN, _SKLEARN_VERSION
 from coremltools.models.utils import (_is_macos, _macos_version,
@@ -94,7 +94,7 @@ class DecisionTreeRegressorBostonHousingScikitNumericTest(unittest.TestCase):
             max_leaf_nodes=[None, 20],
             min_impurity_decrease=[0.0, 1e-07, 0.1],
         )
-        if _SKLEARN_VERSION < StrictVersion("0.22"): # 'presort' option deprecated >=0.22
+        if _SKLEARN_VERSION < Version("0.22"): # 'presort' option deprecated >=0.22
             options["presort"] = [False, True]
 
         # Make a cartesian product of all options


### PR DESCRIPTION
Distutils has been deprecated in 3.10 and removed in 3.12 (https://docs.python.org/3.10/whatsnew/3.10.html#distutils-deprecated)

For 3.12 compatibility (#2129) I'm proposing to remove distutils.

distutils was only used for its StrictVersion class, this can be replaced by packaging's Version class in every instance, as this library is already a dependency this requires no further packages to be added as dependency.

For the use of the Version class, see: https://packaging.pypa.io/en/latest/version.html