### PR TITLE
Fix compilation error for g++ (Debian 12.2.0-14)

### DIFF
--- a/mlmodel/src/MILBlob/Fp8.cpp
+++ b/mlmodel/src/MILBlob/Fp8.cpp
@@ -6,6 +6,7 @@
 #include "MILBlob/Fp8.hpp"
 
 #include <cmath>
+#include <stdexcept>
 
 using namespace MILBlob;
 

--- a/modelpackage/src/utils/JsonMap.hpp
+++ b/modelpackage/src/utils/JsonMap.hpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <vector>
 #include <string>
+#include <memory>
 
 class JsonMapImpl;
 


### PR DESCRIPTION
The errors:
```shell
/workspaces/coremltools/mlmodel/src/MILBlob/Fp8.cpp:34:20: error: 'range_error' is not a member of 'std'
   34 |         throw std::range_error("FP8 SetFloat requires rounding for the given value.");
      |                    ^~~~~~~~~~~
/workspaces/coremltools/modelpackage/src/utils/JsonMap.hpp:20:10: error: 'unique_ptr' in namespace 'std' does not name a template type
   20 |     std::unique_ptr<JsonMapImpl> m_jsonMapImpl;
      |          ^~~~~~~~~~
```


Dockerfile of dev container:

```dockerfile
FROM debian:12
RUN echo "Acquire::http::Pipeline-Depth \"0\";" > /etc/apt/apt.conf.d/99nopipelining
RUN apt-get update && \
    apt-get install -y ca-certificates && \
    update-ca-certificates
RUN apt-get install -y zsh cmake g++ uuid-dev

RUN chsh -s /usr/bin/zsh

# conda
COPY Miniconda3-latest-Linux-x86_64.sh .
RUN chmod +x ./Miniconda3-latest-Linux-x86_64.sh && \
    ./Miniconda3-latest-Linux-x86_64.sh -b && \
    rm Miniconda3-latest-Linux-x86_64.sh
RUN export PATH="/root/miniconda3/bin:$PATH" && \
    conda --version && \
    conda init zsh

RUN g++ -std=c++17 --version
```



Build command inside the container:

```shell
./scripts/build.sh --python="3.11"
```



