### PR TITLE
Fix reshape optimizations in nested blocks

### DIFF
--- a/coremltools/converters/mil/mil/passes/tests/test_pass_pipeline.py
+++ b/coremltools/converters/mil/mil/passes/tests/test_pass_pipeline.py
@@ -118,31 +118,6 @@ class TestPassPipeline:
         assert "default" in available_pipelines
         assert "default_palettization" in available_pipelines
 
-    def test_merge_reshape_in_nested_block(self):
-        INPUT_SHAPE = (6, 7)
-        OUTPUT_SHAPE = (7, 6)
-
-        @mb.program(input_specs=[mb.TensorSpec(shape=INPUT_SHAPE)])
-        def prog(x):
-            loop_var = np.int32(2)
-            def while_cond(loop_Var, _x):
-                return mb.equal(x=loop_Var, y=np.int32(0))
-
-            def while_body(loop_var, x):
-                # Do reshapes of the input
-                y1 = mb.reshape(x=x, shape=(3, 2, 7))
-                y2 = mb.reshape(x=y1, shape=(7, 2, 3))
-                y3 = mb.reshape(x=y2, shape=(14, 3))
-                y4 = mb.reshape(x=y3, shape=OUTPUT_SHAPE)
-                return mb.add(x=loop_var, y=np.int(-1)), y4
-
-            while_results = mb.while_loop(_cond=while_cond, _body=while_body, loop_vars=(loop_var, x))
-            return while_results[1]
-
-        pipeline = PassPipeline.EMPTY
-        pipeline.append_pass("common::merge_consecutive_reshapes")
-        PassPipelineManager.apply_pipeline(prog, pipeline)
-
     @staticmethod
     def test_get_pipeline_should_use_copy():
         pipeline = PassPipeline.DEFAULT_PRUNING

--- a/coremltools/converters/mil/testing_utils.py
+++ b/coremltools/converters/mil/testing_utils.py
@@ -271,7 +271,7 @@ def get_op_names_in_program(prog, func_name="main", skip_const_ops=True):
     return op_names_in_program
 
 
-def get_op_types_in_block(block: Block, skip_const_ops: bool = True):
+def get_op_types_in_block(block: Block, skip_const_ops: bool = True, recurse: bool = False):
     """
     Return the operation types in block,
     in the same order as they are stored (topological)
@@ -282,16 +282,23 @@ def get_op_types_in_block(block: Block, skip_const_ops: bool = True):
             if op.op_type == "const":
                 continue
         op_types_in_block.append(op.op_type)
+
+        if recurse:
+            for child_block in op.blocks:
+                child_ops = get_op_types_in_block(child_block, skip_const_ops, recurse)
+                op_types_in_block += child_ops
+
     return op_types_in_block
 
 
-def get_op_types_in_program(prog: Program, func_name: str = "main", skip_const_ops: bool = True):
+def get_op_types_in_program(prog: Program, func_name: str = "main", skip_const_ops: bool = True, recurse: bool = False):
     """
     Return the operation types in prog[func_name],
     in the same order as they are stored (topological)
     If ``skip_const_ops = True``, const ops are not returned.
+    If ``recurse = True``, the ops of all nested blocks are returned.
     """
-    return get_op_types_in_block(prog[func_name], skip_const_ops)
+    return get_op_types_in_block(prog[func_name], skip_const_ops, recurse)
 
 def random_gen(
     shape,


### PR DESCRIPTION
When reshapes are optimized in nested blocks, the operation builder context is not being updated correctly, because the nested method processing the block is not annotated with the `@block_context_manager` annotation. This causes an error where the `before_op` not to be found when trying to modify the block:
```
self = <coremltools.converters.mil.mil.utils.CacheDoublyLinkedList object at 0x13ae84150>
new_op =    = reshape(x=%x_x0, shape=(7, 6), name="reshape_7")

before_op =   %reshape_7: (7, 6, fp32)(Tensor) = reshape(x=%reshape_6, shape=(7, 6), name="reshape_7")


    def insert_op_before(self, new_op: Operation, before_op: Optional[Operation] = None):
        """
        Insert an op right before before_op. If before_op is None,
         then the new op is appended in the end.
        """
        if new_op in self.op_to_node:
            raise ValueError(f"{new_op} already exisits.")
    
        new_node = OpNode(new_op)
    
        if before_op is None:
            # If before op is None, the new node is appended in the end.
            if self.start is None:
                self.start = self.end = new_node
            else:
                self.end.next = new_node
                new_node.prev = self.end
                self.end = new_node
        else:
>           anchor_node = self.op_to_node[before_op]
E           KeyError:   %reshape_7: (7, 6, fp32)(Tensor) = reshape(x=%reshape_6, shape=(7, 6), name="reshape_7")
```

I've added a test illustrating the issue. Note that I managed to not get the test in `test_passes.py` to run on my machine (because I think my OS X version is too old). However, I did validate the test I've in `test_pass_pipeline.py`. We probably want to remove the test from `test_pass_pipeline.py`.