### PR TITLE
Avoid fp32 cast for Torch div operator

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -1505,12 +1505,12 @@ def div(context, node):
     x = inputs[0]
     y = inputs[1]
     if not types.is_float(x.dtype) and not types.is_float(y.dtype):
-        x = mb.cast(x, dtype="fp32")
-        y = mb.cast(y, dtype="fp32")
+        x = mb.cast(x=x, dtype="fp32")
+        y = mb.cast(x=y, dtype="fp32")
     elif not types.is_float(x.dtype):
-        x = mb.cast(x, dtype=y.dtype)
+        x = mb.cast(x=x, dtype=y.dtype)
     elif not types.is_float(y.dtype):
-        y = mb.cast(y, dtype=x.dtype)
+        y = mb.cast(x=y, dtype=x.dtype)
 
     if len(inputs) > 2 and inputs[2] is not None:
         rounding_mode = inputs[2].val

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -1502,8 +1502,15 @@ def maximum(context, node):
 @register_torch_op
 def div(context, node):
     inputs = _get_inputs(context, node, expected=[2, 3])
-    x = mb.cast(x=inputs[0], dtype="fp32")
-    y = mb.cast(x=inputs[1], dtype="fp32")
+    x = inputs[0]
+    y = inputs[1]
+    if not types.is_float(x.dtype) and not types.is_float(y.dtype):
+        x = mb.cast(x, dtype="fp32")
+        y = mb.cast(y, dtype="fp32")
+    elif not types.is_float(x.dtype):
+        x = mb.cast(x, dtype=y.dtype)
+    elif not types.is_float(y.dtype):
+        y = mb.cast(y, dtype=x.dtype)
 
     if len(inputs) > 2 and inputs[2] is not None:
         rounding_mode = inputs[2].val
@@ -1529,8 +1536,6 @@ def div(context, node):
             )
     else:
         res = mb.real_div(x=x, y=y, name=node.name)
-
-    context.add(res)
 
 
 @register_torch_op(torch_alias=["floordiv"])

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -1537,6 +1537,8 @@ def div(context, node):
     else:
         res = mb.real_div(x=x, y=y, name=node.name)
 
+    context.add(res)
+
 
 @register_torch_op(torch_alias=["floordiv"])
 def floor_divide(context, node):


### PR DESCRIPTION
The `div` Torch op was always casting both operands to fp32, even if both operands are of type fp16. This cast should get removed by the `"common::add_fp16_cast"` optimization pass. However, it causes issues during the PyTorch conversion, for example let's say we have a forward method like this:

```python
class Foo:
    def __init__(self):
        super().__init__()
        self.proj = torch.nn.Linear(16, 1)
    def forward(self, x, y): # both fp16 tensors, shape [1, 16]
        r = x / y # r is now fp32
        return self.proj(r) # Problem
```

Now if we have moved the model (and it's parameters) to fp16 with eg. `m = Foo().to(torch.float16)`, we get an error at conversion time:

> In op, of type linear, named linear_0, the named input `bias` must have the same data type as the named input `x`. However, bias has dtype fp16 whereas x has dtype fp32.

This is because the result of the `div` operation stays fp32, and this doesn't match the resulting type of the PyTorch expression.