### PR TITLE
Fix torch softplus rank limit

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -1325,14 +1325,37 @@ def rrelu(context, node):
 @register_torch_op
 def softplus(context, node):
     inputs = _get_inputs(context, node, expected=3)
-    x = inputs[0]
-    beta_ = inputs[1].val
-    C = x.shape[1]
-    alpha_br = _np.repeat(1.0 / beta_, C).astype('float32')
-    beta_br = _np.repeat(beta_, C).astype('float32')
+    x, beta, threshold = inputs[0], inputs[1].val, inputs[2].val
+    
+    np_type = nptype_from_builtin(x.dtype)
+    b = mb.const(val=np_type(beta))
+    t = mb.const(val=np_type(threshold))
 
-    res = mb.softplus_parametric(x=x, alpha=alpha_br, beta=beta_br, name=node.name)
-    context.add(res)
+    # Most softplus operations in the model use default values.
+    # Using fewer operations can improve performance.
+    if beta == 1 and threshold == 20:
+        res = mb.softplus(x=x, name=node.name)
+    elif threshold == 20:
+        x0 = mb.mul(x=x, y=b)
+        x1 = mb.softplus(x=x0)
+        res = mb.real_div(x=x1, y=b)
+    else:
+        xb = mb.mul(x=x, y=b)
+        m = mb.less_equal(x=xb, y=t)
+        
+        x_dtype = TYPE_TO_DTYPE_STRING[x.dtype]
+        m0 = mb.cast(x=m, dtype=x_dtype)
+        xb0 = mb.mul(x=xb, y=m0)
+        exp = mb.exp(x=xb0)
+        exp0 = mb.add(x=exp, y=m0)
+        log = mb.log(x=exp0)
+        log0 = mb.real_div(x=log, y=b)
+        
+        m1 = mb.logical_not(x=m)
+        x0 = mb.mul(x=x, y=mb.cast(x=m1, dtype=x_dtype))
+        
+        res = mb.add(x=log0, y=x0)
+    context.add(res, torch_name=node.name)
 
 
 @register_torch_op

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -1340,6 +1340,12 @@ def softplus(context, node):
         x1 = mb.softplus(x=x0)
         res = mb.real_div(x=x1, y=b)
     else:
+        # Create mask for x*beta <= threshold, then convert mask to 01 tensor (m0).
+        # Use log(m0 + exp(beta*x*m0)) replacing log(1 + exp(beta*x*m0)) * m0.
+        # The log(1)=0 equals mul mask with result.
+        # If you want to implementation torch.softplus with MetalPerformanceShadersGraph, refer to this implementation.
+        # MPSGraph doesn't have softplus currently.
+        # And this implementation is slightly faster than mb.softplus * mask for inference on the GPU.
         xb = mb.mul(x=x, y=b)
         m = mb.less_equal(x=xb, y=t)
         

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -11743,7 +11743,6 @@ class TestSoftplus(TorchBaseTest):
     )
     def test_softplus_rank(self, compute_unit, backend, rank, beta, threshold):
         input_shape = torch.randint(1, 10, (rank,))
-        print("input_shape:", len(input_shape.tolist()), input_shape.tolist())
         model = nn.Softplus(beta, threshold).eval()
         self.run_compare_torch(
             input_shape,

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -5610,26 +5610,6 @@ class TestActivation(TorchBaseTest):
         )
 
     @pytest.mark.parametrize(
-        "compute_unit, backend, beta, threshold, minimum_deployment_target",
-        itertools.product(compute_units, backends, [1, 2, 5], [5, 10, 20], [None, ct.target.iOS17]),
-    )
-    @pytest.mark.skipif(
-        _macos_version() <= (10, 15),
-        reason="Parametric SoftPlus segfaults on macOS 10.15 and below.",
-    )
-    def test_softplus(self, compute_unit, backend, beta, threshold, minimum_deployment_target):
-        input_shape = (1, 10, 5, 15)
-        model = nn.Softplus(beta, threshold).eval()
-        self.run_compare_torch(
-            input_shape,
-            model,
-            backend=backend,
-            compute_unit=compute_unit,
-            minimum_deployment_target=minimum_deployment_target,
-            target_op="softplus_parametric",
-        )
-
-    @pytest.mark.parametrize(
         "compute_unit, backend, shape",
         itertools.product(
             compute_units,
@@ -11755,3 +11735,47 @@ class TestMultinomial(TorchBaseTest):
                 input_as_shape=False,
                 converter_input_type=converter_input_type,
             )
+
+class TestSoftplus(TorchBaseTest):
+    @pytest.mark.parametrize(
+        "compute_unit, backend, rank, beta, threshold",
+        itertools.product(compute_units, backends, range(1, 4), [1, 2, 5], [5, 10, 20])
+    )
+    def test_softplus_rank(self, compute_unit, backend, rank, beta, threshold):
+        input_shape = torch.randint(1, 10, (rank,))
+        print("input_shape:", len(input_shape.tolist()), input_shape.tolist())
+        model = nn.Softplus(beta, threshold).eval()
+        self.run_compare_torch(
+            input_shape,
+            model,
+            backend=backend,
+            compute_unit=compute_unit,
+        )
+    
+    @pytest.mark.parametrize(
+        "compute_unit, backend",
+        itertools.product(compute_units, backends),
+    )
+    def test_softplus_no_default(self, compute_unit, backend):
+        model = ModuleWrapper(function=torch.nn.functional.softplus, kwargs={"beta": 2, "threshold": 2}).eval()
+        self.run_compare_torch(
+            torch.arange(0, 3).float() + 0.5, 
+            model, 
+            backend=backend, 
+            compute_unit=compute_unit,
+            input_as_shape=False,
+        )
+    
+    @pytest.mark.parametrize(
+        "compute_unit, backend, value",
+        itertools.product(compute_units, backends, [1.0, 3.0, 1e5, 1e7, 1e9]),
+    )
+    def test_softplus_default(self, compute_unit, backend, value):
+        model = ModuleWrapper(function=torch.nn.functional.softplus).eval()
+        self.run_compare_torch(
+            torch.tensor([value, -value]),
+            model,
+            backend=backend,
+            compute_unit=compute_unit,
+            input_as_shape=False,
+        )


### PR DESCRIPTION
In the previous implementation, `x` was required to be at least rank 3. According to the [PyTorch documentation](https://pytorch.org/docs/stable/generated/torch.nn.Softplus.html), the input to `softplus` is not dependent on rank. This PR also adds the implementation of the `threshold` parameter in certain cases.