### PR TITLE
numpy 2.0.0 breaking changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
         ]
     },
     install_requires=[
-        "numpy >= 1.14.5",
+        "numpy >= 1.14.5, < 2.0.0",
         "protobuf >= 3.1.0, <= 4.0.0",
         "sympy",
         "tqdm",


### PR DESCRIPTION
recently, numpy 2.0.0 was introduced which has breaking changes like 

```
ValueError: Unable to avoid copy while creating an array as requested.
If using `np.array(obj, copy=False)` replace it with `np.asarray(obj)` to allow a copy when needed (no behavior change in NumPy 1.x).
```