### PR TITLE
chore: report shape to user upon index_put error

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -3922,7 +3922,7 @@ def index_put(context, node):
         indices = indices[0]
         assert (
             indices.shape == x.shape
-        ), "indices shape must equal to input shape for index put operation."
+        ), f"indices shape {indices.shape} must equal to input shape {x.shape} for index put operation."
         indices = mb.cast(x=indices, dtype="int32")
         indices = mb.non_zero(x=indices)
         # values


### PR DESCRIPTION
Previous error message:
`AssertionError: indices shape must equal to input shape for index put operation.`

New error message:
`AssertionError: indices shape (1, is3) must equal to input shape (1, is2, 256) for index put operation.`