### PR TITLE
Clean up remaining typos and formatting errors

### DIFF
--- a/coremltools/models/utils.py
+++ b/coremltools/models/utils.py
@@ -1419,8 +1419,8 @@ class MultiFunctionDescriptor:
 
     def __init__(self, model_path: _Optional[str] = None):
         """
-        If ``model_path`` is passed to the constructor, it must be a str pointing to an
-        existing ``mlpackage`` on disk. The MultiFunctionDescriptor instance will be initiated
+        If ``model_path`` is passed to the constructor, it must be a :obj:`str` pointing to an
+        existing ``mlpackage`` on disk. The :py:class:`MultiFunctionDescriptor` instance will be initiated
         with the functions in ``model_path``.
         """
         self._default_function_name = None
@@ -1519,15 +1519,15 @@ def save_multifunction(
     destination_path: str,
 ):
     """
-    Save a MultiFunctionDescriptor instance into a multifunction ``mlpackage``.
+    Save a :py:class:`MultiFunctionDescriptor` instance into a multifunction ``mlpackage``.
     This function also performs constant deduplication across functions to allow for weight sharing.
 
     Parameters
     ----------
-    desc : MultiFunctionDescriptor
+    desc: MultiFunctionDescriptor
         Multifunction descriptor to save on the disk.
 
-    destination_path : str
+    destination_path: str
         The path where the new ``mlpackage`` will be saved.
 
     Examples

--- a/coremltools/optimize/coreml/_post_training_quantization.py
+++ b/coremltools/optimize/coreml/_post_training_quantization.py
@@ -190,7 +190,7 @@ def palettize_weights(
     """
     Utility function to convert a float precision MLModel of type ``mlprogram`` to a
     compressed MLModel by reducing the overall number of weights using one or more lookup tables
-    (LUT). A LUT contains a list of float values. An `nbit` LUT has 2\ :sup:`nbits` entries.
+    (LUT). A LUT contains a list of float values. An ``n-bit`` LUT has :math:`2^{n\-bits}` entries.
 
     For example, a float weight vector such as ``{0.3, 0.3, 0.5, 0.5}`` can be compressed
     using a 1-bit LUT: ``{0.3, 0.5}``. In this case the float vector can be replaced
@@ -198,11 +198,11 @@ def palettize_weights(
 
     This function iterates over all the weights in the ``mlprogram``, discretizes its values,
     and constructs the LUT according to the algorithm specified in ``mode``. The float
-    values are then converted to the `nbit` values, and the LUT is saved alongside each
+    values are then converted to the ``n-bit`` values, and the LUT is saved alongside each
     weight. The ``const`` ops storing weight values are replaced by
     ``constexpr_lut_to_dense`` ops.
 
-    At runtime, the LUT and the `nbit` values are used to reconstruct the float weight
+    At runtime, the LUT and the ``n-bit`` values are used to reconstruct the float weight
     values, which are then used to perform the float operation the weight is feeding into.
 
     Consider the following example of ``"uniform"`` mode (a linear histogram):
@@ -238,7 +238,7 @@ def palettize_weights(
         Take "prune + palettize" as an example of joint compression, where the input MLModel is already 
         pruned, and the non-zero entries will be further palettized. In such an example, the weight values are
         represented by ``constexpr_lut_to_sparse`` + ``constexpr_sparse_to_dense`` ops:
-        lut(sparse) -> constexpr_lut_to_sparse -> weight(sparse) -> constexpr_sparse_to_dense -> weight(dense)
+        ``lut(sparse)`` -> ``constexpr_lut_to_sparse`` -> ``weight(sparse)`` -> ``constexpr_sparse_to_dense`` -> ``weight(dense)``
 
     Returns
     -------

--- a/coremltools/optimize/torch/layerwise_compression/algorithms.py
+++ b/coremltools/optimize/torch/layerwise_compression/algorithms.py
@@ -59,28 +59,27 @@ class LayerwiseCompressionAlgorithmConfig(_ABC, _ClassRegistryMixin, _ModuleOpti
 @_define
 class ModuleGPTQConfig(LayerwiseCompressionAlgorithmConfig):
     """
-    Configuration class for specifying global and module level compression options for the
+    Configuration class for specifying global and module-level compression options for the
     `Generative Pre-Trained Transformer Quantization (GPTQ) <https://arxiv.org/pdf/2210.17323.pdf>`_ algorithm.
 
     Args:
         weight_dtype (:py:class:`torch.dtype`): The dtype to use for quantizing the weights. The number of bits used
             for quantization is inferred from the dtype. When dtype is set to :py:class:`torch.float32`, the weights
-            corresponding to that layer are not quantized. Defaults to :py:class:`torch.uint8` which corresponds to
+            corresponding to that layer are not quantized. Defaults to :py:class:`torch.uint8`, which corresponds to
             8-bit quantization.
         granularity (:py:class:`QuantizationGranularity`): Specifies the granularity at which quantization parameters
             will be computed. Can be one of ``per_channel``, ``per_tensor`` or ``per_block``. When using ``per_block``,
             ``block_size`` argument must be specified. Defaults to ``per_channel``.
-        quantization_scheme: (:py:class:`~.coremltools.optimize.torch.quantization.quantization_config.QuantizationScheme`): Type of
+        quantization_scheme (:py:class:`~.coremltools.optimize.torch.quantization.quantization_config.QuantizationScheme`): Type of
             quantization configuration to use. When this parameter is set to ``QuantizationScheme.symmetric``, all
             weights are quantized with zero point as zero. When it is set to ``QuantizationScheme.affine``, zero point
             can be set anywhere in the range of values allowed for the quantized weight.
             Defaults to ``QuantizationScheme.symmetric``.
-         block_size (:obj:`int`): When ``block_size`` is specified, ``block_size``
-            number of values will share the same quantization parameters of scale (and zero point if applicable) across
-            the input-channel axis. Defaults to ``None``.
+        block_size (:obj:`int`): When ``block_size`` is specified, ``block_size`` number of values will share the same quantization 
+            parameters of scale, as well as the same zero point when applicable, across the input channel axis. Defaults to ``None``.
         enable_normal_float (:obj:`bool`): When ``True``, normal float format is used for quantization. It's
             only supported when ``weight_dtype`` is equal to ``int3`` and ``int4``. Defaults to ``False``.
-        hessian_dampening: (:obj:`float`): Dampening factor added to the diagonal of the
+        hessian_dampening (:obj:`float`): Dampening factor added to the diagonal of the
             Hessian used by GPTQ algorithm. Defaults to ``0.01``.
         use_activation_order_heuristic (:obj:`bool`): When ``True``, columns of weight are sorted
             in descending order of values of Hessian diagonal elements. Defaults to ``True``.
@@ -139,7 +138,7 @@ class ModuleGPTQConfig(LayerwiseCompressionAlgorithmConfig):
 @_define
 class ModuleSparseGPTConfig(LayerwiseCompressionAlgorithmConfig):
     """
-    Configuration class for specifying global and module level compression options for the
+    Configuration class for specifying global and module-level compression options for the
     `Sparse Generative Pre-Trained Transformer (SparseGPT) <https://arxiv.org/pdf/2301.00774.pdf>`_ algorithm.
 
     Args:
@@ -151,12 +150,12 @@ class ModuleSparseGPTConfig(LayerwiseCompressionAlgorithmConfig):
             target sparsity is determined by the ``n:m`` ratio.
         weight_dtype (:py:class:`torch.dtype`): The dtype to use for quantizing the weights. The number of bits used
             for quantization is inferred from the dtype. When dtype is set to :py:class:`torch.float32`, the weights
-            corresponding to that layer are not quantized. Defaults to :py:class:`torch.float32` which corresponds to
+            corresponding to that layer are not quantized. Defaults to :py:class:`torch.float32`, which corresponds to
             no quantization.
         quantization_granularity (:py:class:`QuantizationGranularity`): Specifies the granularity at which quantization parameters
             will be computed. Can be one of ``per_channel``, ``per_tensor`` or ``per_block``. When using ``per_block``,
             ``block_size`` argument must be specified. Defaults to ``per_channel``.
-        quantization_scheme: (:py:class:`~.coremltools.optimize.torch.quantization.quantization_config.QuantizationScheme`): Type of
+        quantization_scheme (:py:class:`~.coremltools.optimize.torch.quantization.quantization_config.QuantizationScheme`): Type of
             quantization configuration to use. When this parameter is set to ``QuantizationScheme.symmetric``, all
             weights are quantized with zero point as zero. When it is set to ``QuantizationScheme.affine``, zero point
             can be set anywhere in the range of values allowed for the quantized weight.

--- a/coremltools/optimize/torch/layerwise_compression/layerwise_compressor.py
+++ b/coremltools/optimize/torch/layerwise_compression/layerwise_compressor.py
@@ -66,15 +66,13 @@ _SUPPORTED_MODULES = [_torch.nn.Conv2d, _torch.nn.Linear]
 class LayerwiseCompressorConfig(_OptimizationConfig):
     """
     Configuration class for specifying how different submodules of a model are
-    compressed by :py:class:`LayerwiseCompressor`.
-
-    Only sequential models are supported.
+    compressed by :py:class:`LayerwiseCompressor`. Note that only sequential models are supported.
 
     Args:
         layers (:obj:`list` of :py:class:`torch.nn.Module` or :obj:`str`): List of layers
-            to be compressed. When items in the list are `str`, the string can be regex 
+            to be compressed. When items in the list are :obj:`str`, the string can be a regex 
             or the exact name of the module. The layers listed should be immediate child modules 
-            of the parent container :py:class:`torch.nn.Sequential` model and they should be contiguous. 
+            of the parent container :py:class:`torch.nn.Sequential` model, and they should be contiguous. 
             That is, the output of layer ``n`` should be the input to layer ``n+1``.
         global_config (:py:class:`ModuleGPTQConfig` or :py:class:`ModuleSparseGPTConfig`): Config to be applied globally
             to all supported modules. Missing values are chosen from the default config.
@@ -86,7 +84,7 @@ class LayerwiseCompressorConfig(_OptimizationConfig):
             a fully qualified name that can be used to fetch it from the top level module using the 
             ``module.get_submodule(target)`` method.
         input_cacher (:obj:`str` or :py:class:`FirstLayerInputCacher`): Cacher object that caches inputs which are then
-        fed to the first layer set up for compression.
+            fed to the first layer set up for compression.
         calibration_nsamples (:obj:`int`): Number of samples to be used for calibration.
     """
 
@@ -187,13 +185,14 @@ def _set_torch_flags():
 
 class LayerwiseCompressor(_BaseDataCalibratedModelOptimizer):
     """
-    A post training compression algorithm which compresses a sequential model layer by layer.
-    The implementation supports two variations of this algorithm:
+    A post training compression algorithm which compresses a sequential model layer by layer
+    by minimizing the quantization error while quantizing the weights. The implementation 
+    supports two variations of this algorithm:
 
     1) `Generative Pre-Trained Transformer Quantization (GPTQ) <https://arxiv.org/pdf/2210.17323.pdf>`_
     2) `Sparse Generative Pre-Trained Transformer (SparseGPT) <https://arxiv.org/pdf/2301.00774.pdf>`_
 
-    At a high level, it compresses weights of a model layer by layer,
+    At a high level, it compresses weights of a model layer by layer
     by minimizing the L2 norm of the difference between the original activations and
     activations obtained from compressing the weights of a layer. The activations
     are computed using a few samples of training data.
@@ -201,8 +200,8 @@ class LayerwiseCompressor(_BaseDataCalibratedModelOptimizer):
     Only sequential models are supported, where the output of one layer feeds into the
     input of the next layer.
 
-    For HuggingFace models, disable the `use_cache` config. This is used to speed up decoding, 
-    but to generalize forward pass for `LayerwiseCompressor` algorithms across all
+    For HuggingFace models, disable the ``use_cache`` config. This is used to speed up decoding, 
+    but to generalize forward pass for :py:class:`LayerwiseCompressor` algorithms across all
     model types, the behavior must be disabled.
 
     Example:

--- a/coremltools/optimize/torch/palettization/palettization_config.py
+++ b/coremltools/optimize/torch/palettization/palettization_config.py
@@ -102,7 +102,7 @@ SUPPORTED_PYTORCH_QAT_MODULES = (_nn.Linear, _nn.Conv2d, _nn.Conv3d)
 @_define
 class ModuleDKMPalettizerConfig(_ModuleOptimizationConfig):
     r"""
-    Configuration class for specifying global and module-level options for palettization
+    Configuration class for specifying global and module-level options for the palettization
     algorithm implemented in :py:class:`DKMPalettizer`.
 
     The parameters specified in this config control the DKM algorithm, described in
@@ -125,30 +125,30 @@ class ModuleDKMPalettizerConfig(_ModuleOptimizationConfig):
             Defaults to ``4`` for linear layers and ``2`` for all other layers.
         weight_threshold (:obj:`int`): A module is only palettized if the number of elements in
             its weight matrix exceeds ``weight_threshold``. If there are multiple weights in a
-            module (like :py:class:`torch.nn.MultiheadAttention`), all of them must have
+            module, such as :py:class:`torch.nn.MultiheadAttention`, all of them must have
             more elements than the ``weight_threshold`` for the module to be palettized.
             Defaults to ``2048``.
-        granularity (:py:class:`PalettizationGranularity`) – Granularity for palettization.
+        granularity (:py:class:`PalettizationGranularity`): Granularity for palettization.
             One of ``per_tensor`` or ``per_grouped_channel``. Defaults to ``per_tensor``.
         group_size (:obj:`int`): Specify the number of channels in a group.
             Only effective when granularity is ``per_grouped_channel``.
         channel_axis (:obj:`int`): Specify the channel axis to form a group of channels.
             Only effective when granularity is ``per_grouped_channel``. Defaults to output channel axis. For now, only
             output channel axis is supported by DKM.
-        enable_per_channel_scale (:obj:`bool`): When set to ``True``, per channel scaling is used along the channel
+        enable_per_channel_scale (:obj:`bool`): When set to ``True``, per-channel scaling is used along the channel
             dimension.
         milestone (:obj:`int`): Step or epoch at which palettization begins. Defaults to ``0``.
         cluster_dim (:obj:`int`, ``optional``): The dimension of each cluster.
-        quant_min: (:obj:`int`, ``optional``): The minimum value for each element in the weight clusters if they are
+        quant_min (:obj:`int`, ``optional``): The minimum value for each element in the weight clusters if they are
             quantized. Defaults to ``-128``.
-        quant_max: (:obj:`int`, ``optional``): The maximum value for each element in the weight clusters if they are
+        quant_max (:obj:`int`, ``optional``): The maximum value for each element in the weight clusters if they are
             quantized. Defaults to ``127``
         dtype (:py:class:`torch.dtype`, ``optional``): The ``dtype`` to use for quantizing the activations. Only applies
             when ``quantize_activations`` is ``True``. Defaults to :py:class:`torch.qint8`.
         lut_dtype (:obj:`str`, ``optional``): ``dtype`` to use for quantizing the clusters. Allowed options are
-            ``'i8'``, ``'u8'``, ``'f16'``, ``'bf16'``, ``'f32'``.  Defaults to ``'f32'``, i.e.,
+            ``'i8'``, ``'u8'``, ``'f16'``, ``'bf16'``, ``'f32'``.  Defaults to ``'f32'``, so
             by default, the clusters aren't quantized.
-        quantize_activations (:obj:`bool`, ``optional``): When ``True``, the activation are quantized.
+        quantize_activations (:obj:`bool`, ``optional``): When ``True``, the activations are quantized.
             Defaults to ``False``.
         cluster_permute (:obj:`tuple`, ``optional``): Permutation order to apply to weight partitions.
             Defaults to ``None``.
@@ -156,7 +156,7 @@ class ModuleDKMPalettizerConfig(_ModuleOptimizationConfig):
             palettization. Defaults to ``1.0``.
         kmeans_max_iter (:obj:`int`, ``optional``): Maximum number of differentiable ``k-means`` iterations.
             Defaults to ``3``.
-        prune_threshold (:obj:`float`, ``optional``): Hard-shrinks weights between [``-prune_threshold``,
+        prune_threshold (:obj:`float`, ``optional``): Hardshrinks weights between [``-prune_threshold``,
             ``prune_threshold``] to zero. Useful for joint pruning and palettization. Defaults to ``1e-7``.
         kmeans_init (:obj:`str`, ``optional``): ``k-means`` algorithm to use. Allowed options are
             ``opt1d``, ``cpu.kmeans++`` and ``kmeans++``. Defaults to ``auto``.
@@ -180,10 +180,10 @@ class ModuleDKMPalettizerConfig(_ModuleOptimizationConfig):
             hook for autograd. Defaults to ``64*1024``.
         palett_unique (:obj:`bool`, ``optional``): If ``True``, reduces the attention map by leveraging the fact that
             FP16 only has ``2^16`` unique values. Useful for Large Models like LLMs where attention maps can be huge.
-            Defaults to ``False``. More details can be found `eDKM: An Efficient and Accurate Train-time Weight
+            Defaults to ``False``. For more details, read `eDKM: An Efficient and Accurate Train-time Weight
             Clustering for Large Language Models <https://arxiv.org/pdf/2309.00964.pdf>`_ .
         palett_shard (:obj:`bool`, ``optional``): If ``True``, the index list is sharded across GPUs.
-            Defaults to ``False``. More details can be found `eDKM: An Efficient and Accurate Train-time Weight
+            Defaults to ``False``. For more details, read `eDKM: An Efficient and Accurate Train-time Weight
             Clustering for Large Language Models <https://arxiv.org/pdf/2309.00964.pdf>`_ .
         palett_batch_mode (:obj:`bool`, ``optional``): If ``True``, performs batch DKM across different partitions
             created for different blocks. Defaults to ``False``. More details can be found `eDKM: An Efficient and Accurate Train-time Weight
@@ -192,29 +192,28 @@ class ModuleDKMPalettizerConfig(_ModuleOptimizationConfig):
             distributed torch is available. Defaults to ``False``.
         per_channel_scaling_factor_scheme (:obj:`str`, ``optional``): Criteria to calculate the
             ``per_channel_scaling_factor``. Allowed options are ``min_max`` and ``abs``. Defaults to ``min_max``.
-        percentage_palett_enable (:obj:`float`, ``optional``): Percentage partitions to enable for DKM.
-                    Defaults to ``1.0``.
-        kmeans_batch_threshold (:obj:`int`, ``optional``): Threshold to decide at what num_partitions to go through with
-            sharded centroids list. num_partitions is calculated by dividing the channel size with the group_size
-            provided. If the kmeans_batch_threshold, the algorithm resorts to performing distirbuted kmeans for lower
-            partition numbers, given that num_partition number of GPUs are available. Defaults to ``4``.
+        percentage_palett_enable (:obj:`float`, ``optional``): Percentage partitions to enable for DKM. Defaults to ``1.0``.
+        kmeans_batch_threshold (:obj:`int`, ``optional``): Threshold to decide what the ``num_partitions`` value should be to go through with
+            the sharded centroids list. ``num_partitions`` is calculated by dividing the channel size by the ``group_size``
+            provided. If ``num_partitions``` matches ``kmeans_batch_threshold``, the algorithm resorts to performing distributed k-means for lower
+            partition numbers, given that ``num_partition`` number of GPUs are available. Defaults to ``4``.
         kmeans_n_init (:obj:`int`, ``optional``): Number of time the k-means algorithm will be run with different
-            centroid seeds. The final results will be the best output of kmeans_n_init consecutive runs in terms of inertia.
-        zero_threshold (:obj:`int`, ``optional``): Zero threshold to be used to decide min value of clamp for softmax
-            . Defaults to ``1e-7``.
+            centroid seeds. The final results will be the best output of ``kmeans_n_init`` consecutive runs in terms of inertia.
+        zero_threshold (:obj:`int`, ``optional``): Zero threshold to be used to decide the minimum value of clamp for softmax. Defaults to ``1e-7``.
         kmeans_error_bnd (:obj:`float`, ``optional``): Distance threshold to decide at what distance between parameters
-            and clusters to stop the kmeans operation. Defaults to ``0.0``.
+            and clusters to stop the ``k-means`` operation. Defaults to ``0.0``.
 
-    This class supports few different configurations to structure the palettization:
+    This class supports two different configurations to structure the palettization:
 
-    1. **Per-tensor palettization**:  This is the default configuration where the whole tensor shares a single look-up
+    1. **Per-tensor palettization**: This is the default configuration where the whole tensor shares a single lookup
     table. The ``granularity`` is set to ``per_tensor`` and ``group_size`` is ``None``.
 
     2. **Per-grouped-channel palettization**: In this configuration, ``group_size`` number of channels along
-    ``channel_axis`` share the same look-up table. For example, for a weight matrix of shape ``(16, 25)``, if we provide
-     ``group_size = 8``, the shape of the look-up table would be ``(2, 2^n_bits)``.
+    ``channel_axis`` share the same lookup table. For example, for a weight matrix of shape ``(16, 25)``, if we provide
+     ``group_size = 8``, the shape of the lookup table would be ``(2, 2^n_bits)``.
 
-    NOTE: Currently grouping is only supported along output channel axis.
+    .. note::
+        Grouping is currently only supported along the output channel axis.
     """
     n_bits: _Optional[int] = _field(
         default=None, validator=_validators.optional(_validators.instance_of(int))
@@ -464,9 +463,9 @@ class DKMPalettizerConfig(_OptimizationConfig):
             The keys can be either strings or module classes. When ``module_type_config`` is set to ``None``
             for a module type, it is not palettized.
         module_name_configs (:obj:`dict` of :obj:`str` to :py:class:`ModuleDKMPalettizerConfig`):
-            Module level configs applied to specific modules.
+            Module-level configs applied to specific modules.
             The name of the module must be a fully qualified name that can be used to fetch it
-            from the top level module using the ``module.get_submodule(target)`` method. When
+            from the top-level module using the ``module.get_submodule(target)`` method. When
             ``module_name_config`` is set to ``None`` for a module, it is not palettized.
     """
 

--- a/coremltools/optimize/torch/palettization/post_training_palettization.py
+++ b/coremltools/optimize/torch/palettization/post_training_palettization.py
@@ -56,7 +56,7 @@ _logger = _logging.getLogger(__name__)
 @_define
 class ModulePostTrainingPalettizerConfig(_ModuleOptimizationConfig):
     """
-    Configuration class for specifying global and module level palettization options for
+    Configuration class for specifying global and module-level palettization options for
     :py:class:`PostTrainingPalettizerConfig` algorithm.
 
     Args:
@@ -71,7 +71,7 @@ class ModulePostTrainingPalettizerConfig(_ModuleOptimizationConfig):
         channel_axis (:obj:`int`): Specify the channel axis to form a group of channels.
             Only effective when granularity is ``per_grouped_channel``. Defaults to output channel axis.
         cluster_dim (:obj:`int`): The dimension of centroids for each lookup table.
-            The centroid is a scalar by default. When ``cluster_dim > 1``, it indicates 2-D clustering
+            The centroid is a scalar by default. When ``cluster_dim > 1``, it indicates 2-D clustering,
             and each ``cluster_dim`` length of weight vectors along the output channel are palettized
             using the same 2-D centroid. The length of each entry in the lookup tables is equal to ``cluster_dim``.
         enable_per_channel_scale (:obj:`bool`): When set to ``True``, weights are normalized along the output channels
@@ -86,7 +86,8 @@ class ModulePostTrainingPalettizerConfig(_ModuleOptimizationConfig):
     ``channel_axis`` share the same lookup table. For example, for a weight matrix of shape ``(16, 25)``, if we provide 
     ``group_size = 8``, the shape of the lookup table would be ``(2, 2^n_bits)``.
 
-    NOTE: Currently, grouping is only supported along either the input or output channel axis.
+    .. note::
+    Grouping is currently only supported along either the input or output channel axis.
     """
 
     n_bits: _Optional[int] = _field(

--- a/coremltools/optimize/torch/palettization/sensitive_k_means.py
+++ b/coremltools/optimize/torch/palettization/sensitive_k_means.py
@@ -69,7 +69,7 @@ _logger = _logging.getLogger(__name__)
 @_define
 class ModuleSKMPalettizerConfig(_ModuleOptimizationConfig):
     """
-    Configuration class for specifying global and module level palettization options for
+    Configuration class for specifying global and module-level palettization options for
     :py:class:`SKMPalettizer` algorithm.
 
     Args:
@@ -84,7 +84,7 @@ class ModuleSKMPalettizerConfig(_ModuleOptimizationConfig):
         channel_axis (:obj:`int`): Specify the channel axis to form a group of channels.
             Only effective when granularity is ``per_grouped_channel``. Defaults to output channel axis.
         cluster_dim (:obj:`int`): The dimension of centroids for each lookup table.
-            The centroid is a scalar by default. When ``cluster_dim > 1``, it indicates 2-D clustering
+            The centroid is a scalar by default. When ``cluster_dim > 1``, it indicates 2-D clustering,
             and each ``cluster_dim`` length of weight vectors along the output channel are palettized
             using the same 2-D centroid. The length of each entry in the lookup tables is equal to ``cluster_dim``.
         enable_per_channel_scale (:obj:`bool`): When set to ``True``, weights are normalized along the output channels
@@ -99,7 +99,8 @@ class ModuleSKMPalettizerConfig(_ModuleOptimizationConfig):
     ``channel_axis`` share the same lookup table. For example, for a weight matrix of shape ``(16, 25)``, if we provide 
     ``group_size = 8``, the shape of the lookup table would be ``(2, 2^n_bits)``.
 
-    NOTE: Currently grouping is only supported along either the input or output channel axis.
+    .. note::
+    Grouping is currently only supported along either the input or output channel axis.
     """
 
     n_bits: int = _field(default=4, validator=_validators.instance_of(int))
@@ -229,11 +230,11 @@ class SKMPalettizer(_BaseDataCalibratedModelOptimizer):
     Perform post-training palettization of weights by running a weighted k-means
     on the model weights. The weight values used for weighing different elements of
     a model's weight matrix are computed using the Fisher information matrix, which
-    is an approximation of the Hessian. These weight values indicate how sensitive
-    a given weight element is; the more sensitive an element, the larger impact perturbing
-    it (or palettizing it) has on the model's loss function. Thus, weighted k-means
-    moves the clusters closer to the sensitive weight values, allowing them to be
-    represented more exactly and thus leading to a lower degradation in model performance
+    is an approximation of the Hessian. These weight values indicate how sensitive 
+    a given weight element is: the more sensitive an element, the larger the impact perturbing 
+    or palettizing it has on the model’s loss function. This means that weighted k-means 
+    moves the clusters closer to the sensitive weight values, allowing them to be 
+    represented more exactly. This leads to a lower degradation in model performance 
     after palettization. The Fisher information matrix is computed using a few
     samples of calibration data.
 

--- a/coremltools/optimize/torch/quantization/post_training_quantization.py
+++ b/coremltools/optimize/torch/quantization/post_training_quantization.py
@@ -71,13 +71,13 @@ _logger = _logging.getLogger(__name__)
 @_define
 class ModulePostTrainingQuantizerConfig(_ModuleOptimizationConfig):
     """
-    Configuration class for specifying global and module level quantizer options for
+    Configuration class for specifying global and module-level quantizer options for
     :py:class:`PostTrainingQuantizer` algorithm.
 
     Args:
         weight_dtype (:py:class:`torch.dtype`): The dtype to use for quantizing the weights. The number of bits used
             for quantization is inferred from the dtype. When dtype is set to :py:class:`torch.float32`, the weights
-            corresponding to that layer are not quantized. Defaults to :py:class:`torch.int8` which corresponds to
+            corresponding to that layer are not quantized. Defaults to :py:class:`torch.int8`, which corresponds to
             8-bit quantization.
         granularity (:py:class:`QuantizationGranularity`): Specifies the granularity at which quantization parameters
             will be computed. Can be one of ``per_channel``, ``per_tensor`` or ``per_block``. When using ``per_block``,
@@ -88,9 +88,9 @@ class ModulePostTrainingQuantizerConfig(_ModuleOptimizationConfig):
             zero point can be set anywhere in the range of values allowed for the quantized weight.
             Defaults to ``QuantizationScheme.symmetric``.
         block_size (:obj:`tuple` of :obj:`int` or :obj:`int`): When ``block_size`` is specified, ``block_size``
-            number of values will share the same quantization parameters of scale (and zero point if applicable) across
-            the input channel axis. A tuple of integers can be provided for arbitrary sized blockwise quantization.
-            See below for more details on different possible configurations. Defaults to ``None``.
+            number of values will share the same quantization parameters of scale, as well as the same zero point when applicable, across
+            the input channel axis. A tuple of integers can be provided for arbitrarily sized blockwise quantization.
+            See more details on different possible configurations below. Defaults to ``None``.
 
     This class supports three different configurations to structure the quantization:
 
@@ -98,21 +98,21 @@ class ModulePostTrainingQuantizerConfig(_ModuleOptimizationConfig):
     ``block_size`` is ``None``. In this configuration, quantization parameters are computed for each output channel.
 
     2. **Per-tensor quantization**: In this configuration, quantization parameters are computed for the tensor as a whole. That is,
-    all values in the tensor will share a single scale (and a single zero point if applicable). The ``granularity`` argument is set
+    all values in the tensor will share a single scale and, if applicable, a single zero point. The ``granularity`` argument is set
     to ``per_tensor``.
 
     3. **Per-block quantization**: This configuration is used to structure the tensor for blockwise quantization. The ``granularity`` 
-    is set to ``per_block`` and the ``block_size`` argument has to be specified. The ``block_size`` argument can either be of type
+    is set to ``per_block``, and the ``block_size`` argument has to be specified. The ``block_size`` argument can either be of type
     ``int`` or ``tuple``:
-        * int: In this case, each row along the output-channel axis will have its own quantization parameters (similar to ``per_channel``).
-               Additionally, ``block_size`` number of values will share the same quantization parameters, along the input channel axis.
+        * int: In this configuration, each row along the output channel axis will have its own quantization parameters, similar to the ``per_channel`` configuration.
+               Additionally, ``block_size`` number of values will share the same quantization parameters along the input channel axis.
                For example, for a weight matrix of shape ``(10, 10)``, if we provide ``block_size = 2``, the shape of the quantization
                parameters would be ``(10, 5)``.
-        * tuple: For more advanced configuration, users can provide an arbitrary n-dimensional block to share the quantization parameters.
-                 This is specified in the form of a tuple where each value corresponds to the block size for the respective axis of the
+        * tuple: For a more advanced configuration, users can provide an arbitrary n-dimensional block to share the quantization parameters.
+                 This is specified in the form of a tuple, where each value corresponds to the block size for the respective axis of the
                  weight matrix. The length of the provided tuple should be at most the number of dimensions of the weight matrix.
 
-    .. note:
+    .. note::
         When performing 4-bit quantization, ``weight_dtype`` is set to :py:class:`torch.int8` for ``int4`` or
         :py:class:`torch.uint8` for ``uint4``. This is because PyTorch currently doesn't provide support for 4-bit
         data types. However, the quantization range is set according to 4-bit quantization and based on
@@ -251,10 +251,10 @@ class PostTrainingQuantizer(_BasePostTrainingModelOptimizer):
     """
     Perform post-training quantization on a torch model. After quantization, weights of all
     submodules selected for quantization contain full precision values obtained by quantizing
-    and dequantizing the original weights which captures the error induced by quantization.
+    and dequantizing the original weights, which captures the error induced by quantization.
 
     .. note::
-        After quantization, the weight values stored will still remain in full precision, therefore
+        After quantization, the weight values stored will still remain in full precision, so
         the PyTorch model size will not be reduced. To see the reduction in model size, please convert
         the model using ``coremltools.convert(...)``, which will produce a model intermediate language 
         (MIL) model containing the compressed weights.


### PR DESCRIPTION
After an initial round of review and changes to the doc strings for new Core ML Tools APIs, there were some lingering typos and formatting issues, so this PR fixes them.  