### PR TITLE
Review of new Core ML Tools public API docstrings, part 2

### DIFF
--- a/coremltools/optimize/coreml/_post_training_quantization.py
+++ b/coremltools/optimize/coreml/_post_training_quantization.py
@@ -147,13 +147,13 @@ def linear_quantize_weights(
         An :py:class:`OptimizationConfig` object that specifies the parameters for weight quantization.
 
     joint_compression: bool
-        When it is set, the input mlmodel (should already be compressed) is further quantized to a
-        jointly compressed mlmodel. For what compression schema that could be futher jointly
-        quantized, see the `blockwise_quantize_weights` graph pass for details.
+        Specification of whether or not to further compress the already-compressed input MLModel to a
+        jointly compressed MLModel. See the `blockwise_palettize_weights` graph pass for information 
+        about which compression schemas could be further jointly palettized.
 
-        Using "palettize + quantize" as an example, where the input mlmodel is already palettized,
-        and the palettization's lut will be further quantized. The weight values are represented by
-        ``constexpr_blockwise_shift_scale`` + ``constexpr_lut_to_dense`` ops:
+        Take "palettize + quantize" as an example of joint compression, where the input MLModel is already 
+        palettized, and the palettization's lookup table will be further quantized. In such an example, 
+        the weight values are represented by ``constexpr_blockwise_shift_scale`` + ``constexpr_lut_to_dense`` ops:
         lut(int8) -> constexpr_blockwise_shift_scale -> lut(fp16) -> constexpr_lut_to_dense -> dense(fp16)
 
     Returns
@@ -189,7 +189,7 @@ def palettize_weights(
 ):
     """
     Utility function to convert a float precision MLModel of type ``mlprogram`` to a
-    compressed MLModel by reducing the overall number of weights using one or more look-up-table
+    compressed MLModel by reducing the overall number of weights using one or more lookup tables
     (LUT). A LUT contains a list of float values. An `nbit` LUT has 2\ :sup:`nbits` entries.
 
     For example, a float weight vector such as ``{0.3, 0.3, 0.5, 0.5}`` can be compressed
@@ -214,12 +214,12 @@ def palettize_weights(
     The weight can be converted to a palette with indices ``[0, 1, 2, 3]`` (2 bits). The
     indices are a byte array.
 
-    The data range ``[0.0, 0.3]`` is divided into 4 partitions linearly, which is
+    The data range ``[0.0, 0.3]`` is divided into four partitions linearly, which is
     ``[0.0, 0.1, 0.2, 0.3]``.
 
         * The LUT would be ``[0.0, 0.1, 0.2, 0.3]``.
 
-        * The weight is rounded to ``[0.1, 0.2, 0.3, 0.1, 0.0, 0.0]``, and represented in
+        * The weight is rounded to ``[0.1, 0.2, 0.3, 0.1, 0.0, 0.0]`` and represented in
           the palette as indices ``[01b, 10b, 11b, 01b, 00b, 00b]``.
 
     Parameters
@@ -231,13 +231,13 @@ def palettize_weights(
         An :py:class:`OptimizationConfig` object that specifies the parameters for weight palettization.
 
     joint_compression: bool
-        When it is set, the input mlmodel (should already be compressed) is further palettized to a
-        jointly compressed mlmodel. For what compression schema that could be futher jointly
-        palettized, see the `channelwise_palettize_weights` graph pass for details.
+        Specification of whether or not to further compress the already-compressed input MLModel to a
+        jointly compressed MLModel. See the `channelwise_palettize_weights` graph pass for information 
+        about which compression schemas could be further jointly palettized.
 
-        Using "prune + palettize" as an example, where the input mlmodel is already pruned,
-        and the non-zero entries will be further palettized. The weight values are represented by
-        ``constexpr_lut_to_sparse`` + ``constexpr_sparse_to_dense`` ops:
+        Take "prune + palettize" as an example of joint compression, where the input MLModel is already 
+        pruned, and the non-zero entries will be further palettized. In such an example, the weight values are
+        represented by ``constexpr_lut_to_sparse`` + ``constexpr_sparse_to_dense`` ops:
         lut(sparse) -> constexpr_lut_to_sparse -> weight(sparse) -> constexpr_sparse_to_dense -> weight(dense)
 
     Returns
@@ -303,13 +303,13 @@ def prune_weights(
         An :py:class:`OptimizationConfig` object that specifies the parameters for weight pruning.
 
     joint_compression: bool
-        When it is set, the input mlmodel (should already be compressed) is further pruned to a
-        jointly compressed mlmodel. For what compression schema that could be futher jointly
-        pruned, see the `prune_weights` graph pass for details.
+        Specification of whether or not to further prune the already-compressed input MLModel to a
+        jointly compressed MLModel. See the `prune_weights` graph pass for information 
+        about which compression schemas could be further pruned.
 
-        Using "quantize + prune" as an example, where the input mlmodel is already quantized,
-        and it will be further pruned. The weight values are represented by
-        ``constexpr_sparse_blockwise_shift_scale`` + ``constexpr_sparse_to_dense`` ops:
+        Take "quantize + prune" as an example of joint compression, where the input MLModel is already 
+        quantized, and it will be further pruned. In such an example, the weight values are
+        represented by ``constexpr_sparse_blockwise_shift_scale`` + ``constexpr_sparse_to_dense`` ops:
         quantized(sparse) -> constexpr_sparse_blockwise_shift_scale -> weight(sparse) -> constexpr_sparse_to_dense -> weight(dense)
 
     Returns

--- a/coremltools/optimize/coreml/experimental/_post_training_quantization.py
+++ b/coremltools/optimize/coreml/experimental/_post_training_quantization.py
@@ -27,15 +27,15 @@ from ._quantization_passes import (
 def linear_quantize_activations(mlmodel: _MLModel, config: _OptimizationConfig, sample_data: List):
     """
     Utility function to convert a float precision MLModel of type ``mlprogram``, which uses
-    float-precision activations, into a compressed MLModel that uses n-bit activations (currently only
-    support n=8).
+    float-precision activations, into a compressed MLModel that uses n-bit activations. Currently, only n=8
+    is suppported.
 
-    This is achieved by calibrating the float activation values that observed by feeding real sample data into
-    the model, converting calibrated statistics into the ``quantize`` and ``dequantize`` op pairs, and inserted
-    into where activation get quantized.
+    This is achieved by feeding real sample data into the input MLModel, calibrating the resulting float activation values, 
+    converting the calibrated values into ``quantize`` and ``dequantize`` op pairs, and inserting those
+    op pairs into the new MLModel instance where activations get quantized.
 
-    It's recommended to use with linear_quantize_weights for 8-bit activation and 8-bit weight linear quantization.
-    It's also compatible to use with other weight compression methods.
+    Use this function with ``linear_quantize_weights`` for 8-bit activation and 8-bit weight linear quantization.
+    It's also compatible for use with other weight compression methods.
 
     Parameters
     ----------
@@ -47,7 +47,7 @@ def linear_quantize_activations(mlmodel: _MLModel, config: _OptimizationConfig, 
 
     sample_data: List
         Data used to characterize statistics of the activation values of the original float precision model.
-        Expecting a list of sample input dictionaries.
+        Expects a list of sample input dictionaries.
 
     Returns
     -------
@@ -130,7 +130,7 @@ def linear_quantize_activations(mlmodel: _MLModel, config: _OptimizationConfig, 
         specification_version=specification_version,
         compute_units=mlmodel.compute_unit,
         model_description=model_spec.description,
-        skip_model_load=False,  # Must be False to avoid manually re-load from disk before running prediction.
+        skip_model_load=False,  # Must be False to avoid manually re-loading from disk before running prediction.
     )
     return mlmodel_activation_quantized
 

--- a/coremltools/optimize/torch/layerwise_compression/algorithms.py
+++ b/coremltools/optimize/torch/layerwise_compression/algorithms.py
@@ -59,17 +59,17 @@ class LayerwiseCompressionAlgorithmConfig(_ABC, _ClassRegistryMixin, _ModuleOpti
 @_define
 class ModuleGPTQConfig(LayerwiseCompressionAlgorithmConfig):
     """
-    Configuration class for specifying global and module level compression options for
-    `GPTQ <https://arxiv.org/pdf/2210.17323.pdf>`_ algorithm.
+    Configuration class for specifying global and module level compression options for the
+    `Generative Pre-Trained Transformer Quantization (GPTQ) <https://arxiv.org/pdf/2210.17323.pdf>`_ algorithm.
 
     Args:
         weight_dtype (:py:class:`torch.dtype`): The dtype to use for quantizing the weights. The number of bits used
             for quantization is inferred from the dtype. When dtype is set to :py:class:`torch.float32`, the weights
-            corresponding to that layer are not quantized.  Defaults to :py:class:`torch.uint8` which corresponds to
+            corresponding to that layer are not quantized. Defaults to :py:class:`torch.uint8` which corresponds to
             8-bit quantization.
         granularity (:py:class:`QuantizationGranularity`): Specifies the granularity at which quantization parameters
             will be computed. Can be one of ``per_channel``, ``per_tensor`` or ``per_block``. When using ``per_block``,
-            ``block_size`` argument must be specified.  Defaults to ``per_channel``.
+            ``block_size`` argument must be specified. Defaults to ``per_channel``.
         quantization_scheme: (:py:class:`~.coremltools.optimize.torch.quantization.quantization_config.QuantizationScheme`): Type of
             quantization configuration to use. When this parameter is set to ``QuantizationScheme.symmetric``, all
             weights are quantized with zero point as zero. When it is set to ``QuantizationScheme.affine``, zero point
@@ -77,20 +77,20 @@ class ModuleGPTQConfig(LayerwiseCompressionAlgorithmConfig):
             Defaults to ``QuantizationScheme.symmetric``.
          block_size (:obj:`int`): When ``block_size`` is specified, ``block_size``
             number of values will share the same quantization parameters of scale (and zero point if applicable) across
-            the input-channel axis.  Defaults to ``None``.
+            the input-channel axis. Defaults to ``None``.
         enable_normal_float (:obj:`bool`): When ``True``, normal float format is used for quantization. It's
             only supported when ``weight_dtype`` is equal to ``int3`` and ``int4``. Defaults to ``False``.
         hessian_dampening: (:obj:`float`): Dampening factor added to the diagonal of the
             Hessian used by GPTQ algorithm. Defaults to ``0.01``.
         use_activation_order_heuristic (:obj:`bool`): When ``True``, columns of weight are sorted
             in descending order of values of Hessian diagonal elements. Defaults to ``True``.
-        processing_group_size (:obj:`int`):  The weights are updated in
-            blocks of size processing_group_size. Defaults to ``128``.
+        processing_group_size (:obj:`int`): The weights are updated in
+            blocks of size ``processing_group_size``. Defaults to ``128``.
 
-        .. note:
-            Currently blocking is limited to only the input-channel axis for GPTQ. For a linear layer of shape (C_o x C_i), and block_size B,
-            the quantization scales will have shape (C_o x C_i/B). For a 2D conv layer of shape (C_o x C_i x H x W), the
-            quantization scales will have shape (C_o x C_i/B x 1 x 1).
+    .. note:
+        Blocking is currently limited to the input channel axis for GPTQ. For a linear layer of shape `(C_o x C_i)`, and ``block_size`` `B`,
+        the quantization scales will have shape `(C_o x C_i/B)`. For a 2D conv layer of shape `(C_o x C_i x H x W)`, the
+        quantization scales will have shape `(C_o x C_i/B x 1 x 1)`.
     """
 
     weight_dtype: _Union[str, _torch.dtype] = _field(
@@ -139,8 +139,8 @@ class ModuleGPTQConfig(LayerwiseCompressionAlgorithmConfig):
 @_define
 class ModuleSparseGPTConfig(LayerwiseCompressionAlgorithmConfig):
     """
-    Configuration class for specifying global and module level compression options for
-    `SparseGPT <https://arxiv.org/pdf/2301.00774.pdf>`_ algorithm.
+    Configuration class for specifying global and module level compression options for the
+    `Sparse Generative Pre-Trained Transformer (SparseGPT) <https://arxiv.org/pdf/2301.00774.pdf>`_ algorithm.
 
     Args:
         target_sparsity (:obj:`float`): Fraction of weight elements to set to ``0``. Defaults to
@@ -151,11 +151,11 @@ class ModuleSparseGPTConfig(LayerwiseCompressionAlgorithmConfig):
             target sparsity is determined by the ``n:m`` ratio.
         weight_dtype (:py:class:`torch.dtype`): The dtype to use for quantizing the weights. The number of bits used
             for quantization is inferred from the dtype. When dtype is set to :py:class:`torch.float32`, the weights
-            corresponding to that layer are not quantized.  Defaults to :py:class:`torch.float32` which corresponds to
+            corresponding to that layer are not quantized. Defaults to :py:class:`torch.float32` which corresponds to
             no quantization.
         quantization_granularity (:py:class:`QuantizationGranularity`): Specifies the granularity at which quantization parameters
             will be computed. Can be one of ``per_channel``, ``per_tensor`` or ``per_block``. When using ``per_block``,
-            ``block_size`` argument must be specified.  Defaults to ``per_channel``.
+            ``block_size`` argument must be specified. Defaults to ``per_channel``.
         quantization_scheme: (:py:class:`~.coremltools.optimize.torch.quantization.quantization_config.QuantizationScheme`): Type of
             quantization configuration to use. When this parameter is set to ``QuantizationScheme.symmetric``, all
             weights are quantized with zero point as zero. When it is set to ``QuantizationScheme.affine``, zero point
@@ -165,7 +165,7 @@ class ModuleSparseGPTConfig(LayerwiseCompressionAlgorithmConfig):
             only supported for ``weight_dtype`` is equal to ``int3`` and ``int4``.
         hessian_dampening (:obj:`float`): Dampening factor added to the diagonal of the
             Hessian used by GPTQ algorithm. Defaults to ``0.01``.
-        processing_group_size (:obj:`int`):  The weights are updated in
+        processing_group_size (:obj:`int`): The weights are updated in
             blocks of size processing_group_size. Defaults to ``128``.
     """
 

--- a/coremltools/optimize/torch/layerwise_compression/layerwise_compressor.py
+++ b/coremltools/optimize/torch/layerwise_compression/layerwise_compressor.py
@@ -72,22 +72,21 @@ class LayerwiseCompressorConfig(_OptimizationConfig):
 
     Args:
         layers (:obj:`list` of :py:class:`torch.nn.Module` or :obj:`str`): List of layers
-            which should be compressed. The layer names can also be specified as a regex.
+            to be compressed. The layer names within the list can be specified as a string or regex.
             The layers listed should be immediate child modules of the parent container
-            :py:class:`torch.nn.Sequential` model and they should be contiguous, i.e.,
-            output of layer ``n`` should be input of layer ``n+1``.
+            :py:class:`torch.nn.Sequential` model and they should be contiguous. That is,
+            the output of layer ``n`` should be the input to layer ``n+1``.
         global_config (:py:class:`ModuleGPTQConfig` or :py:class:`ModuleSparseGPTConfig`): Config to be applied globally
             to all supported modules. Missing values are chosen from the default config.
         module_type_configs (:obj:`dict` of :obj:`str` to :py:class:`ModuleGPTQConfig` or :py:class:`ModuleSparseGPTConfig`):
-            Module type configs applied to a specific
-            module class, such as :py:class:`torch.nn.Linear`. The keys can be either strings
-            or module classes.
+            Module type configs applied to a specific module class, such as :py:class:`torch.nn.Linear`. 
+            The keys can be either strings or module classes.
         module_name_configs (:obj:`dict` of :obj:`str` to :py:class:`ModuleGPTQConfig` or :py:class:`ModuleSparseGPTConfig`):
-            Module level configs applied to specific modules.
-            The name of the module must either be a regex or a fully qualified name that can be used
-            to fetch it from the top level module using the ``module.get_submodule(target)`` method.
-        input_cacher (:obj:`str` or :py:class:`FirstLayerInputCacher`): Cacher object
-            which caches inputs which are fed to the first layer which is set up for compression
+            Module level configs applied to specific modules. The name of the module must either be a regex or 
+            a fully qualified name that can be used to fetch it from the top level module using the 
+            ``module.get_submodule(target)`` method.
+        input_cacher (:obj:`str` or :py:class:`FirstLayerInputCacher`): Cacher object that caches inputs which are then
+        fed to the first layer set up for compression.
         calibration_nsamples (:obj:`int`): Number of samples to be used for calibration.
     """
 
@@ -191,20 +190,20 @@ class LayerwiseCompressor(_BaseDataCalibratedModelOptimizer):
     A post training compression algorithm which compresses a sequential model layer by layer.
     The implementation supports two variations of this algorithm:
 
-    1) `GPTQ <https://arxiv.org/pdf/2210.17323.pdf>`_
-    2) `SparseGPT <https://arxiv.org/pdf/2301.00774.pdf>`_
+    1) `Generative Pre-Trained Transformer Quantization (GPTQ) <https://arxiv.org/pdf/2210.17323.pdf>`_
+    2) `Sparse Generative Pre-Trained Transformer (SparseGPT) <https://arxiv.org/pdf/2301.00774.pdf>`_
 
     At a high level, it compresses weights of a model layer by layer,
     by minimizing the L2 norm of the difference between the original activations and
-    activations obtained on compressing the weights of a layer. The activations
+    activations obtained from compressing the weights of a layer. The activations
     are computed using a few samples of training data.
 
-    Only sequential models are supported, where output of one layer feeds into the
+    Only sequential models are supported, where the output of one layer feeds into the
     input of the next layer.
 
-    For HuggingFace models, disable use_cache config. This is used to speed up decoding but,
-    to generalize forward pass for LayerwiseCompressor algorithms across all
-    model types we need to disable this behavior.
+    For HuggingFace models, disable the `use_cache` config. This is used to speed up decoding, 
+    but to generalize forward pass for `LayerwiseCompressor` algorithms across all
+    model types, the behavior must be disabled.
 
     Example:
 

--- a/coremltools/optimize/torch/layerwise_compression/layerwise_compressor.py
+++ b/coremltools/optimize/torch/layerwise_compression/layerwise_compressor.py
@@ -72,10 +72,10 @@ class LayerwiseCompressorConfig(_OptimizationConfig):
 
     Args:
         layers (:obj:`list` of :py:class:`torch.nn.Module` or :obj:`str`): List of layers
-            to be compressed. The layer names within the list can be specified as a string or regex.
-            The layers listed should be immediate child modules of the parent container
-            :py:class:`torch.nn.Sequential` model and they should be contiguous. That is,
-            the output of layer ``n`` should be the input to layer ``n+1``.
+            to be compressed. When items in the list are `str`, the string can be regex 
+            or the exact name of the module. The layers listed should be immediate child modules 
+            of the parent container :py:class:`torch.nn.Sequential` model and they should be contiguous. 
+            That is, the output of layer ``n`` should be the input to layer ``n+1``.
         global_config (:py:class:`ModuleGPTQConfig` or :py:class:`ModuleSparseGPTConfig`): Config to be applied globally
             to all supported modules. Missing values are chosen from the default config.
         module_type_configs (:obj:`dict` of :obj:`str` to :py:class:`ModuleGPTQConfig` or :py:class:`ModuleSparseGPTConfig`):

--- a/coremltools/optimize/torch/palettization/sensitive_k_means.py
+++ b/coremltools/optimize/torch/palettization/sensitive_k_means.py
@@ -90,7 +90,7 @@ class ModuleSKMPalettizerConfig(_ModuleOptimizationConfig):
         enable_per_channel_scale (:obj:`bool`): When set to ``True``, weights are normalized along the output channels
             using per-channel scales before being palettized. This is not supported with ``cluster_dim > 1``.
 
-    This class two different configurations to structure the palettization:
+    This class supports two different configurations to structure the palettization:
 
     1. **Per-tensor palettization**:  This is the default configuration where the whole tensor shares a single lookup
     table. The ``granularity`` is set to ``per_tensor``, and ``group_size`` is ``None``.

--- a/coremltools/optimize/torch/quantization/post_training_quantization.py
+++ b/coremltools/optimize/torch/quantization/post_training_quantization.py
@@ -77,11 +77,11 @@ class ModulePostTrainingQuantizerConfig(_ModuleOptimizationConfig):
     Args:
         weight_dtype (:py:class:`torch.dtype`): The dtype to use for quantizing the weights. The number of bits used
             for quantization is inferred from the dtype. When dtype is set to :py:class:`torch.float32`, the weights
-            corresponding to that layer are not quantized.  Defaults to :py:class:`torch.int8` which corresponds to
+            corresponding to that layer are not quantized. Defaults to :py:class:`torch.int8` which corresponds to
             8-bit quantization.
         granularity (:py:class:`QuantizationGranularity`): Specifies the granularity at which quantization parameters
             will be computed. Can be one of ``per_channel``, ``per_tensor`` or ``per_block``. When using ``per_block``,
-            ``block_size`` argument must be specified.  Defaults to ``per_channel``.
+            ``block_size`` argument must be specified. Defaults to ``per_channel``.
         quantization_scheme (:py:class:`~.coremltools.optimize.torch.quantization.quantization_config.QuantizationScheme`): Type of
             quantization configuration to use. When this parameter is set to ``QuantizationScheme.symmetric``,
             all weights are quantized with zero point as zero. When it is set to ``QuantizationScheme.affine``,
@@ -89,26 +89,26 @@ class ModulePostTrainingQuantizerConfig(_ModuleOptimizationConfig):
             Defaults to ``QuantizationScheme.symmetric``.
         block_size (:obj:`tuple` of :obj:`int` or :obj:`int`): When ``block_size`` is specified, ``block_size``
             number of values will share the same quantization parameters of scale (and zero point if applicable) across
-            the input-channel axis. A tuple of integers can be provided for arbitrary sized blockwise quantization.
+            the input channel axis. A tuple of integers can be provided for arbitrary sized blockwise quantization.
             See below for more details on different possible configurations. Defaults to ``None``.
 
-    This class supports few different configurations to structure the quantization:
+    This class supports three different configurations to structure the quantization:
 
     1. **Per-channel quantization**: This is the default configuration where ``granularity`` is ``per_channel`` and
     ``block_size`` is ``None``. In this configuration, quantization parameters are computed for each output channel.
 
-    2. **Per-tensor quantization**:  In this configuration, quantization paramaters are computed for the tensor as a whole. That is,
+    2. **Per-tensor quantization**: In this configuration, quantization parameters are computed for the tensor as a whole. That is,
     all values in the tensor will share a single scale (and a single zero point if applicable). The ``granularity`` argument is set
     to ``per_tensor``.
 
-    3. **Per-block quantization**: This is used to structure the tensor for block-wise quantization. For this configuration,
-    the ``granularity`` is set to ``per_block`` and the ``block_size`` argument has to be specified.
-    The ``block_size`` argument can either be:
+    3. **Per-block quantization**: This configuration is used to structure the tensor for blockwise quantization. The ``granularity`` 
+    is set to ``per_block`` and the ``block_size`` argument has to be specified. The ``block_size`` argument can either be of type
+    ``int`` or ``tuple``:
         * int: In this case, each row along the output-channel axis will have its own quantization parameters (similar to ``per_channel``).
-               Additionally, ``block_size`` number of values will share the same quantization parameters, along the input-channel axis.
+               Additionally, ``block_size`` number of values will share the same quantization parameters, along the input channel axis.
                For example, for a weight matrix of shape ``(10, 10)``, if we provide ``block_size = 2``, the shape of the quantization
                parameters would be ``(10, 5)``.
-        * tuple: For more advanced configuration, users can provide an arbitrary N-D shaped block to share the quantization parameters.
+        * tuple: For more advanced configuration, users can provide an arbitrary n-dimensional block to share the quantization parameters.
                  This is specified in the form of a tuple where each value corresponds to the block size for the respective axis of the
                  weight matrix. The length of the provided tuple should be at most the number of dimensions of the weight matrix.
 
@@ -191,7 +191,7 @@ class PostTrainingQuantizerConfig(_OptimizationConfig):
             The keys can be either strings or module classes.
         module_name_configs (:obj:`dict` of :obj:`str` to :py:class:`ModulePostTrainingQuantizerConfig`):
             Module name configs applied to specific modules. This can be a dictionary with module names pointing to their
-            corresponding :py:class:`ModulePostTrainingQuantizerConfig`s
+            corresponding :py:class:`ModulePostTrainingQuantizerConfig`.
     """
 
     global_config: _Optional[ModulePostTrainingQuantizerConfig] = _field(
@@ -256,8 +256,8 @@ class PostTrainingQuantizer(_BasePostTrainingModelOptimizer):
     .. note::
         After quantization, the weight values stored will still remain in full precision, therefore
         the PyTorch model size will not be reduced. To see the reduction in model size, please convert
-        the model using ``coremltools.convert(...)``, which will produce a MIL model containing the
-        compressed weights.
+        the model using ``coremltools.convert(...)``, which will produce a model intermediate language 
+        (MIL) model containing the compressed weights.
 
         Example:
 
@@ -281,7 +281,7 @@ class PostTrainingQuantizer(_BasePostTrainingModelOptimizer):
                 )
 
                 # initialize the quantizer
-                config = PostTrainingquantizerConfig.from_dict(
+                config = PostTrainingQuantizerConfig.from_dict(
                     {
                         "global_config": {
                             "weight_dtype": "int8",


### PR DESCRIPTION
This PR reviews and makes edits to the remaining 8 new docstrings in the Core ML Tools public API reference guide.

### Change summary

- Normalize spelling of "lookup table" and "blockwise" in non-code text
- Fixed formatting and removed extra spaces after some periods in non-code text.
- Modified docstrings to conform to Apple style and fix typos
- Re-worded the `joint_compression: bool` argument in the `linear_quantize_weights`, `palettize_weights`, and `prune_weight` methods for clarity.
- Re-worded `LayerwiseCompressorConfig` and `linear_quantize_activations` docstrings for clarity
- Expanded acronyms for MIL, GPTQ, SparseGPT

5 docstrings related to post-training quantization:
- [ModulePostTrainingQuantizerConfig](https://apple.github.io/coremltools/source/coremltools.optimize.torch.quantization.html#coremltools.optimize.torch.quantization.ModulePostTrainingQuantizerConfig)
- [PostTrainingQuantizer](https://apple.github.io/coremltools/source/coremltools.optimize.torch.quantization.html#coremltools.optimize.torch.quantization.PostTrainingQuantizer)
- [PostTrainingQuantizerConfig](https://apple.github.io/coremltools/source/coremltools.optimize.torch.quantization.html#coremltools.optimize.torch.quantization.PostTrainingQuantizerConfig)
- [ModuleGPTQConfig](https://apple.github.io/coremltools/source/coremltools.optimize.torch.quantization.html#coremltools.optimize.torch.layerwise_compression.algorithms.ModuleGPTQConfig)
- [linear_quantize_activations](https://apple.github.io/coremltools/source/coremltools.optimize.coreml.quantization.html#coremltools.optimize.coreml.experimental.linear_quantize_activations)

2 docstrings related to the layerwise compressor:
- [LayerwiseCompressorConfig](https://apple.github.io/coremltools/source/coremltools.optimize.torch.quantization.html#coremltools.optimize.torch.layerwise_compression.LayerwiseCompressorConfig)
- [LayerwiseCompressor](https://apple.github.io/coremltools/source/coremltools.optimize.torch.quantization.html#coremltools.optimize.torch.layerwise_compression.LayerwiseCompressor)

1 docstring related to palettization:
- [palettize_weights](https://apple.github.io/coremltools/source/coremltools.optimize.coreml.post_training_quantization.html#coremltools.optimize.coreml.palettize_weights)

### Next steps

After this PR is approved and merged, I'll run the make html script from the gh-pages branch and put up a PR in that branch so the changes can go live on the website.