### PR TITLE
Surfacing array_feature_extractor as a member of coremltools.models

### DIFF
--- a/coremltools/models/__init__.py
+++ b/coremltools/models/__init__.py
@@ -3,6 +3,7 @@
 # Use of this source code is governed by a BSD-3-clause license that can be
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
+from . import array_feature_extractor
 from . import datatypes
 
 from . import _feature_management

--- a/coremltools/optimize/__init__.py
+++ b/coremltools/optimize/__init__.py
@@ -2,3 +2,6 @@
 #
 #  Use of this source code is governed by a BSD-3-clause license that can be
 #  found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+
+from . import coreml
+from . import torch

--- a/coremltools/test/api/test_api_visibilities.py
+++ b/coremltools/test/api/test_api_visibilities.py
@@ -76,6 +76,7 @@ class TestApiVisibilities:
 
     def test_models(self):
         expected = [
+            "array_feature_extractor",
             "CompiledMLModel",
             "MLModel",
             "datatypes",


### PR DESCRIPTION
Before this PR: 

```
>>> import coremltools as ct
>>> ct.models.array_feature_extractor
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'coremltools.models' has no attribute 'array_feature_extractor'
```

```
>>> ct.optimize.torch
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'coremltools.optimize' has no attribute 'torch'

```


After this PR: 

```
>>> import coremltools as ct
>>> ct.models.array_feature_extractor
<module 'coremltools.models.array_feature_extractor' from '/Volumes/Data/Apple/Repositories/Public/coremltools-public/coremltools/models/array_feature_extractor.py'>
```

```
>>> ct.optimize.torch
<module 'coremltools.optimize.torch' from '/Volumes/Data/Apple/Repositories/Public/coremltools-public/coremltools/optimize/torch/__init__.py'>
```

CI: ~https://gitlab.com/coremltools1/coremltools/-/commit/83d349060c1ad025a1d58ef44f02f3f4f818209e~

CI: https://gitlab.com/coremltools1/coremltools/-/pipelines/1392512958