### PR TITLE
Normalize spellings and fix note format

### DIFF
--- a/coremltools/optimize/coreml/_post_training_quantization.py
+++ b/coremltools/optimize/coreml/_post_training_quantization.py
@@ -190,7 +190,7 @@ def palettize_weights(
     """
     Utility function to convert a float precision MLModel of type ``mlprogram`` to a
     compressed MLModel by reducing the overall number of weights using one or more lookup tables
-    (LUT). A LUT contains a list of float values. An ``n-bit`` LUT has :math:`2^{n\-bits}` entries.
+    (LUT). A LUT contains a list of float values. An ``n-bit`` LUT has :math:`2^{n-bits}` entries.
 
     For example, a float weight vector such as ``{0.3, 0.3, 0.5, 0.5}`` can be compressed
     using a 1-bit LUT: ``{0.3, 0.5}``. In this case the float vector can be replaced

--- a/coremltools/optimize/torch/layerwise_compression/algorithms.py
+++ b/coremltools/optimize/torch/layerwise_compression/algorithms.py
@@ -346,13 +346,13 @@ class OBSCompressionAlgorithm(LayerwiseCompressionAlgorithm):
 @LayerwiseCompressionAlgorithm.register("gptq")
 class GPTQ(OBSCompressionAlgorithm):
     """
-    A post training compression algorithm based on the paper
+    A post-training compression algorithm based on the paper
     `GPTQ: Accurate Post-Training Quantization for Generative Pre-trained Transformers
     <https://arxiv.org/pdf/2210.17323.pdf>`_.
 
     Args:
         layer (:obj:`torch.nn.Module`): Module to be compressed.
-        config (:py:class:`ModuleGPTQConfig`): Config specifying hyper-parameters
+        config (:py:class:`ModuleGPTQConfig`): Config specifying hyperparameters
             for the GPTQ algorithm.
     """
 
@@ -527,7 +527,7 @@ class GPTQ(OBSCompressionAlgorithm):
 @LayerwiseCompressionAlgorithm.register("sparse_gpt")
 class SparseGPT(OBSCompressionAlgorithm):
     """
-    A post training compression algorithm based on the paper
+    A post-training compression algorithm based on the paper
     `SparseGPT: Massive Language Models Can be Accurately Pruned in One-Shot
     <https://arxiv.org/pdf/2301.00774.pdf>`_
 

--- a/coremltools/optimize/torch/layerwise_compression/layerwise_compressor.py
+++ b/coremltools/optimize/torch/layerwise_compression/layerwise_compressor.py
@@ -80,7 +80,7 @@ class LayerwiseCompressorConfig(_OptimizationConfig):
             Module type configs applied to a specific module class, such as :py:class:`torch.nn.Linear`. 
             The keys can be either strings or module classes.
         module_name_configs (:obj:`dict` of :obj:`str` to :py:class:`ModuleGPTQConfig` or :py:class:`ModuleSparseGPTConfig`):
-            Module level configs applied to specific modules. The name of the module must either be a regex or 
+            Module-level configs applied to specific modules. The name of the module must either be a regex or 
             a fully qualified name that can be used to fetch it from the top level module using the 
             ``module.get_submodule(target)`` method.
         input_cacher (:obj:`str` or :py:class:`FirstLayerInputCacher`): Cacher object that caches inputs which are then
@@ -185,7 +185,7 @@ def _set_torch_flags():
 
 class LayerwiseCompressor(_BaseDataCalibratedModelOptimizer):
     """
-    A post training compression algorithm which compresses a sequential model layer by layer
+    A post-training compression algorithm which compresses a sequential model layer by layer
     by minimizing the quantization error while quantizing the weights. The implementation 
     supports two variations of this algorithm:
 

--- a/coremltools/optimize/torch/palettization/palettizer.py
+++ b/coremltools/optimize/torch/palettization/palettizer.py
@@ -58,7 +58,7 @@ class DKMPalettizer(Palettizer):
     """
     A palettization algorithm based on `"DKM: Differentiable K-Means Clustering Layer for Neural Network
     Compression" <https://arxiv.org/pdf/2108.12659.pdf>`_. It clusters the weights
-    using a differentiable version of ``k-means``, allowing the look-up-table (LUT)
+    using a differentiable version of ``k-means``, allowing the lookup table (LUT)
     and indices of palettized weights to be learnt using a gradient-based optimization algorithm such as SGD.
 
     Example:

--- a/coremltools/optimize/torch/palettization/post_training_palettization.py
+++ b/coremltools/optimize/torch/palettization/post_training_palettization.py
@@ -87,7 +87,7 @@ class ModulePostTrainingPalettizerConfig(_ModuleOptimizationConfig):
     ``group_size = 8``, the shape of the lookup table would be ``(2, 2^n_bits)``.
 
     .. note::
-    Grouping is currently only supported along either the input or output channel axis.
+        Grouping is currently only supported along either the input or output channel axis.
     """
 
     n_bits: _Optional[int] = _field(

--- a/coremltools/optimize/torch/palettization/sensitive_k_means.py
+++ b/coremltools/optimize/torch/palettization/sensitive_k_means.py
@@ -100,7 +100,7 @@ class ModuleSKMPalettizerConfig(_ModuleOptimizationConfig):
     ``group_size = 8``, the shape of the lookup table would be ``(2, 2^n_bits)``.
 
     .. note::
-    Grouping is currently only supported along either the input or output channel axis.
+        Grouping is currently only supported along either the input or output channel axis.
     """
 
     n_bits: int = _field(default=4, validator=_validators.instance_of(int))
@@ -170,7 +170,7 @@ class SKMPalettizerConfig(_OptimizationConfig):
             Module type configs applied to a specific module class, such as :py:class:`torch.nn.Linear`.
             The keys can be either strings or module classes.
         module_name_configs (:obj:`dict` of :obj:`str` to :py:class:`ModuleSKMPalettizerConfig`):
-            Module level configs applied to specific modules. The name of the module must either be
+            Module-level configs applied to specific modules. The name of the module must either be
             a regex or a fully qualified name that can be used to fetch it from the top level module
             using the ``module.get_submodule(target)`` method.
         calibration_nsamples (:obj:`int`): Number of samples to be used for calibration.

--- a/coremltools/optimize/torch/quantization/quantization_config.py
+++ b/coremltools/optimize/torch/quantization/quantization_config.py
@@ -107,7 +107,7 @@ _SUPPORTED_N_BITS = [4, 8, 32]
 @_define
 class ModuleLinearQuantizerConfig(_ModuleOptimizationConfig):
     """
-    Configuration class for specifying global and module level quantization options for linear quantization
+    Configuration class for specifying global and module-level quantization options for linear quantization
     algorithm implemented in :py:class:`LinearQuantizer`.
 
     Linear quantization algorithm simulates the effects of quantization during training, by quantizing
@@ -332,7 +332,7 @@ class LinearQuantizerConfig(_OptimizationConfig):
             module class, such as :py:class:`torch.nn.Linear`. The keys can be either strings
             or module classes.
         module_name_configs (:obj:`dict` of :obj:`str` to :py:class:`ModuleLinearQuantizerConfig`):
-            Module level configs applied to specific modules.
+            Module-level configs applied to specific modules.
             The name of the module must be a fully qualified name that can be used to fetch it
             from the top level module using the ``module.get_submodule(target)`` method.
         non_traceable_module_names (:obj:`list` of :obj:`str`):

--- a/docs/source/coremltools.optimize.torch.palettization.rst
+++ b/docs/source/coremltools.optimize.torch.palettization.rst
@@ -2,7 +2,7 @@ Palettization
 =============
 
 Palettization is a mechanism for compressing a model by clustering the model's float
-weights into a look-up table (LUT) of centroids and indices.
+weights into a lookup table (LUT) of centroids and indices.
 
 Palettization is implemented as an extension of `PyTorch's QAT <https://pytorch.org/docs/stable/quantization.html>`_
 APIs. It works by inserting palettization layers in appropriate places inside a model.


### PR DESCRIPTION
This commit normalizes the spellings for "hyperparameters", "post-training", and "lookup table" across new Core ML Tools API docstrings.

It also fixes the format for two note boxes and for one instance of n-bit.