### PR TITLE
8.0 Release

### DIFF
--- a/coremlpython/CoreMLPython.h
+++ b/coremlpython/CoreMLPython.h
@@ -57,7 +57,7 @@ namespace CoreML {
             Model(const Model&) = delete;
             Model& operator=(const Model&) = delete;
             ~Model();
-            explicit Model(const std::string& urlStr, const std::string& computeUnits, const std::string& functionName);
+            explicit Model(const std::string& urlStr, const std::string& computeUnits, const std::string& functionName, const py::dict& optimizationHints);
             explicit Model(MLModel* m_model, NSURL* compiledUrl, bool deleteCompiledModelOnExit);
 
             py::list batchPredict(const py::list& batch) const;
@@ -67,6 +67,7 @@ namespace CoreML {
             py::dict predict(const py::dict& input, State* state=NULL) const;
 
 #if BUILT_WITH_MACOS15_SDK
+            static void setOptimizationHints(MLModelConfiguration *configuration, const py::dict& optimizationHints);
             State newState() const;
 #endif
 

--- a/coremltools/__init__.py
+++ b/coremltools/__init__.py
@@ -72,11 +72,35 @@ class ComputeUnit(_Enum):
     '''
     The set of processing-unit configurations the model can use to make predictions.
     '''
-    ALL = 1  # Allows the model to use all compute units available, including the neural engine
-    CPU_AND_GPU = 2 # Allows the model to use both the CPU and GPU, but not the neural engine
-    CPU_ONLY = 3 # Limit the model to only use the CPU
-    CPU_AND_NE = 4 # Allows the model to use both the CPU and neural engine, but not the GPU.
-                   # Only available on macOS >= 13.0
+    ALL = 1           # Allows model to use all compute units available, including the neural engine.
+    CPU_AND_GPU = 2   # Allows model to use both the CPU and GPU, but not the neural engine.
+    CPU_ONLY = 3      # Limits model to only use the CPU.
+    CPU_AND_NE = 4    # Allows model to use both the CPU and neural engine, but not the GPU.
+                          # Only available on macOS >= 13.0
+
+
+class ReshapeFrequency(_Enum):
+    '''
+    https://developer.apple.com/documentation/coreml/mlreshapefrequencyhint?language=objc
+    '''
+    Frequent = 1
+    Infrequent = 2
+
+
+class SpecializationStrategy(_Enum):
+    '''
+    The optimization strategy for the model specialization.
+
+    https://developer.apple.com/documentation/coreml/mlspecializationstrategy?language=objc
+    '''
+
+    # The strategy that works well for most applications.
+    Default = 1
+
+    # Prefer the prediction latency at the potential cost of specialization time, memory footprint,
+    # and the disk space usage of specialized artifacts.
+    FastPrediction = 2
+
 
 # A dictionary that maps the CoreML model specification version to the MLProgram/MIL opset string
 _OPSET = {

--- a/coremltools/_deps/__init__.py
+++ b/coremltools/_deps/__init__.py
@@ -153,18 +153,33 @@ MSG_TF2_NOT_FOUND = "TensorFlow 2.x not found."
 
 # ---------------------------------------------------------------------------------------
 _HAS_TORCH = True
-_TORCH_MAX_VERSION = "2.3.0"
+_TORCH_MAX_VERSION = "2.4.0"
 _HAS_TORCH_EXPORT_API = False
+_CT_OPTIMIZE_TORCH_MIN_VERSION = "2.1.0"
+_IMPORT_CT_OPTIMIZE_TORCH = False
 try:
     import torch
     _warn_if_above_max_supported_version("Torch", torch.__version__, _TORCH_MAX_VERSION)
 
-    if _get_version(torch.__version__) >= Version("2.1.0"):
+    torch_version = _get_version(torch.__version__)
+
+    if torch_version >= Version("2.1.0"):
         _HAS_TORCH_EXPORT_API = True
+
+    if torch_version >= Version(_CT_OPTIMIZE_TORCH_MIN_VERSION):
+        _IMPORT_CT_OPTIMIZE_TORCH = True
+    else:
+        logger.warning(
+            (
+                f"Minimum required torch version for importing coremltools.optimize.torch is {_CT_OPTIMIZE_TORCH_MIN_VERSION}. "
+                f"Got torch version {torch_version}."
+            )
+        )
 
 except:
     _HAS_TORCH = False
 MSG_TORCH_NOT_FOUND = "PyTorch not found."
+MSG_TORCH_EXPORT_API_NOT_FOUND = "Torch.Export API not found."
 
 
 _HAS_TORCH_VISION = True
@@ -188,6 +203,13 @@ try:
 except:
     _HAS_EXECUTORCH = False
 MSG_EXECUTORCH_NOT_FOUND = "Executorch not found."
+
+_HAS_TORCHAO = True
+try:
+    import torchao
+except:
+    _HAS_TORCHAO = False
+MSG_TORCHAO_NOT_FOUND = "Torchao not found."
 
 # ---------------------------------------------------------------------------------------
 try:

--- a/coremltools/converters/mil/frontend/tensorflow2/test/test_v2_ops_tf_keras.py
+++ b/coremltools/converters/mil/frontend/tensorflow2/test/test_v2_ops_tf_keras.py
@@ -1389,11 +1389,6 @@ class TestRecurrent(TensorFlowBaseTest):
         "compute_unit, backend", itertools.product(compute_units, backends)
     )
     def test_lstm_dynamic_batch(self, compute_unit, backend):
-        if backend == ("mlprogram", "fp16"):
-            pytest.xfail(
-                "rdar://116060011: re-activate coremltools tests blocked by Core ML regressions"
-            )
-
         input_shape = (1, 1280)
         inp = tf.keras.layers.Input(shape=input_shape)
         out, hn, cn = tf.keras.layers.LSTM(512,

--- a/coremltools/converters/mil/frontend/torch/load.py
+++ b/coremltools/converters/mil/frontend/torch/load.py
@@ -10,15 +10,19 @@ import torch as _torch
 from torch.jit._script import RecursiveScriptModule
 
 from coremltools import _logger as logger
-from coremltools._deps import _HAS_TORCH_EXPORT_API
+from coremltools._deps import _HAS_EXECUTORCH, _HAS_TORCH_EXPORT_API
 from coremltools.converters.mil.frontend.torch.converter import TorchConverter
 from coremltools.converters.mil.input_types import StateType, TensorType
 from coremltools.converters.mil.mil.program import Program
 
 from .converter import TorchConverter
+from .utils import TorchFrontend
 
 if _HAS_TORCH_EXPORT_API:
     from torch.export import ExportedProgram
+
+if _HAS_EXECUTORCH:
+    import executorch.exir
 
 
 def load(
@@ -108,14 +112,41 @@ def _torchscript_from_spec(model_spec: Union[str, RecursiveScriptModule]) -> Rec
 
     elif isinstance(model_spec, _torch.jit.ScriptModule):
         return model_spec
-    elif _HAS_TORCH_EXPORT_API and isinstance(model_spec, ExportedProgram):
-        return model_spec
+
     else:
         raise TypeError(
-            "A PyTorch model must either be a .pt or .pth file, or a TorchScript object. Received: {}".format(
-                type(model_spec)
-            )
+            "A PyTorch model must either be a .pt or .pth file, or a TorchScript object. "
+            f"Received: {type(model_spec)}"
         )
+
+
+if _HAS_TORCH_EXPORT_API:
+
+    def _torchexport_from_spec(
+        model_spec: Union[str, ExportedProgram],
+        frontend=TorchFrontend.TORCHEXPORT,
+    ) -> ExportedProgram:
+        # Load torch.export serialization
+        if isinstance(model_spec, str) and model_spec.endswith(".pt2"):
+            filename = _os_path.abspath(model_spec)
+            try:
+                model = _torch.export.load(filename)
+            except Exception as e:
+                logger.error(
+                    "\n\nERROR - Could not load the PyTorch model. Got the following error:\n"
+                )
+                raise e
+        elif isinstance(model_spec, ExportedProgram):
+            model = model_spec
+        else:
+            raise TypeError(
+                "A PyTorch model must either be a .pt2 file, or an ExportedProgram object. "
+                f"Received: {type(model_spec)}"
+            )
+        # To edge if edge dialect is desired
+        if frontend == TorchFrontend.EXECUTORCH and model.dialect != "EDGE":
+            model = executorch.exir.to_edge(model).exported_program()
+        return model
 
 
 def _perform_torch_convert(converter: TorchConverter, debug: bool) -> Program:

--- a/coremltools/converters/mil/frontend/torch/quantization_ops.py
+++ b/coremltools/converters/mil/frontend/torch/quantization_ops.py
@@ -3,12 +3,14 @@
 #  Use of this source code is governed by a BSD-3-clause license that can be
 #  found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
-
 import numpy as _np
 import torch as _torch
+from packaging.version import Version
 
 from coremltools import _logger as logger
+from coremltools._deps import _HAS_TORCHAO, MSG_TORCHAO_NOT_FOUND
 from coremltools.converters.mil.frontend import _utils
+from coremltools.converters.mil.frontend.torch.ops import NUM_TO_NUMPY_DTYPE
 from coremltools.converters.mil.mil import Builder as mb
 from coremltools.converters.mil.mil import Var, types
 
@@ -16,11 +18,16 @@ from .ops import _create_linear_layer, _get_inputs, promote_input_dtypes
 from .torch_op_registry import register_torch_op
 from .utils import (
     NUM_TO_TORCH_DTYPE,
+    TORCH_DTYPE_TO_NUM,
+    TORCH_EXPORT_BASED_FRONTENDS,
     TORCH_QTYPE_TO_NP_TYPE,
     TORCH_QTYPE_TO_STR,
     TYPE_TO_DTYPE_STRING,
     TorchFrontend,
 )
+
+if _HAS_TORCHAO:
+    from torchao.quantization import quant_primitives as torchao_quant
 
 
 def _quantize_general(
@@ -94,17 +101,22 @@ def quantize_per_tensor(context, node):
     inputs = _get_inputs(
         context,
         node,
-        expected={TorchFrontend.TORCHSCRIPT: 4, TorchFrontend.EXIR: 6},
+        expected={
+            TorchFrontend.TORCHSCRIPT: 4,
+            TorchFrontend.TORCHEXPORT: 6,
+            TorchFrontend.EXECUTORCH: 6,
+        },
     )
-    assert context.frontend in (TorchFrontend.TORCHSCRIPT, TorchFrontend.EXIR)
     if context.frontend == TorchFrontend.TORCHSCRIPT:
         input, scale, zero_point, torch_dtype = inputs
-    elif context.frontend == TorchFrontend.EXIR:
+    elif context.frontend in TORCH_EXPORT_BASED_FRONTENDS:
         input, scale, zero_point, qmin, qmax, torch_dtype = inputs
         if qmax.val - qmin.val <= 16:
             logger.warning(
                 f"Core ML does not support 4-bit activation, so {torch_dtype.val} is used instead"
             )
+    else:
+        raise ValueError(f"Invalid PyTorch frontend {context.frontend}")
 
     _quantize_general(context, node, input, scale, zero_point, torch_dtype)
 
@@ -117,6 +129,17 @@ def quantize_per_channel(context, node):
         raise ValueError("quantization axis must be const at compile time")
 
     _quantize_general(context, node, input, scale, zero_point, torch_dtype, axis.val)
+
+
+@register_torch_op(
+    torch_alias=[
+        "quantized_decomposed::choose_qparams_per_token_asymmetric",
+        "quantized_decomposed.choose_qparams_per_token_asymmetric",
+    ]
+)
+def choose_qparams_per_token_asymmetric(context, node):
+    """PyTorch uses this op to calculate scale and zero_point on-the-fly for input data."""
+    raise NotImplementedError("Dynamic activation quantization is not supported in Core ML.")
 
 
 def _dequantize_general(
@@ -194,8 +217,10 @@ def _dequantize_general(
 def dequantize(context, node):
     if context.frontend == TorchFrontend.TORCHSCRIPT:
         context.quant_context.get_dequantized_var(node.inputs[0], node.name)
-    elif context.frontend == TorchFrontend.EXIR:
-        inputs = _get_inputs(context, node, min_expected={TorchFrontend.EXIR: 6})
+    elif context.frontend in TORCH_EXPORT_BASED_FRONTENDS:
+        inputs = _get_inputs(
+            context, node, min_expected={TorchFrontend.TORCHEXPORT: 6, TorchFrontend.EXECUTORCH: 6}
+        )
         num_inputs = len(inputs)
         if num_inputs == 6:
             input, scale, zero_point, qmin, qmax, _ = inputs
@@ -206,10 +231,7 @@ def dequantize(context, node):
             raise ValueError(f"dequantize should have 6 or 7 inputs, but got {num_inputs}")
         _dequantize_general(context, node, input, scale, zero_point, axis, qmin, qmax)
     else:
-        raise ValueError(
-            "dequantize is supported only in TorchScript and EXIR frontends, "
-            f"but got {context.frontend}"
-        )
+        raise ValueError(f"Invalid PyTorch frontend {context.frontend}")
 
 
 def _dequantized_weight(qweight, name: str = None):
@@ -457,3 +479,234 @@ def quantized_embedding(context, node):
     #  Changing the axis from 0 is not an option in torch, so we don't expose it
     gather = mb.gather(x=dequant_weights, indices=indices, name=node.name)
     context.add(gather)
+
+
+@register_torch_op(
+    torch_alias=[
+        "quantized_decomposed::embedding_4bit",
+        "quantized_decomposed::embedding_4bit.dtype",
+        "quantized_decomposed.embedding_4bit",
+        "quantized_decomposed.embedding_4bit.dtype",
+    ]
+)
+def quantized_embedding_4bit(context, node):
+    """Lower the 4-bit quantized embedding op used in executorch."""
+    inputs = _get_inputs(context, node, expected=[6, 7])
+    weight = inputs[0].val
+    weight_scales = inputs[1].val
+    weight_zero_points = None
+    if inputs[2] is not None and inputs[2].val is not None:
+        weight_zero_points = inputs[2].val
+    weight_quant_min = inputs[3].val
+    weight_quant_max = inputs[4].val
+    indices = inputs[5]
+
+    out_np_dtype = None
+    if len(inputs) > 6:
+        if isinstance(inputs[6].val, _torch.dtype):
+            out_np_dtype = NUM_TO_NUMPY_DTYPE[TORCH_DTYPE_TO_NUM[inputs[6].val]]
+        elif isinstance(inputs[6].val, (int, _np.generic)):
+            out_np_dtype = NUM_TO_NUMPY_DTYPE[inputs[6].val]
+    if out_np_dtype is not None:
+        weight_scales = weight_scales.astype(out_np_dtype)
+
+    if weight_quant_min == 0 and weight_quant_max == 0:
+        # Executorch wrongly passes both weight_quant_min and weight_quant_max. We should set it to correct numbers.
+        signed = True
+        weight_quant_min = -8
+        weight_quant_max = 7
+    else:
+        signed = weight_quant_min < 0
+
+    quant_low = -8 if signed else 0
+    quant_high = 7 if signed else 15
+    quant_torch_dtype = _torch.int8 if signed else _torch.uint8
+    if weight_quant_min != quant_low:
+        raise ValueError(
+            f"The weight_quant_min should be {quant_low} for 4-bit embedding, but got {weight_quant_min}."
+        )
+    if weight_quant_max != quant_high:
+        raise ValueError(
+            f"The weight_quant_max should be {quant_high} for 4-bit embedding, but got {weight_quant_max}."
+        )
+
+    # Unpack the weight to the normal layout.
+    with _torch.no_grad():
+        weight = _torch.from_numpy(weight)
+        # The original weight was packed by using 8-bit to represent two numbers, so we need to separate them.
+        help_move_bits = 2**4
+        weight_even = weight.div(help_move_bits, rounding_mode="trunc")
+        weight_odd = weight.remainder(help_move_bits)
+        weight_unpacked = _torch.stack((weight_even, weight_odd), dim=-1)
+        weight = weight_unpacked.view(weight.shape[0], -1)
+        weight = weight.view(quant_torch_dtype).add(weight_quant_min).numpy()
+
+    if not _np.logical_and(weight >= quant_low, weight <= quant_high).all():
+        raise ValueError(
+            f"All elements in weight should be within 4-bit range ({quant_low} to {quant_high})."
+        )
+
+    quantized_np_dtype = types.nptype_from_builtin(
+        types.string_to_builtin("int4" if signed else "uint4")
+    )
+    dequant_weight = _utils._construct_constexpr_dequant_op(
+        weight.astype(quantized_np_dtype),
+        weight_zero_points,
+        weight_scales,
+        axis=-1,
+        name=inputs[0].name,
+    )
+
+    gather = mb.gather(x=dequant_weight, indices=indices, name=node.name)
+    context.add(gather)
+
+
+@register_torch_op
+def _convert_weight_to_int4pack(context, node):
+    """Pack weight to int4pack format which will be fed into `_weight_int4pack_mm` op."""
+    inputs = _get_inputs(context, node, expected=2)
+    x = inputs[0].val
+    inner_k_tiles = inputs[1].val
+
+    if x is None or inner_k_tiles is None:
+        raise NotImplementedError(
+            "For `_convert_weight_to_int4pack` op, we only support static case, where x, "
+            "and inner_k_tiles are all known during compilation time."
+        )
+
+    with _torch.no_grad():
+        x_int4packed = _torch._convert_weight_to_int4pack(
+            _torch.from_numpy(x), inner_k_tiles
+        ).numpy()
+
+    res = mb.const(val=x_int4packed, name=node.name)
+    context.add(res)
+
+
+@register_torch_op
+def _weight_int4pack_mm(context, node):
+    """
+    The first argument is the same as torch.mm, but the second argument (weight) is packed.
+    The packed weight has rank=4, because the meta registration in dynamo requires operator has the same output shape
+    for each device. So it creates a fake shape {N / 8, K / (16 * innerKTiles), 32, innerKTiles / 2} for CPU.
+
+    More specifically:
+
+        # Original torch.mm
+        torch.mm(a, b)
+
+        # The int4 packed version mm
+        b_uint8, b_scales_and_zeros = _group_quantize_tensor(
+            b, n_bit=4, q_group_size=q_group
+        )
+        b_int4pack = torch._convert_weight_to_int4pack(
+            b_uint8, inner_k_tiles
+        )
+        weight_int4pack_mm(a, b_int4pack, b_scales_and_zeros)
+    """
+    if Version(_torch.__version__) < Version("2.4.0"):
+        raise AssertionError("To lower _weight_int4pack_mm, requires torch >= 2.4.0")
+
+    logger.warning(
+        "The current conversion of `_weight_int4pack_mm` op only works with model produced by torchao. "
+        "If the op is produced by other libs, you may observe large numerical discrepancy."
+    )
+
+    if not _HAS_TORCHAO:
+        raise AssertionError(
+            f"{MSG_TORCHAO_NOT_FOUND}\n torchao is needed to convert torch blockwise quantized model."
+        )
+
+    inputs = _get_inputs(context, node, expected=4)
+    x = inputs[0]
+    y_int4pack = inputs[1].val
+    group_size = inputs[2].val
+    y_scales_and_zeros = inputs[3].val
+
+    if y_int4pack is None or group_size is None or y_scales_and_zeros is None:
+        raise NotImplementedError(
+            "For `_weight_int4pack_mm` op, we only support static case, where y_int4pack, "
+            "group_size, y_scales_and_zeros are all known during compilation time."
+        )
+
+    if not (len(y_scales_and_zeros.shape) == 3 and y_scales_and_zeros.shape[2] == 2):
+        raise ValueError(
+            "The scales_and_zeros from torch should have 3 dims and last dim has size 2."
+        )
+    scales = _np.transpose(y_scales_and_zeros[:, :, 0])
+    zero_points = _np.transpose(y_scales_and_zeros[:, :, 1])
+
+    if _np.allclose(zero_points, zero_points.astype("int32")):
+        zero_points = zero_points.astype("int32")
+    else:
+        zero_points = zero_points.astype(_np.float32)
+
+    # Unpack the result of `torch._convert_weight_to_int4pack` back to plain layout.
+    # TODO: Use `torchao.ops.unpack_tensor_core_tiled_layout` to unpack after it has CPU implementation.
+    # The current way to unpack by using _weight_int4pack_mm with eye matrix is a workaround on CPU.
+    if len(y_int4pack.shape) != 4:
+        raise ValueError(
+            f"The packed y from torch should have 4 dims, but got {len(y_int4pack.shape)}."
+        )
+    inner_k_tiles = y_int4pack.shape[-1] * 2
+    y_unpacked_shape = (y_int4pack.shape[0] * 8, y_int4pack.shape[1] * (inner_k_tiles * 16))
+    eye_shape = y_unpacked_shape[1]
+    quant_min = 0
+    quant_max = 2**4 - 1
+    with _torch.no_grad():
+        y_dequantized = (
+            _torch._weight_int4pack_mm(
+                _torch.eye(eye_shape, device=_torch.device("cpu"), dtype=_torch.float32),
+                _torch.from_numpy(y_int4pack),
+                group_size,
+                _torch.from_numpy(y_scales_and_zeros).float(),
+            )
+            .t()
+            .contiguous()
+        )
+        zero_point_domain = (
+            torchao_quant.ZeroPointDomain.INT
+            if _np.issubdtype(zero_points.dtype, _np.integer)
+            else torchao_quant.ZeroPointDomain.FLOAT
+        )
+        y_quantized = torchao_quant.quantize_affine(
+            y_dequantized,
+            (1, group_size),
+            _torch.from_numpy(scales),
+            _torch.from_numpy(zero_points),
+            _torch.int32,
+            quant_min=quant_min,
+            quant_max=quant_max,
+            zero_point_domain=zero_point_domain,
+        )
+    y_quantized = y_quantized.numpy().astype(_np.uint8)
+    if len(y_quantized.shape) != 2:
+        raise ValueError(
+            f"The unpacked quantized y should have 2 dims, but got {len(y_quantized.shape)}."
+        )
+    if not _np.logical_and(y_quantized >= 0, y_quantized <= 15).all():
+        raise ValueError("All elements should be within 4-bit range (0 to 15).")
+
+    # If zero_point_domain in `quantize_affine` is set to `ZeroPointDomain.INT`, it matches with CoreML implementation:
+    #         quant = torch.clamp(torch.round(input * (1.0 / scale)) + zero_point, quant_min, quant_max)
+    # However, for `ZeroPointDomain.FLOAT`, torchao did following transformations to make it compatible with `tinygemm`:
+    #         mid_point = (quant_max + quant_min + 1) / 2
+    #         min_val = zero_point - scale * mid_point
+    #         quant = torch.clamp(torch.round((input - min_val) / scale), quant_min, quant_max))
+    # As we want to make sure the quantize matches CoreML dequant op, we have to do following transformations:
+    #         dequant = (quant - mid_point) * scale + zp
+    # so we can re-write the expression as
+    #         dequant = (quant - (mid_point - zp / scale)) * scale
+    # which means the zero_point in CoreML is actually `mid_point - zp / scale`.
+    if not _np.issubdtype(zero_points.dtype, _np.integer):
+        mid_point = (quant_max + quant_min + 1) / 2
+        zero_points = mid_point - zero_points / scales
+
+    # Use MIL constexpr op to represent the quantization.
+    quantized_np_dtype = types.nptype_from_builtin(types.string_to_builtin("uint4"))
+    dequant_weights = _utils._construct_constexpr_dequant_op(
+        y_quantized.astype(quantized_np_dtype), zero_points, scales, axis=-1, name=inputs[1].name
+    )
+
+    res = mb.linear(x=x, weight=dequant_weights, name=node.name)
+    context.add(res)

--- a/coremltools/converters/mil/frontend/torch/test/test_internal_graph.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_internal_graph.py
@@ -1412,7 +1412,8 @@ class TestTorchOps:
                 ceil_mode,
             ],
             "max_pool2d",
-            ops.max_pool2d,
+            # Using ops.max_pool1d because max_pool2d is its alias
+            ops.max_pool1d,
             expected_result,
         )
 

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_conversion_api.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_conversion_api.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 
 import numpy as np
 import pytest
+from packaging.version import Version
 from PIL import Image
 
 import coremltools as ct
@@ -19,8 +20,10 @@ from coremltools._deps import (
     _HAS_EXECUTORCH,
     _HAS_HF,
     _HAS_TORCH,
+    _HAS_TORCHAO,
     MSG_EXECUTORCH_NOT_FOUND,
     MSG_TORCH_NOT_FOUND,
+    MSG_TORCHAO_NOT_FOUND,
 )
 from coremltools.converters.mil.frontend.torch.test.testing_utils import _copy_input_data
 from coremltools.converters.mil.frontend.torch.torch_op_registry import (
@@ -59,6 +62,9 @@ if _HAS_HF:
 if _HAS_EXECUTORCH:
     import executorch.exir
 
+if _HAS_TORCHAO:
+    from torchao.quantization import quant_api
+    from torchao.utils import unwrap_tensor_subclass
 
 @pytest.fixture
 def torch_model():
@@ -2842,3 +2848,111 @@ class TestiOS16DefaultIODtype:
             output_dtype="fp32",
             expected_op_list=["add"],
         )
+
+
+@pytest.mark.skipif(
+    Version(torch.__version__) < Version("2.4.0"),
+    reason="Most torchao functionalities only work with PyTorch 2.4.0+",
+)
+@pytest.mark.skipif(
+    ct.utils._macos_version() < (15, 0),
+    reason="Torchao block-wise quantization requires MacOS 15+.",
+)
+@pytest.mark.skipif(not _HAS_TORCHAO, reason=MSG_TORCHAO_NOT_FOUND)
+class TestTorchao:
+    """
+    This class tests the torchao quantized model conversion.
+    """
+
+    @staticmethod
+    def _construct_test_model():
+        # The old Quantizer method in torchao doesn't work with a single-layer model such as model=nn.Linear(...),
+        # so we have to create a Module which contains linear layers.
+        class TestModel(nn.Module):
+            def __init__(self):
+                super(TestModel, self).__init__()
+                # Currently torchao only supports Linear module without bias.
+                self.linear1 = nn.Linear(32, 64, bias=False)
+                self.linear2 = nn.Linear(64, 32, bias=False)
+                self.relu = nn.ReLU()
+
+            def forward(self, x):
+                x = self.relu(self.linear1(x))
+                return self.relu(self.linear2(x))
+
+        return TestModel().to(torch.device("cpu")).eval()
+
+    @pytest.mark.parametrize("use_export", (False, True))
+    def test_weight_only_quantization(self, use_export):
+        model = self._construct_test_model()
+        quantizer = quant_api.Int4WeightOnlyQuantizer(
+            precision=torch.float32, groupsize=32, inner_k_tiles=2, device=torch.device("cpu")
+        )
+        model = quantizer.quantize(model)
+        input_data = torch.randn((2, 32), dtype=torch.float16)
+
+        if use_export:
+            exported_model = torch.export.export(model, (input_data,))
+            inputs = None
+        else:
+            exported_model = torch.jit.trace(model, example_inputs=(input_data,))
+            inputs = [ct.TensorType(shape=input_data.shape, name="input")]
+
+        converted_model = ct.convert(
+            exported_model, inputs=inputs, minimum_deployment_target=ct.target.iOS18
+        )
+        main_func = converted_model._mil_program.functions["main"]
+        quantize_ops = main_func.find_ops(op_type="constexpr_blockwise_shift_scale")
+        assert len(quantize_ops) > 0
+
+        if ct.utils._is_macos():
+            result = converted_model.predict(
+                {
+                    list(converted_model.input_description)[0]: input_data.detach()
+                    .numpy()
+                    .astype(np.float32)
+                }
+            )
+            expected = model(input_data)
+            output_name = list(result.keys())[0]
+            np.testing.assert_allclose(result[output_name], expected.detach().numpy(), atol=1e-3)
+
+    def test_weight_only_quantization_bfloat16_not_support(self):
+        """
+        Torchao quant_api.int4_weight_only only supports bfloat16.
+        """
+        model = self._construct_test_model().bfloat16()
+        quant_api.quantize_(model, quant_api.int4_weight_only(group_size=32, inner_k_tiles=2))
+        model = unwrap_tensor_subclass(model)
+        input_data = torch.randn((2, 32), dtype=torch.float16)
+        exported_model = torch.export.export(model, (input_data,))
+        # The conversion of bfloat16 hasn't been supported yet.
+        with pytest.raises(KeyError, match="torch.bfloat16"):
+            ct.convert(exported_model, minimum_deployment_target=ct.target.iOS17)
+
+    @pytest.mark.parametrize("use_export", (True, False))
+    def test_dynamic_activation_quantization_not_support(self, use_export):
+        """
+        Although Int8DynActInt4WeightQuantizer will be deprecated, we still want
+        to test it because it's used in ExecuTorch to quantize llama models.
+        """
+        model = self._construct_test_model()
+        quantizer = quant_api.Int8DynActInt4WeightQuantizer(
+            precision=torch.float16, groupsize=32, device=torch.device("cpu")
+        )
+        model = quantizer.quantize(model)
+        input_data = torch.randn((2, 32), dtype=torch.float16)
+
+        if use_export:
+            exported_model = torch.export.export(model, (input_data,))
+            inputs = None
+            err_msg = "Unsupported fx node quantize_per_token"
+            err_type = ValueError
+        else:
+            exported_model = torch.jit.trace(model, example_inputs=(input_data,))
+            inputs = [ct.TensorType(shape=input_data.shape)]
+            err_msg = "Dynamic activation quantization is not supported in Core ML"
+            err_type = NotImplementedError
+
+        with pytest.raises(err_type, match=err_msg):
+            ct.convert(exported_model, inputs=inputs, minimum_deployment_target=ct.target.iOS17)

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_export_quantization.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_export_quantization.py
@@ -13,9 +13,12 @@ from coremltools._deps import _HAS_EXECUTORCH, _HAS_TORCH_EXPORT_API
 if not _HAS_TORCH_EXPORT_API:
     pytest.skip(allow_module_level=True, reason="torch.export is required")
 
-USE_EDGE_DIALECT = [False]
+from coremltools.converters.mil.frontend.torch.utils import TorchFrontend
+
+frontends = [TorchFrontend.TORCHEXPORT]
+
 if _HAS_EXECUTORCH:
-    USE_EDGE_DIALECT.append(True)
+    frontends.append(TorchFrontend.EXECUTORCH)
 
 import torch
 
@@ -42,7 +45,7 @@ from coremltools.optimize.torch.quantization.quantization_config import (
     QuantizationScheme,
 )
 
-from .testing_utils import TorchBaseTest, TorchFrontend
+from .testing_utils import TorchBaseTest
 
 
 class TestTorchExportQuantization(TorchBaseTest):
@@ -108,18 +111,16 @@ class TestTorchExportQuantization(TorchBaseTest):
         return converted_graph
 
     @pytest.mark.parametrize(
-        "quantizer_name, quantization_type, is_per_channel, nbit, use_edge_dialect",
+        "quantizer_name, quantization_type, is_per_channel, nbit, frontend",
         itertools.product(
             ("XNNPack", "CoreML"),
             ("PTQ", "QAT"),
             (True, False),
             (4, 8),
-            USE_EDGE_DIALECT,
+            frontends,
         ),
     )
-    def test_conv_relu(
-        self, quantizer_name, quantization_type, is_per_channel, nbit, use_edge_dialect
-    ):
+    def test_conv_relu(self, quantizer_name, quantization_type, is_per_channel, nbit, frontend):
         SHAPE = (1, 3, 256, 256)
 
         class Model(torch.nn.Module):
@@ -152,8 +153,7 @@ class TestTorchExportQuantization(TorchBaseTest):
         _, mlmodel, _, _, _, _ = self.run_compare_torch(
             SHAPE,
             converted_graph,
-            frontend=TorchFrontend.EXIR,
-            use_edge_dialect=use_edge_dialect,
+            frontend=frontend,
             backend=("mlprogram", "fp16"),
             minimum_deployment_target=minimum_deployment_target,
         )
@@ -173,18 +173,16 @@ class TestTorchExportQuantization(TorchBaseTest):
             assert constexpr_affine_dequantize_op.quantized_data.dtype in (types.int8, types.uint8)
 
     @pytest.mark.parametrize(
-        "quantizer_name, quantization_type, is_per_channel, nbit, use_edge_dialect",
+        "quantizer_name, quantization_type, is_per_channel, nbit, frontend",
         itertools.product(
             ("XNNPack", "CoreML"),
             ("PTQ", "QAT"),
             (True, False),
             (4, 8),
-            USE_EDGE_DIALECT,
+            frontends,
         ),
     )
-    def test_linear(
-        self, quantizer_name, quantization_type, is_per_channel, nbit, use_edge_dialect
-    ):
+    def test_linear(self, quantizer_name, quantization_type, is_per_channel, nbit, frontend):
         SHAPE = (1, 5)
 
         class Model(torch.nn.Module):
@@ -213,8 +211,7 @@ class TestTorchExportQuantization(TorchBaseTest):
         _, mlmodel, _, _, _, _ = self.run_compare_torch(
             SHAPE,
             converted_graph,
-            frontend=TorchFrontend.EXIR,
-            use_edge_dialect=use_edge_dialect,
+            frontend=frontend,
             backend=("mlprogram", "fp16"),
             minimum_deployment_target=minimum_deployment_target,
         )

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_quantization_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_quantization_ops.py
@@ -8,9 +8,11 @@ from contextlib import nullcontext
 from typing import Optional
 
 import numpy as np
+import numpy.testing
 import pytest
 import torch
 import torchvision
+from packaging.version import Version
 
 import coremltools as ct
 import coremltools.optimize as cto
@@ -18,10 +20,13 @@ from coremltools import TensorType
 from coremltools._deps import (
     _HAS_TORCH,
     _HAS_TORCH_VISION,
+    _HAS_TORCHAO,
     MSG_TORCH_NOT_FOUND,
     MSG_TORCH_VISION_NOT_FOUND,
+    MSG_TORCHAO_NOT_FOUND,
 )
 from coremltools.converters.mil import testing_reqs
+from coremltools.converters.mil.frontend.torch.utils import TorchFrontend
 from coremltools.converters.mil.mil import types
 from coremltools.converters.mil.testing_utils import get_op_types_in_program
 from coremltools.optimize.coreml import _quantization_passes
@@ -32,7 +37,11 @@ from coremltools.test.optimize.coreml.test_post_training_quantization import (
     create_unique_weight,
 )
 
-from .testing_utils import TorchBaseTest
+from .testing_utils import TorchBaseTest, frontends
+
+if _HAS_TORCHAO:
+    import torchao
+    from torchao.quantization import quant_primitives as torchao_quant
 
 pytest.mark.skipif(not _HAS_TORCH, reason=MSG_TORCH_NOT_FOUND)
 
@@ -103,6 +112,7 @@ class TorchQuantizationBaseTest(TorchBaseTest):
         input_as_shape=True,
         minimum_deployment_target=ct.target.iOS17,
         compute_unit=ct.ComputeUnit.CPU_ONLY,
+        frontend=TorchFrontend.TORCHSCRIPT,
         converter=ct.convert,
     ):
         # TODO(rdar://108472419): properly design a random input
@@ -119,6 +129,7 @@ class TorchQuantizationBaseTest(TorchBaseTest):
             use_scripting=False,
             compute_unit=compute_unit,
             minimum_deployment_target=minimum_deployment_target,
+            frontend=frontend,
             converter=converter,
         )
 
@@ -431,6 +442,185 @@ class TestPytorchQuantizedOps(TorchQuantizationBaseTest):
         else:
             assert get_op_types_in_program(prog) == ["constexpr_blockwise_shift_scale", "matmul"]
 
+    @pytest.mark.skipif(not _HAS_TORCHAO, reason=MSG_TORCHAO_NOT_FOUND)
+    @pytest.mark.parametrize(
+        "use_numpy, inner_k_tiles, group_size",
+        itertools.product([True, False], [2, 4, 8], [32, 64]),
+    )
+    def test_unpack_int4packed_by_mm_with_eye_matrix(self, use_numpy, inner_k_tiles, group_size):
+        """
+        Check if the packed weight could be restored by _weight_int4pack_mm with eye matrix on CPU.
+
+        As there is no kernel implemented for CPU to unpack the data packed by `torch._convert_weight_to_int4pack`,
+        we use `torch._weight_int4pack_mm` to do matrix multiplication with an eye matrix to get unpacked data.
+        """
+        if use_numpy:
+            y_np = numpy.random.rand(128, 128).astype(np.float32)
+            y = torch.from_numpy(y_np).to(torch.device("cpu"))
+        else:
+            y = torch.rand(128, 128, dtype=torch.float32, device=torch.device("cpu"))
+
+        (
+            y_quantized,
+            y_scales_and_zeros,
+        ) = torchao.quantization.utils.groupwise_affine_quantize_tensor(
+            y, n_bit=4, groupsize=group_size, dtype=torch.float32
+        )
+        y_int4packed = torch._convert_weight_to_int4pack(y_quantized, inner_k_tiles)
+        y_unpacked_shape = (y_int4packed.shape[0] * 8, y_int4packed.shape[1] * (inner_k_tiles * 16))
+        eye_shape = y_unpacked_shape[1]
+        eye_matrix = torch.eye(eye_shape, device=torch.device("cpu"), dtype=torch.float32)
+        if Version(torch.__version__) < Version("2.4.0"):
+            # The `torch._weight_int4pack_mm` op requires bfloat16 before PyTorch 2.4.0.
+            eye_matrix = eye_matrix.to(torch.bfloat16)
+            y_scales_and_zeros = y_scales_and_zeros.to(torch.bfloat16)
+        y_dequant = torch._weight_int4pack_mm(
+            eye_matrix,
+            y_int4packed,
+            group_size,
+            y_scales_and_zeros,
+        )
+        y_dequant = y_dequant.t().contiguous().float()
+
+        # Makes sure this `_weight_int4pack_mm` with eye matrix fully restores the original y.
+        np.testing.assert_allclose(y_dequant.numpy(), y.numpy(), atol=0.035, rtol=0.05)
+
+        # Also verifies that the quantized y could be accurately reproduced by torchao utils.
+        scales = torch.transpose(y_scales_and_zeros[:, :, 0], 0, 1)
+        zero_points = torch.transpose(y_scales_and_zeros[:, :, 1], 0, 1)
+        block_size = (1, group_size)
+        y_dequant_quantized = torchao_quant.quantize_affine(
+            y_dequant,
+            block_size,
+            scales,
+            zero_points,
+            torch.int32,
+            quant_min=0,
+            quant_max=2**4 - 1,
+            zero_point_domain=torchao_quant.ZeroPointDomain.FLOAT,
+        )
+        assert torch.equal(y_quantized, y_dequant_quantized)
+
+        # The torchao dequantization utils should be able to recover the original y.
+        y_dequantized_by_torchao = torchao_quant.dequantize_affine(
+            y_quantized,
+            (1, group_size),
+            scales,
+            zero_points,
+            torch.int32,
+            quant_min=0,
+            quant_max=2**4 - 1,
+            zero_point_domain=torchao_quant.ZeroPointDomain.FLOAT,
+        )
+        np.testing.assert_allclose(y_dequant.numpy(), y_dequantized_by_torchao.numpy(), rtol=4e-3)
+
+    @pytest.mark.skipif(
+        Version(torch.__version__) < Version("2.4.0"),
+        reason="_weight_int4pack_mm requires bfloat16 before PyTorch 2.4.0",
+    )
+    @pytest.mark.skipif(not _HAS_TORCHAO, reason=MSG_TORCHAO_NOT_FOUND)
+    @pytest.mark.parametrize(
+        "compute_unit, inner_k_tiles, group_size",
+        itertools.product(compute_units, [2, 4, 8], [32, 64]),
+    )
+    def test_weight_int4pack_mm(self, compute_unit, inner_k_tiles, group_size):
+        y = torch.rand(128, 128, dtype=torch.float32, device=torch.device("cpu"))
+
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                (
+                    y_quantized,
+                    y_scales_and_zeros,
+                ) = torchao.quantization.utils.groupwise_affine_quantize_tensor(
+                    y, n_bit=4, groupsize=group_size, dtype=torch.float32
+                )
+                y_int4packed = torch._convert_weight_to_int4pack(y_quantized, inner_k_tiles)
+                return torch._weight_int4pack_mm(x, y_int4packed, group_size, y_scales_and_zeros)
+
+        model = Model().to(torch.device("cpu"))
+        input_shape = [(2, 128)]
+        res = self.run_compare_torch(
+            input_shape,
+            model,
+            minimum_deployment_target=ct.target.iOS18,
+            compute_unit=compute_unit,
+            rtol=0.1,
+        )
+        prog = res[1]._mil_program
+        assert get_op_types_in_program(prog) == ["constexpr_blockwise_shift_scale", "linear"]
+
+    @pytest.mark.skipif(
+        not hasattr(torch.ops.quantized_decomposed, "embedding_4bit"),
+        reason="The `embedding_4bit` op doesn't exist in quantized_decomposed custom opset.",
+    )
+    @pytest.mark.parametrize(
+        "compute_unit, group_size, dtype, signed",
+        itertools.product(
+            compute_units, [32, 64], [None, torch.float16, torch.float32], [False, True]
+        ),
+    )
+    def test_quantized_decomposed_embedding_4bit_dtype(
+        self, compute_unit, group_size, dtype, signed
+    ):
+        if not signed:
+            # To reproduce this executorch bug, use following settings
+            #    scales = torch.ones(size=scales_shape, dtype=torch.float32, device=torch.device("cpu"))
+            #    input_data = torch.zeros(size=(1, 1), dtype=torch.int32)
+            # Then you will find coreml outputs is the expected (consistent with `unpacked_weight`).
+            pytest.skip(
+                "rdar://135216194 (Executorch embedding_4bit implementation bug for unsigned quantization)"
+            )
+
+        quant_low = -8 if signed else 0
+        quant_high = 7 if signed else 15
+        quant_dtype = torch.int8 if signed else torch.uint8
+
+        weight_shape = (128, 128)
+        unpacked_weight = torch.randint(
+            low=quant_low,
+            high=quant_high + 1,
+            size=weight_shape,
+            dtype=quant_dtype,
+        )
+        # Pack the weight to embedding_4bit's usable format.
+        weight_range_shifted = unpacked_weight.add(-quant_low).view(torch.uint8)
+        weight_view = weight_range_shifted.view(
+            unpacked_weight.shape[0], unpacked_weight.shape[1] // 2, 2
+        )
+        weight_even = weight_view[:, :, 0] * 16  # left shift 4
+        weight_odd = weight_view[:, :, 1]
+        weight = weight_even + weight_odd
+
+        scales_shape = list(weight_shape)
+        scales_shape[-1] = weight_shape[-1] // group_size
+        scales = torch.rand(*scales_shape, dtype=torch.float32)
+
+        class Model(torch.nn.Module):
+            def forward(self, indices: torch.Tensor):
+                if dtype is not None:
+                    return torch.ops.quantized_decomposed.embedding_4bit(
+                        weight, scales, None, quant_low, quant_high, indices, dtype=dtype
+                    )
+                else:
+                    return torch.ops.quantized_decomposed.embedding_4bit(
+                        weight, scales, None, quant_low, quant_high, indices
+                    )
+
+        # The 4-bit packing-unpacking in torch could be messed up when transferring between devices, so it's safer
+        # to specify device at the beginning.
+        model = Model().to(torch.device("cpu"))
+        input_data = torch.randint(low=0, high=weight_shape[-1], size=(2, 128), dtype=torch.int32)
+        res = self.run_compare_torch(
+            input_data,
+            model,
+            input_as_shape=False,
+            minimum_deployment_target=ct.target.iOS18,
+            compute_unit=compute_unit,
+            rtol=1e-3,
+        )
+        prog = res[1]._mil_program
+        assert get_op_types_in_program(prog) == ["constexpr_blockwise_shift_scale", "gather"]
+
 
 @pytest.mark.skipif(not _HAS_TORCH_VISION, reason=MSG_TORCH_VISION_NOT_FOUND)
 class TestTorchvisionQuantizedModels(TorchQuantizationBaseTest):
@@ -451,30 +641,36 @@ class TestPytorchCarryCompressionInfo(TorchQuantizationBaseTest):
     """Test compressed PyTorch models which use register_buffer to carry compression info."""
 
     @pytest.mark.parametrize(
-        "compute_unit, n_bits, signed, minimum_deployment_target",
+        "compute_unit, n_bits, signed, use_linear, minimum_deployment_target, frontend",
         itertools.product(
             compute_units,
             [4, 8],
             [True, False],
+            [True, False],
             [ct.target.iOS16, ct.target.iOS18],
+            frontends,
         ),
     )
-    def test_quantization(self, compute_unit, n_bits, signed, minimum_deployment_target):
+    def test_quantization(
+        self, compute_unit, n_bits, signed, use_linear, minimum_deployment_target, frontend
+    ):
         if n_bits == 4 and minimum_deployment_target < ct.target.iOS18:
             pytest.skip("Sub-byte quantization is only supported since iOS18.")
 
-        model, inputs, torch_input_values, coreml_input_values = get_test_model_and_data(
+        model, inputs, _, _ = get_test_model_and_data(
             quantize_config=cto.coreml.OpLinearQuantizerConfig(
                 mode="linear_symmetric",
                 dtype=types.get_nbits_int_builtin_type(n_bits, signed),
                 granularity="per_tensor",
-            )
+            ),
+            use_linear=use_linear,
         )
 
-        scale = np.array([2.0], dtype=np.float32).reshape(1, 1, 1, 1)
+        target_scale_shape = (1, 1) if use_linear else (1, 1, 1, 1)
+        scale = np.array([2.0], dtype=np.float32).reshape(*target_scale_shape)
         zero_point = np.array(
             [0 if signed else 2 ** (n_bits - 1)], dtype=np.int8 if signed else np.uint8
-        ).reshape(1, 1, 1, 1)
+        ).reshape(*target_scale_shape)
 
         model.register_buffer("_COREML_/metadata_version", torch.tensor(2))
         model.register_buffer("_COREML_/weight/compression_type", torch.tensor([3]))
@@ -482,13 +678,13 @@ class TestPytorchCarryCompressionInfo(TorchQuantizationBaseTest):
         model.register_buffer("_COREML_/weight/quantization_scale", torch.from_numpy(scale))
         model.register_buffer("_COREML_/weight/zero_point", torch.from_numpy(zero_point))
 
-        traced_model = torch.jit.trace(model, torch_input_values)
         input_shape = [input.shape.to_list() for input in inputs]
         res = self.run_compare_torch(
             input_shape,
-            traced_model,
+            model,
             minimum_deployment_target=minimum_deployment_target,
             compute_unit=compute_unit,
+            frontend=frontend,
             converter=ct.convert,
             rtol=1e-04,
             atol=1e-03,
@@ -511,11 +707,11 @@ class TestPytorchCarryCompressionInfo(TorchQuantizationBaseTest):
                 assert types.builtin_to_string(quantize_op.zero_point.dtype) == target_dtype_str
 
     @pytest.mark.parametrize(
-        "compute_unit, n_bits, minimum_deployment_target",
-        itertools.product(compute_units, [4, 8], [ct.target.iOS16, ct.target.iOS18]),
+        "compute_unit, n_bits, minimum_deployment_target, frontend",
+        itertools.product(compute_units, [4, 8], [ct.target.iOS16, ct.target.iOS18], frontends),
     )
     def test_multiple_parameters_in_same_layer(
-        self, compute_unit, n_bits, minimum_deployment_target
+        self, compute_unit, n_bits, minimum_deployment_target, frontend
     ):
         """Test one layer has multiple parameters (such as weight and bias in a linear layer)"""
         if n_bits == 4 and minimum_deployment_target < ct.target.iOS18:
@@ -559,13 +755,12 @@ class TestPytorchCarryCompressionInfo(TorchQuantizationBaseTest):
         )
         model.register_buffer("_COREML_/metadata_version", torch.tensor(2))
 
-        torch_input_values = torch.rand((8, 16))
-        traced_model = torch.jit.trace(model, torch_input_values)
         res = self.run_compare_torch(
             [(8, 16)],
-            traced_model,
+            model,
             minimum_deployment_target=minimum_deployment_target,
             compute_unit=compute_unit,
+            frontend=frontend,
             converter=ct.convert,
         )
         main_func = res[1]._mil_program.functions["main"]
@@ -579,8 +774,15 @@ class TestPytorchCarryCompressionInfo(TorchQuantizationBaseTest):
         linear_ops = main_func.find_ops(op_type="linear")
         assert linear_ops[0].weight.op.op_type == "const"
         assert linear_ops[0].bias.op.op_type == "const"
-        assert linear_ops[1].weight.op.op_type == quantize_op_type
-        assert linear_ops[1].bias.op.op_type == quantize_op_type
+        if frontend == TorchFrontend.EXECUTORCH:
+            # In EXECUTORCH, the second linear layer is represented by `matmul` and `add` op.
+            matmul_op = main_func.find_ops(op_type="matmul")[0]
+            add_op = main_func.find_ops(op_type="add")[0]
+            assert matmul_op.y.op.op_type == quantize_op_type
+            assert add_op.x.op.op_type == quantize_op_type
+        else:
+            assert linear_ops[1].weight.op.op_type == quantize_op_type
+            assert linear_ops[1].bias.op.op_type == quantize_op_type
 
         quantize_ops = main_func.find_ops(op_type=quantize_op_type)
         assert len(quantize_ops) == 2
@@ -634,18 +836,28 @@ class TestPytorchCarryCompressionInfo(TorchQuantizationBaseTest):
             )
 
     @pytest.mark.parametrize(
-        "compute_unit, n_bits, group_size, channel_axis, cluster_dim, minimum_deployment_target",
+        "compute_unit, n_bits, group_size, channel_axis, cluster_dim, use_linear, minimum_deployment_target, frontend",
         itertools.product(
             compute_units,
             [4, 8],
             [0, 1, 2],
             [0, 1],
             [1, 2],
+            [True, False],
             [ct.target.iOS16, ct.target.iOS18],
+            frontends,
         ),
     )
     def test_palettization(
-        self, compute_unit, n_bits, group_size, channel_axis, cluster_dim, minimum_deployment_target
+        self,
+        compute_unit,
+        n_bits,
+        group_size,
+        channel_axis,
+        cluster_dim,
+        use_linear,
+        minimum_deployment_target,
+        frontend,
     ):
         if (
             group_size in (0, 2)
@@ -661,21 +873,35 @@ class TestPytorchCarryCompressionInfo(TorchQuantizationBaseTest):
                 pytest.skip("Cluster dim must <= group size.")
 
         model, inputs, torch_input_values, coreml_input_values = get_test_model_and_data(
-            multi_layer=True
+            multi_layer=True,
+            use_linear=use_linear,
         )
 
-        # per-channel scales for the [32, 64, 2, 2] and [64, 32, 2, 2] weight.
-        scale_1 = np.array([2.0] * 32, dtype=np.float32).reshape(32, 1, 1, 1)
-        scale_2 = np.array([3.0] * 64, dtype=np.float32).reshape(64, 1, 1, 1)
+        if use_linear:
+            # per-channel scales for the [32, 64] and [16, 32] weight.
+            scale_1 = np.array([2.0] * 32, dtype=np.float32).reshape(32, 1)
+            scale_2 = np.array([3.0] * 16, dtype=np.float32).reshape(16, 1)
+        else:
+            # per-channel scales for the [32, 64, 2, 2] and [64, 32, 2, 2] weight.
+            scale_1 = np.array([2.0] * 32, dtype=np.float32).reshape(32, 1, 1, 1)
+            scale_2 = np.array([3.0] * 64, dtype=np.float32).reshape(64, 1, 1, 1)
 
+        layername_1 = "linear_1" if use_linear else "conv_1"
+        layername_2 = "linear_2" if use_linear else "conv_2"
         unique_weight_1 = create_unique_weight(
-            model.conv_1.weight, nbits=n_bits, vector_size=cluster_dim, vector_axis=channel_axis
+            getattr(model, layername_1).weight,
+            nbits=n_bits,
+            vector_size=cluster_dim,
+            vector_axis=channel_axis,
         )
         unique_weight_2 = create_unique_weight(
-            model.conv_2.weight, nbits=n_bits, vector_size=cluster_dim, vector_axis=channel_axis
+            getattr(model, layername_2).weight,
+            nbits=n_bits,
+            vector_size=cluster_dim,
+            vector_axis=channel_axis,
         )
 
-        # Use grouped-channel-wise lut for conv1 for iOS18+.
+        # Use grouped-channel-wise lut for layer1 for iOS18+.
         block_sizes = [0] * len(unique_weight_1.shape)
         if minimum_deployment_target >= ct.target.iOS18:
             block_sizes[channel_axis] = group_size
@@ -688,7 +914,7 @@ class TestPytorchCarryCompressionInfo(TorchQuantizationBaseTest):
             channel_axis=channel_axis,
         )
 
-        # Use per-tensor lut for conv2.
+        # Use per-tensor lut for layer2.
         lut_2_params = _quantization_passes.palettize_weights.blockwise_compress(
             unique_weight_2,
             "UNIQUE",
@@ -704,30 +930,38 @@ class TestPytorchCarryCompressionInfo(TorchQuantizationBaseTest):
             unique_weight_2 *= scale_2
 
         with torch.no_grad():
-            model.conv_1.weight = torch.nn.Parameter(torch.Tensor(unique_weight_1))
-            model.conv_2.weight = torch.nn.Parameter(torch.Tensor(unique_weight_2))
+            getattr(model, layername_1).weight = torch.nn.Parameter(torch.Tensor(unique_weight_1))
+            getattr(model, layername_2).weight = torch.nn.Parameter(torch.Tensor(unique_weight_2))
 
         model.register_buffer("_COREML_/metadata_version", torch.tensor(1))
         if minimum_deployment_target >= ct.target.iOS18:
-            model.conv_1.register_buffer("_COREML_/weight/compression_type", torch.tensor([2]))
-            model.conv_1.register_buffer("_COREML_/weight/lut", torch.tensor(lut_1_params.lut))
-            model.conv_1.register_buffer(
+            getattr(model, layername_1).register_buffer(
+                "_COREML_/weight/compression_type", torch.tensor([2])
+            )
+            getattr(model, layername_1).register_buffer(
+                "_COREML_/weight/lut", torch.tensor(lut_1_params.lut)
+            )
+            getattr(model, layername_1).register_buffer(
                 "_COREML_/weight/palettization_scale", torch.from_numpy(scale_1)
             )
-        model.conv_2.register_buffer("_COREML_/weight/compression_type", torch.tensor([2]))
-        model.conv_2.register_buffer("_COREML_/weight/lut", torch.tensor(lut_2_params.lut))
+        getattr(model, layername_2).register_buffer(
+            "_COREML_/weight/compression_type", torch.tensor([2])
+        )
+        getattr(model, layername_2).register_buffer(
+            "_COREML_/weight/lut", torch.tensor(lut_2_params.lut)
+        )
         if minimum_deployment_target >= ct.target.iOS18:
-            model.conv_2.register_buffer(
+            getattr(model, layername_2).register_buffer(
                 "_COREML_/weight/palettization_scale", torch.from_numpy(scale_2)
             )
 
-        traced_model = torch.jit.trace(model, torch_input_values)
         input_shape = [input.shape.to_list() for input in inputs]
         res = self.run_compare_torch(
             input_shape,
-            traced_model,
+            model,
             minimum_deployment_target=minimum_deployment_target,
             compute_unit=compute_unit,
+            frontend=frontend,
             converter=ct.convert,
             rtol=0.2 if cluster_dim > 1 else 1e-5,  # Vector palettization has larger info loss.
         )
@@ -737,16 +971,19 @@ class TestPytorchCarryCompressionInfo(TorchQuantizationBaseTest):
             expected_dtype = f"uint{n_bits}"
             expected_quantize_ops_num = 2
             expected_palettize_ops_num = 2
-            palettize_op_child_op_type = "constexpr_blockwise_shift_scale"
+            # The lut with pcs op order is determined by canonicalize_quantized_lut_pattern graph pass.
+            palettize_op_child_op_type = "linear" if use_linear else "conv"
         else:
             expected_dtype = "uint8"
             expected_quantize_ops_num = 0
             expected_palettize_ops_num = 1
-            # The iOS16 doesn't have per-channel-scale, so lut output is directly fed into conv.
-            palettize_op_child_op_type = "conv"
+            # The iOS16 doesn't have per-channel-scale, so lut output is directly fed into next op.
+            palettize_op_child_op_type = "linear" if use_linear else "conv"
 
         quantize_ops = main_func.find_ops(op_type="constexpr_blockwise_shift_scale")
         assert len(quantize_ops) == expected_quantize_ops_num
+        for quantize_op in quantize_ops:
+            assert quantize_op.outputs[0].child_ops[0].op_type == "constexpr_lut_to_dense"
         palettize_ops = main_func.find_ops(op_type="constexpr_lut_to_dense")
         assert len(palettize_ops) == expected_palettize_ops_num
         for palettize_op in palettize_ops:
@@ -756,10 +993,10 @@ class TestPytorchCarryCompressionInfo(TorchQuantizationBaseTest):
                 assert palettize_op.lut.shape[-1] == cluster_dim
 
     @pytest.mark.parametrize(
-        "compute_unit, minimum_deployment_target",
-        itertools.product(compute_units, [ct.target.iOS16, ct.target.iOS18]),
+        "compute_unit, minimum_deployment_target, frontend",
+        itertools.product(compute_units, [ct.target.iOS16, ct.target.iOS18], frontends),
     )
-    def test_palettization_8bit_lut(self, compute_unit, minimum_deployment_target):
+    def test_palettization_8bit_lut(self, compute_unit, minimum_deployment_target, frontend):
         model, inputs, torch_input_values, coreml_input_values = get_test_model_and_data(
             multi_layer=True
         )
@@ -857,36 +1094,54 @@ class TestPytorchCarryCompressionInfo(TorchQuantizationBaseTest):
         assert len(palettize_ops) == 2
         assert types.builtin_to_string(palettize_ops[0].indices.dtype) == "uint4"
         assert types.builtin_to_string(palettize_ops[1].indices.dtype) == "uint6"
+        # The op order is adjusted by common::canonicalize_quantized_lut_pattern graph pass.
+        for quantize_op in quantize_ops:
+            assert quantize_op.outputs[0].child_ops[0].op_type == "constexpr_lut_to_dense"
         for palettize_op in palettize_ops:
-            assert palettize_op.outputs[0].child_ops[0].op_type == "constexpr_blockwise_shift_scale"
+            assert palettize_op.outputs[0].child_ops[0].op_type == "conv"
 
     @pytest.mark.parametrize(
-        "compute_unit, sparse_ratio, minimum_deployment_target",
+        "compute_unit, sparse_ratio, use_linear, minimum_deployment_target, frontend",
         itertools.product(
             compute_units,
             [0.01, 0.5, 0.99],
+            [True, False],
             [ct.target.iOS16, ct.target.iOS18],
+            frontends,
         ),
     )
-    def test_pruning(self, compute_unit, sparse_ratio, minimum_deployment_target):
+    def test_pruning(
+        self, compute_unit, sparse_ratio, use_linear, minimum_deployment_target, frontend
+    ):
         model, inputs, torch_input_values, coreml_input_values = get_test_model_and_data(
-            multi_layer=True
+            multi_layer=True, use_linear=use_linear
         )
+        layername_1 = "linear_1" if use_linear else "conv_1"
+        layername_2 = "linear_2" if use_linear else "conv_2"
+
         with torch.no_grad():
-            model.conv_1.weight = torch.nn.Parameter(
+            getattr(model, layername_1).weight = torch.nn.Parameter(
                 torch.Tensor(
-                    create_sparse_weight(model.conv_1.weight, target_sparsity=sparse_ratio)
+                    create_sparse_weight(
+                        getattr(model, layername_1).weight, target_sparsity=sparse_ratio
+                    )
                 )
             )
-            model.conv_2.weight = torch.nn.Parameter(
+            getattr(model, layername_2).weight = torch.nn.Parameter(
                 torch.Tensor(
-                    create_sparse_weight(model.conv_2.weight, target_sparsity=sparse_ratio)
+                    create_sparse_weight(
+                        getattr(model, layername_2).weight, target_sparsity=sparse_ratio
+                    )
                 )
             )
 
         model.register_buffer("_COREML_/metadata_version", torch.tensor(1))
-        model.conv_1.register_buffer("_COREML_/weight/compression_type", torch.tensor([1]))
-        model.conv_2.register_buffer("_COREML_/weight/compression_type", torch.tensor([1]))
+        getattr(model, layername_1).register_buffer(
+            "_COREML_/weight/compression_type", torch.tensor([1])
+        )
+        getattr(model, layername_2).register_buffer(
+            "_COREML_/weight/compression_type", torch.tensor([1])
+        )
 
         traced_model = torch.jit.trace(model, torch_input_values)
         input_shape = [input.shape.to_list() for input in inputs]
@@ -902,7 +1157,7 @@ class TestPytorchCarryCompressionInfo(TorchQuantizationBaseTest):
         assert len(sparse_ops) == 2
 
         for sparse_op in sparse_ops:
-            assert sparse_op.outputs[0].child_ops[0].op_type == "conv"
+            assert sparse_op.outputs[0].child_ops[0].op_type == "linear" if use_linear else "conv"
             assert types.builtin_to_string(sparse_op.nonzero_data.dtype) == "fp32"
             if minimum_deployment_target >= ct.target.iOS18:
                 assert types.builtin_to_string(sparse_op.mask.dtype) == "uint1"
@@ -911,52 +1166,69 @@ class TestPytorchCarryCompressionInfo(TorchQuantizationBaseTest):
                 assert types.builtin_to_string(sparse_op.shape.dtype) == "uint32"
 
     @pytest.mark.parametrize(
-        "compute_unit, n_bits, signed",
+        "compute_unit, n_bits, signed, use_linear, frontend",
         itertools.product(
             compute_units,
             [4, 8],
             [True, False],
+            [True, False],
+            frontends,
         ),
     )
-    def test_joint_pruning_quantization(self, compute_unit, n_bits, signed):
+    def test_joint_pruning_quantization(self, compute_unit, n_bits, signed, use_linear, frontend):
         model, inputs, torch_input_values, coreml_input_values = get_test_model_and_data(
             multi_layer=True,
+            use_linear=use_linear,
         )
 
         # Make the weight sparse and also quantization-friendly.
+        layername_1 = "linear_1" if use_linear else "conv_1"
+        layername_2 = "linear_2" if use_linear else "conv_2"
         weight_1, scale_1, zero_point_1 = create_quantize_friendly_weight(
-            model.conv_1.weight.detach().numpy(), nbits=n_bits, signed=signed
+            getattr(model, layername_1).weight.detach().numpy(), nbits=n_bits, signed=signed
         )
-        weight_1 *= np.random.randint(low=0, high=2, size=model.conv_1.weight.shape)
+        weight_1 *= np.random.randint(low=0, high=2, size=weight_1.shape)
         weight_2, scale_2, zero_point_2 = create_quantize_friendly_weight(
-            model.conv_2.weight.detach().numpy(), nbits=n_bits, signed=signed
+            getattr(model, layername_2).weight.detach().numpy(), nbits=n_bits, signed=signed
         )
-        weight_2 *= np.random.randint(low=0, high=2, size=model.conv_2.weight.shape)
+        weight_2 *= np.random.randint(low=0, high=2, size=weight_2.shape)
         with torch.no_grad():
-            model.conv_1.weight = torch.nn.Parameter(torch.Tensor(weight_1))
-            model.conv_2.weight = torch.nn.Parameter(torch.Tensor(weight_2))
+            getattr(model, layername_1).weight = torch.nn.Parameter(torch.Tensor(weight_1))
+            getattr(model, layername_2).weight = torch.nn.Parameter(torch.Tensor(weight_2))
 
         model.register_buffer("_COREML_/metadata_version", torch.tensor(2))
-        model.conv_1.register_buffer("_COREML_/weight/compression_type", torch.tensor([1, 3]))
-        model.conv_1.register_buffer("_COREML_/weight/quantization_n_bits", torch.tensor(n_bits))
-        model.conv_1.register_buffer(
+        getattr(model, layername_1).register_buffer(
+            "_COREML_/weight/compression_type", torch.tensor([1, 3])
+        )
+        getattr(model, layername_1).register_buffer(
+            "_COREML_/weight/quantization_n_bits", torch.tensor(n_bits)
+        )
+        getattr(model, layername_1).register_buffer(
             "_COREML_/weight/quantization_scale", torch.from_numpy(scale_1)
         )
-        model.conv_1.register_buffer("_COREML_/weight/zero_point", torch.from_numpy(zero_point_1))
-        model.conv_2.register_buffer("_COREML_/weight/compression_type", torch.tensor([1, 3]))
-        model.conv_2.register_buffer("_COREML_/weight/quantization_n_bits", torch.tensor(n_bits))
-        model.conv_2.register_buffer(
+        getattr(model, layername_1).register_buffer(
+            "_COREML_/weight/zero_point", torch.from_numpy(zero_point_1)
+        )
+        getattr(model, layername_2).register_buffer(
+            "_COREML_/weight/compression_type", torch.tensor([1, 3])
+        )
+        getattr(model, layername_2).register_buffer(
+            "_COREML_/weight/quantization_n_bits", torch.tensor(n_bits)
+        )
+        getattr(model, layername_2).register_buffer(
             "_COREML_/weight/quantization_scale", torch.from_numpy(scale_2)
         )
-        model.conv_2.register_buffer("_COREML_/weight/zero_point", torch.from_numpy(zero_point_2))
+        getattr(model, layername_2).register_buffer(
+            "_COREML_/weight/zero_point", torch.from_numpy(zero_point_2)
+        )
 
-        traced_model = torch.jit.trace(model, torch_input_values)
         input_shape = [input.shape.to_list() for input in inputs]
         res = self.run_compare_torch(
             input_shape,
-            traced_model,
+            model,
             minimum_deployment_target=ct.target.iOS18,
             compute_unit=compute_unit,
+            frontend=frontend,
             converter=ct.convert,
             atol=1e-2,
         )
@@ -976,32 +1248,39 @@ class TestPytorchCarryCompressionInfo(TorchQuantizationBaseTest):
         for sparse_op in sparse_ops:
             assert types.builtin_to_string(sparse_op.mask.dtype) == "uint1"
             assert types.builtin_to_string(sparse_op.nonzero_data.dtype) == "fp32"
-            assert sparse_op.outputs[0].child_ops[0].op_type == "conv"
+            assert sparse_op.outputs[0].child_ops[0].op_type == "linear" if use_linear else "conv"
 
     @pytest.mark.parametrize(
-        "compute_unit, n_bits, group_size",
+        "compute_unit, n_bits, group_size, use_linear, frontend",
         itertools.product(
             compute_units,
             [4, 8],
             [0, 1, 2],
+            [True, False],
+            frontends,
         ),
     )
-    def test_joint_pruning_palettization(self, compute_unit, n_bits, group_size):
+    def test_joint_pruning_palettization(
+        self, compute_unit, n_bits, group_size, use_linear, frontend
+    ):
         model, inputs, torch_input_values, coreml_input_values = get_test_model_and_data(
-            multi_layer=True
+            multi_layer=True,
+            use_linear=use_linear,
         )
 
         # Make the weight sparse and also can be represented by lut.
-        weight_1 = create_unique_weight(model.conv_1.weight, nbits=n_bits) * np.random.randint(
-            low=0, high=2, size=model.conv_1.weight.shape
-        )
-        weight_2 = create_unique_weight(model.conv_2.weight, nbits=n_bits) * np.random.randint(
-            low=0, high=2, size=model.conv_2.weight.shape
-        )
+        layername_1 = "linear_1" if use_linear else "conv_1"
+        layername_2 = "linear_2" if use_linear else "conv_2"
+        weight_1 = create_unique_weight(
+            getattr(model, layername_1).weight, nbits=n_bits
+        ) * np.random.randint(low=0, high=2, size=getattr(model, layername_1).weight.shape)
+        weight_2 = create_unique_weight(
+            getattr(model, layername_2).weight, nbits=n_bits
+        ) * np.random.randint(low=0, high=2, size=getattr(model, layername_2).weight.shape)
 
         with torch.no_grad():
-            model.conv_1.weight = torch.nn.Parameter(torch.Tensor(weight_1))
-            model.conv_2.weight = torch.nn.Parameter(torch.Tensor(weight_2))
+            getattr(model, layername_1).weight = torch.nn.Parameter(torch.Tensor(weight_1))
+            getattr(model, layername_2).weight = torch.nn.Parameter(torch.Tensor(weight_2))
 
         lut_1_params = _quantization_passes.palettize_weights.blockwise_compress(
             weight_1,
@@ -1017,10 +1296,18 @@ class TestPytorchCarryCompressionInfo(TorchQuantizationBaseTest):
         )
 
         model.register_buffer("_COREML_/metadata_version", torch.tensor(1))
-        model.conv_1.register_buffer("_COREML_/weight/compression_type", torch.tensor([1, 2]))
-        model.conv_1.register_buffer("_COREML_/weight/lut", torch.tensor(lut_1_params.lut))
-        model.conv_2.register_buffer("_COREML_/weight/compression_type", torch.tensor([1, 2]))
-        model.conv_2.register_buffer("_COREML_/weight/lut", torch.tensor(lut_2_params.lut))
+        getattr(model, layername_1).register_buffer(
+            "_COREML_/weight/compression_type", torch.tensor([1, 2])
+        )
+        getattr(model, layername_1).register_buffer(
+            "_COREML_/weight/lut", torch.tensor(lut_1_params.lut)
+        )
+        getattr(model, layername_2).register_buffer(
+            "_COREML_/weight/compression_type", torch.tensor([1, 2])
+        )
+        getattr(model, layername_2).register_buffer(
+            "_COREML_/weight/lut", torch.tensor(lut_2_params.lut)
+        )
 
         traced_model = torch.jit.trace(model, torch_input_values)
         input_shape = [input.shape.to_list() for input in inputs]
@@ -1058,4 +1345,4 @@ class TestPytorchCarryCompressionInfo(TorchQuantizationBaseTest):
         for sparse_op in sparse_ops:
             assert types.builtin_to_string(sparse_op.mask.dtype) == "uint1"
             assert types.builtin_to_string(sparse_op.nonzero_data.dtype) == "fp32"
-            assert sparse_op.outputs[0].child_ops[0].op_type == "conv"
+            assert sparse_op.outputs[0].child_ops[0].op_type == "linear" if use_linear else "conv"

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_stateful_model.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_stateful_model.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 import coremltools as ct
-from coremltools._deps import _HAS_EXECUTORCH, _HAS_TORCH_EXPORT_API
+from coremltools.converters.mil.frontend.torch.utils import TorchFrontend
 from coremltools.converters.mil.mil import types
 from coremltools.converters.mil.mil.types.symbolic import any_symbolic
 from coremltools.converters.mil.testing_reqs import compute_units
@@ -25,15 +25,7 @@ from coremltools.proto import FeatureTypes_pb2 as ft
 
 torch = pytest.importorskip("torch")
 
-from .testing_utils import TorchFrontend, export_torch_model_to_frontend
-
-frontends = [TorchFrontend.TORCHSCRIPT]
-if _HAS_TORCH_EXPORT_API or _HAS_EXECUTORCH:
-    frontends.append(TorchFrontend.EXIR)
-
-ALTER_FRONTEND = [False]
-if _HAS_EXECUTORCH:
-    ALTER_FRONTEND.append(True)
+from .testing_utils import export_torch_model_to_frontend, frontends
 
 
 @pytest.fixture
@@ -239,16 +231,13 @@ def rank4_grayscale_input_model_with_buffer():
 )
 class TestStateConversionAPI:
     @pytest.mark.parametrize(
-        "compute_unit, frontend, alter_frontend",
-        itertools.product(compute_units, frontends, ALTER_FRONTEND),
+        "compute_unit, frontend",
+        itertools.product(compute_units, frontends),
     )
-    def test_state_model_api_example(self, compute_unit, frontend, alter_frontend):
+    def test_state_model_api_example(self, compute_unit, frontend):
         """
         Test the public API example.
         """
-        if frontend == TorchFrontend.TORCHSCRIPT and alter_frontend:
-            pytest.skip("Stateful conversion from torch.jit.script is not supported")
-
         class UpdateBufferModel(torch.nn.Module):
             def __init__(self):
                 super(UpdateBufferModel, self).__init__()
@@ -265,18 +254,18 @@ class TestStateConversionAPI:
             source_model,
             (torch.tensor([1, 2, 3], dtype=torch.float16),),
             frontend,
-            use_scripting=alter_frontend,
-            use_edge_dialect=alter_frontend,
         )
 
+        inputs = [ct.TensorType(shape=(3,))] if frontend == TorchFrontend.TORCHSCRIPT else None
+        states = (
+            [ct.StateType(wrapped_type=ct.TensorType(shape=(3,)), name="state_1")]
+            if frontend == TorchFrontend.TORCHSCRIPT
+            else None
+        )
         mlmodel = ct.convert(
             torch_model,
-            inputs=(None if frontend == TorchFrontend.EXIR else [ct.TensorType(shape=(3,))]),
-            states=(
-                None
-                if frontend == TorchFrontend.EXIR
-                else [ct.StateType(wrapped_type=ct.TensorType(shape=(3,)), name="state_1")]
-            ),
+            inputs=inputs,
+            states=states,
             minimum_deployment_target=ct.target.iOS18,
             convert_to="mlprogram",
             compute_units=compute_unit,

--- a/coremltools/converters/mil/frontend/torch/utils.py
+++ b/coremltools/converters/mil/frontend/torch/utils.py
@@ -118,7 +118,11 @@ TORCH_DTYPE_TO_MIL_DTYPE[torch.float64] = types.fp32
 
 class TorchFrontend(Enum):
     TORCHSCRIPT = 1
-    EXIR = 2
+    TORCHEXPORT = 2
+    EXECUTORCH = 3
+
+
+TORCH_EXPORT_BASED_FRONTENDS = (TorchFrontend.TORCHEXPORT, TorchFrontend.EXECUTORCH)
 
 
 def sanitize_op_kind(op_kind: str) -> str:
@@ -141,14 +145,21 @@ def sanitize_op_kind(op_kind: str) -> str:
     ) -> str:
         split = op_kind.split(deliminator)
         start = 1 if split[0] in {"aten", "prim"} and len(split) > 1 else 0
-        stop = -1 if split[-1] in {
-            "default",
-            "tensor",
-            "tensor_mode",
-            "scalar",
-            "tensor_scalar",
-        } and len(split) - start > 1 else len(split)
-        op_kind = deliminator.join(split[start : stop])
+        stop = (
+            -1
+            if split[-1]
+            in {
+                "default",
+                "int",
+                "tensor",
+                "tensor_mode",
+                "scalar",
+                "tensor_scalar",
+            }
+            and len(split) - start > 1
+            else len(split)
+        )
+        op_kind = deliminator.join(split[start:stop])
         return op_kind
 
     # 1. Lower case

--- a/coremltools/converters/mil/mil/operation.py
+++ b/coremltools/converters/mil/mil/operation.py
@@ -498,8 +498,8 @@ class Operation:
                 and not no_check_var_types
             ):
                 raise ValueError(
-                    f"New var type `{v_new.sym_type}` not a "
-                    f"subtype of existing var type `{v_old.sym_type}`."
+                    f"New var {v_new} doesn't have compatible "
+                    f"subtype of existing var `{v_old}`."
                 )
             v_old.remove_child_op(op, no_check_var_types)
 

--- a/coremltools/converters/mil/mil/ops/defs/iOS18/compression.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS18/compression.py
@@ -97,8 +97,8 @@ class constexpr_blockwise_shift_scale(Operation):
             scale_dim = scale.shape[rank_idx]
             if data_dim % scale_dim != 0:
                 raise ValueError(
-                    f"Number of scales along each dimension should be a factor of "
-                    f"corresponding dimension size of 'data'. However, at dim "
+                    "Number of scales along each dimension should be a factor of "
+                    "corresponding dimension size of 'data'. However, at dim "
                     f"{rank_idx}, the 'data' has {data_dim} while 'scale' has {scale_dim}."
                 )
 

--- a/coremltools/converters/mil/mil/passes/defs/cleanup/const_deduplication.py
+++ b/coremltools/converters/mil/mil/passes/defs/cleanup/const_deduplication.py
@@ -4,7 +4,7 @@
 #  found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
 import hashlib
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Union
 
 import numpy as np
 
@@ -46,13 +46,31 @@ class const_deduplication(AbstractGraphPass):
     (2) Deduplication of ``constexpr_*`` op:
 
         We consider a ``constexpr_*`` as duplicated if there exists such a previous ``constexpr_*`` that has the same ``op_type`` and input attributes.
+
+    Support options:
+
+    - ``const_threshold``: Skip deduplicating ``const`` ops that have smaller number of elements than a threshold. Defaults to ``100``. i.e. the constants with ``size < 100`` will not be deduplicated.
     """
 
-    NUMEL_THRESH = 100
+    # const with size < _const_threshold will not be deduplicated
+    _const_threshold = 100
+
+    # length of the number value hashkey
+    LENGTH_OF_HASHKEY = 100
     DTYPE2ATOL = {
         types.fp16: 6e-8,
         types.fp32: 1e-12,
     }
+
+    @property
+    def const_threshold(self) -> int:
+        return const_deduplication._const_threshold
+
+    @const_threshold.setter
+    def const_threshold(self, val: int) -> None:
+        if not isinstance(val, int):
+            raise ValueError(f"Expect option 'const_threshold' to be type of int. Got {type(val)}.")
+        const_deduplication._const_threshold = val
 
     def apply(self, prog) -> None:
         for f in prog.functions.values():
@@ -140,10 +158,10 @@ class const_deduplication(AbstractGraphPass):
                     hash_key = [op.op_type]
                 for v in op.inputs.values():
                     hash_key.append(v.dtype)
-                    if np.prod(v.shape) < const_deduplication.NUMEL_THRESH:
-                        hash_key.append(str(v.val))
-                    else:
+                    if v.val is None or const_deduplication.should_be_deduplicated(v.val):
                         hash_key.append(v)
+                    else:
+                        hash_key.append(str(v.val))
                 hash_key = tuple(hash_key)
                 if hash_key not in hashkey_2_duplicates:
                     hashkey_2_duplicates[hash_key] = [op.outputs[0]]
@@ -151,6 +169,15 @@ class const_deduplication(AbstractGraphPass):
                     hashkey_2_duplicates[hash_key].append(op.outputs[0])
 
         return {v[0]: v[1:] for v in hashkey_2_duplicates.values()}
+
+    @staticmethod
+    def should_be_deduplicated(val: Union[str, bool, np.ndarray]) -> bool:
+        assert val is not None, "val should only be type of (str, bool, np.ndarray)"
+        if isinstance(val, (str, bool)):
+            return False
+        if np.prod(val.shape) < const_deduplication._const_threshold:
+            return False
+        return True
 
     @staticmethod
     def find_constants(blocks: List[Block]) -> Dict[Var, List[Var]]:
@@ -173,16 +200,16 @@ class const_deduplication(AbstractGraphPass):
                 constant_var = op.outputs[0]
                 if isinstance(constant_var, ListVar):
                     continue
-                shape = constant_var.shape
 
-                numel = np.prod(shape)
-                if numel < const_deduplication.NUMEL_THRESH:
+                if not const_deduplication.should_be_deduplicated(constant_var.val):
                     continue
 
+                shape = constant_var.shape
                 dtype = constant_var.dtype
                 value = constant_var.val
+
                 hash = hashlib.sha1(
-                    np.ascontiguousarray(value.reshape(-1)[: const_deduplication.NUMEL_THRESH])
+                    np.ascontiguousarray(value.reshape(-1)[: const_deduplication.LENGTH_OF_HASHKEY])
                 ).hexdigest()
                 if hasattr(op, "weight_key"):
                     key = (op.weight_key, dtype, shape, hash)

--- a/coremltools/converters/mil/mil/passes/defs/optimize_elementwise_binary.py
+++ b/coremltools/converters/mil/mil/passes/defs/optimize_elementwise_binary.py
@@ -427,7 +427,10 @@ class rank0_expand_dims_swap(AbstractGraphPass):
 
         # check the expand_dim op has axes = [0]
         expand_dims_op = expand_dims_ops[0]
-        if expand_dims_op.axes.val != [0]:
+        expand_dims_op_axes_val = expand_dims_op.axes.val
+        if isinstance(expand_dims_op_axes_val, np.ndarray):
+            expand_dims_op_axes_val = expand_dims_op_axes_val.tolist()
+        if expand_dims_op_axes_val != [0]:
             return False
         ops_to_remove.append(expand_dims_op)
         ops_to_remove += other_ops

--- a/coremltools/converters/mil/mil/passes/defs/optimize_quantization.py
+++ b/coremltools/converters/mil/mil/passes/defs/optimize_quantization.py
@@ -1120,3 +1120,115 @@ class reorder_lut_per_channel_scale(AbstractGraphPass):
             new_var=scaled_output,
             force_replace=True,  # Need to force replace because it involves replacing constexpr op.
         )
+
+
+@register_pass(namespace="common")
+class canonicalize_quantized_lut_pattern(AbstractGraphPass):
+    """
+    The quantized lut (e.g. each entry in the LUT is int8) could be represented by two patterns:
+        Pattern 1:
+            lut(int8) -> constexpr_blockwise_shift_scale -> lut(fp16) -> constexpr_lut_to_dense -> dense(fp16)
+        Pattern 2:
+            lut(int8) -> constexpr_lut_to_dense -> dense(int8) -> constexpr_blockwise_shift_scale -> dense(fp16)
+    Those two patterns are mathematically equivalent when the quantization is per-tensor or per-channel.
+
+    This graph pass makes sure we always use one specific pattern by re-ordering the ops.
+    """
+
+    _DEQUANT_FIRST = True  # First dequantize and then depalettize (use pattern 1).
+
+    def apply(self, prog):
+        wrong_order_op1 = (
+            "constexpr_lut_to_dense" if self._DEQUANT_FIRST else "constexpr_blockwise_shift_scale"
+        )
+        wrong_order_op2 = (
+            "constexpr_blockwise_shift_scale" if self._DEQUANT_FIRST else "constexpr_lut_to_dense"
+        )
+
+        @block_context_manager
+        def apply_block(block: Block):
+            for op in list(block.operations):
+                for b in op.blocks:
+                    apply_block(b)
+                if op.op_type == wrong_order_op1 and len(op.outputs[0].child_ops) == 1:
+                    if op.outputs[0].child_ops[0].op_type == wrong_order_op2:
+                        self._reorder_quant_lut(block, op)
+
+        for f in prog.functions.values():
+            apply_block(f)
+
+    def _reorder_quant_lut(self, block: Block, old_op1: Operation):
+        """
+        Original order is op1 -> op2 -> output_op, and after reorder it becomes op2 -> op1 -> output_op.
+        Here op1 and op2 corresponds to either lut op or quant op, depending on `_DEQUANT_FIRST`.
+        """
+        old_op2 = old_op1.outputs[0].child_ops[0]
+        # If the old op has some meaningful info in the name (such as "conv1.weight"), we need to keep it.
+        new_op1_name = None if old_op1.op_type in old_op1.name else old_op1.name
+        new_op2_name = None if old_op2.op_type in old_op2.name else old_op2.name
+
+        if old_op1.op_type == "constexpr_blockwise_shift_scale":
+            # The old_op1 is dequant op and old_op2 is a lut op.
+            # The scale and offset from old_op1 is for lut, so the rank need to be adjusted.
+            if old_op1.scale.shape[-2:] != (1, 1):
+                raise AssertionError(
+                    "The quantization on lut must be per-tensor, so last two dims in `scale` should "
+                    f"both be 1, but got scale with shape {old_op1.scale.shape}."
+                )
+            new_scale_shape = old_op1.scale.shape[-2:]
+            scale = old_op1.scale.val.reshape(new_scale_shape)
+            offset = old_op1.offset
+            if offset is not None and offset.val is not None:
+                offset = old_op1.offset.val.reshape(new_scale_shape)
+
+            new_op1_args = {"indices": old_op2.indices, "lut": old_op1.data, "before_op": old_op2}
+            if new_op1_name is not None:
+                new_op1_args["name"] = new_op1_name
+            new_op1 = mb.constexpr_lut_to_dense(**new_op1_args)
+
+            new_op2_args = {"data": new_op1, "scale": scale, "offset": offset, "before_op": old_op2}
+            if new_op2_name is not None:
+                new_op2_args["name"] = new_op2_name
+            new_op2 = mb.constexpr_blockwise_shift_scale(**new_op2_args)
+        else:
+            # The old_op1 is lut op and old_op2 is a dequant op.
+            # The scale and offset from old_op2 is for depalettized weight, so the rank need to be adjusted to match
+            # the lut's rank.
+            new_scale_shape = old_op2.scale.shape + (1, 1)
+            scale = old_op2.scale.val.reshape(new_scale_shape)
+            offset = old_op2.offset
+            if offset is not None and offset.val is not None:
+                offset = old_op2.offset.val.reshape(new_scale_shape)
+
+            lut = old_op1.lut
+            if any(shape != 1 for shape in new_scale_shape):
+                # The lut need to be repeated when necessary. For example, in per-channel-scale, the lut has shape
+                # [16, 1, 16, 1], indices has shape [32, 1], and scale has shape [32, 1]. It means every two rows in
+                # the weight share a lut, and it's impossible to apply 32 scales to 16 lut tables. So we need to repeat
+                # the lut to become [32, 1, 16, 1], and then apply those 32 scales to each row.
+                lut = old_op1.lut.val
+                if lut is None:
+                    return  # Cannot handle the reording when the lut is not const.
+                for axis, (scale_shape, lut_shape) in enumerate(zip(new_scale_shape, lut.shape)):
+                    if scale_shape > lut_shape:
+                        if scale_shape % lut_shape != 0:
+                            return  # Skip when lut's shape cannot be repeated to match scale's shape.
+                        lut = np.repeat(lut, scale_shape // lut_shape, axis=axis)
+
+            new_op1_args = {"data": lut, "scale": scale, "offset": offset, "before_op": old_op1}
+            if new_op1_name is not None:
+                new_op1_args["name"] = new_op1_name
+            new_op1 = mb.constexpr_blockwise_shift_scale(**new_op1_args)
+
+            new_op2_args = {"indices": old_op1.indices, "lut": new_op1, "before_op": old_op1}
+            if new_op2_name is not None:
+                new_op2_args["name"] = new_op2_name
+            new_op2 = mb.constexpr_lut_to_dense(**new_op2_args)
+
+        block.replace_uses_of_var_after_op(
+            anchor_op=old_op2,
+            old_var=old_op2.outputs[0],
+            new_var=new_op2,
+            force_replace=True,  # Need to force replace because it involves replacing constexpr op.
+        )
+        block.remove_ops([old_op1, old_op2])

--- a/coremltools/converters/mil/mil/passes/defs/quantization.py
+++ b/coremltools/converters/mil/mil/passes/defs/quantization.py
@@ -9,6 +9,7 @@ from typing import Dict, Set, Text, Tuple
 
 import numpy as np
 
+from coremltools import _logger as logger
 from coremltools.converters.mil._deployment_compatibility import AvailableTarget
 from coremltools.converters.mil.input_types import TensorType
 from coremltools.converters.mil.mil import Block
@@ -293,6 +294,11 @@ class CastTypeQuantization(AbstractQuantizationPass):
                     len(var._child_ops) > 1
                     and casted_var_name in self.current_cache_vars()
                 ):
+                    if self.current_cache_vars()[casted_var_name].op.x != var:
+                        logger.warning(
+                            "The cached cast Var doesn't match the original Var. It's due to duplicated Var "
+                            f"names in the graph for {casted_var_name}."
+                        )
                     casted_inputs[param][i] = self.current_cache_vars()[casted_var_name]
                 else:
                     x = mb.cast(

--- a/coremltools/converters/mil/mil/passes/pass_pipeline.py
+++ b/coremltools/converters/mil/mil/passes/pass_pipeline.py
@@ -34,6 +34,7 @@ _COMMON_PASSES: List[Text] = [
     # after all quantization passes, since constexpr will not be further optimized
     # before const elimination, otherwise const dequantize would get bloated
     "common::dequantize_to_constexpr",
+    "common::canonicalize_quantized_lut_pattern",
     "common::const_elimination",
     "common::sanitize_input_output_names",
     "common::divide_to_multiply",
@@ -93,6 +94,7 @@ _COMMON_PASSES: List[Text] = [
     # in the network (while reducing the total number of transposes), and after passes such as "fuse_layernorm_or_instancenorm"
     # which detects patterns that involve redundant ops ("sub") etc.
     "common::remove_redundant_ops",
+    "common::dedup_op_and_var_names",  # Must be applied before "add_fp16_cast" because "add_fp16_cast" use unique name cache.
     "common::add_fp16_cast",  # Will be removed if compute precision is not FP16.
     "common::add_int16_cast",  # Will be removed if compute precision is not FP16.
     "common::update_output_dtypes",  # Must run again after `add_fp16_cast` and `add_int16_cast`.

--- a/coremltools/converters/mil/mil/passes/tests/test_cleanup_passes.py
+++ b/coremltools/converters/mil/mil/passes/tests/test_cleanup_passes.py
@@ -150,6 +150,138 @@ class TestConstDeduplication:
             assert const_ops[1].weight_id == 1
             assert const_ops[2].weight_id == 2
 
+    @staticmethod
+    def test_const_deduplication_with_threshold():
+        @mb.program(
+            input_specs=[
+                mb.TensorSpec(shape=(2,)),
+            ]
+        )
+        def prog(x):
+            # const_1 and const_2 will not be deduplicated
+            const_1 = [0.0]
+            const_2 = [0.0]
+            const_3 = [0.0, 1.0]
+            const_4 = [0.0, 1.0]
+
+            # 4 add ops
+            x = mb.add(x=x, y=const_1)
+            x = mb.add(x=x, y=const_2)
+            x = mb.add(x=x, y=const_3)
+            return mb.add(x=x, y=const_4)
+
+        graph_pass = PASS_REGISTRY["common::const_deduplication"]
+        graph_pass.const_threshold = 2
+        apply_pass_and_basic_check(prog, graph_pass)
+
+        # check the graph pass
+        assert_op_count_match(prog, expect=3, op="const")
+        const_ops = prog.functions["main"].find_ops(op_type="const")
+        assert const_ops[0].outputs[0].val.tolist() == [0.0]
+        assert const_ops[1].outputs[0].val.tolist() == [0.0]
+        assert const_ops[2].outputs[0].val.tolist() == [0.0, 1.0]
+
+    @staticmethod
+    def test_const_deduplication_with_threshold_for_pad():
+        @mb.program(
+            input_specs=[
+                mb.TensorSpec(shape=(100,)),
+            ]
+        )
+        def prog(x):
+            # both constant_val and pad inputs for two pad ops are deduplicaed
+            c_zero_scalar = np.float32(0.0)
+            x = mb.pad(x=x, pad=[1, 0], mode="constant", constant_val=c_zero_scalar)
+            return mb.pad(x=x, pad=[1, 0], mode="constant", constant_val=c_zero_scalar)
+
+        graph_pass = PASS_REGISTRY["common::const_deduplication"]
+        graph_pass.const_threshold = -1
+        apply_pass_and_basic_check(prog, graph_pass)
+
+        # check the graph pass
+        assert_op_count_match(prog, expect=4, op="const")
+        const_ops = prog.functions["main"].find_ops(op_type="const")
+        assert const_ops[0].outputs[0].val.tolist() == [1, 0]
+        assert const_ops[1].outputs[0].val == "constant"
+        assert const_ops[2].outputs[0].val == 0.0
+        assert const_ops[3].outputs[0].val == "constant"
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "constexpr_op",
+        CONSTEXPR_OPS,
+    )
+    def test_constexpr_deduplication_with_threshold(constexpr_op):
+        BATCH_DIM = 1
+        SEQUENCE_LENGTH = 1
+        ENCODING_DIM = 1
+        EMBEDDING_DIM = 2
+
+        @mb.program(
+            input_specs=[
+                mb.TensorSpec(shape=(BATCH_DIM, SEQUENCE_LENGTH, ENCODING_DIM)),
+                mb.TensorSpec(shape=(BATCH_DIM, SEQUENCE_LENGTH, ENCODING_DIM)),
+            ]
+        )
+        def prog(q, k):
+            weight_q = CONSTEXPR_FUNCS[constexpr_op]((EMBEDDING_DIM, ENCODING_DIM), seed=19)
+            weight_k = CONSTEXPR_FUNCS[constexpr_op]((EMBEDDING_DIM, ENCODING_DIM), seed=19)
+            q_e = mb.linear(x=q, weight=weight_q)
+            k_e = mb.linear(x=k, weight=weight_k)
+            return mb.matmul(x=q_e, y=k_e, transpose_y=True)
+
+        graph_pass = PASS_REGISTRY["common::const_deduplication"]
+        graph_pass.const_threshold = -1
+        apply_pass_and_basic_check(prog, graph_pass)
+
+        # check the graph pass
+        assert_op_count_match(prog, expect=1, op=constexpr_op)
+
+    @staticmethod
+    def test_str_should_not_be_deduplicated():
+        @mb.program(
+            input_specs=[
+                mb.TensorSpec(shape=(1,)),
+            ]
+        )
+        def prog(x):
+            x = mb.cast(x=x, dtype="int32")
+            return mb.cast(x=x, dtype="int32")
+
+        graph_pass = PASS_REGISTRY["common::const_deduplication"]
+        graph_pass.const_threshold = -1
+        apply_pass_and_basic_check(prog, graph_pass)
+
+        # check the graph pass
+        assert_op_count_match(prog, expect=2, op="const")
+        const_ops = prog.functions["main"].find_ops(op_type="const")
+        assert const_ops[0].outputs[0].val == "int32"
+        assert const_ops[1].outputs[0].val == "int32"
+
+    @staticmethod
+    def test_bool_should_not_be_deduplicated():
+        @mb.program(
+            input_specs=[
+                mb.TensorSpec(shape=(2,)),
+                mb.TensorSpec(shape=(2,)),
+            ]
+        )
+        def prog(x, y):
+            return mb.argsort(x=x, axis=-1, ascending=False), mb.argsort(
+                x=y, axis=-1, ascending=False
+            )
+
+        graph_pass = PASS_REGISTRY["common::const_deduplication"]
+        graph_pass.const_threshold = -1
+        apply_pass_and_basic_check(prog, graph_pass)
+
+        # check the graph pass
+        assert_op_count_match(prog, expect=3, op="const")
+        const_ops = prog.functions["main"].find_ops(op_type="const")
+        assert const_ops[0].outputs[0].val == -1
+        assert const_ops[1].outputs[0].val == False
+        assert const_ops[2].outputs[0].val == False
+
     @pytest.mark.parametrize(
         "q_weight_key, k_weight_key",
         itertools.product(

--- a/coremltools/optimize/__init__.py
+++ b/coremltools/optimize/__init__.py
@@ -3,9 +3,9 @@
 #  Use of this source code is governed by a BSD-3-clause license that can be
 #  found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
-from coremltools._deps import _HAS_TORCH
+from coremltools._deps import _IMPORT_CT_OPTIMIZE_TORCH
 
 from . import coreml
 
-if _HAS_TORCH:
+if _IMPORT_CT_OPTIMIZE_TORCH:
     from . import torch

--- a/coremltools/optimize/coreml/_quantization_passes.py
+++ b/coremltools/optimize/coreml/_quantization_passes.py
@@ -1307,6 +1307,8 @@ class linear_quantize_weights(AbstractCompressionPass):
         """
         Compress original_data into n-bit representation by quantization.
 
+        mode: "LINEAR_SYMMETRIC" or "LINEAR".
+
         block_sizes: Each element is the block size on corresponding axis for original_data.
 
         Returns None if the weight cannot be compressed (for example, the dim size on an axis is not

--- a/coremltools/optimize/torch/quantization/_backend_config.py
+++ b/coremltools/optimize/torch/quantization/_backend_config.py
@@ -29,7 +29,7 @@ from coremltools.optimize.torch.quantization._backend_config_utils import (
     activation_configs as _activation_configs,
 )
 from coremltools.optimize.torch.quantization._backend_config_utils import (
-    binary_op_act_configs as _binary_op_relu_configs,
+    binary_op_act_configs as _binary_op_act_configs,
 )
 from coremltools.optimize.torch.quantization._backend_config_utils import (
     binary_op_configs as _binary_op_configs,
@@ -724,7 +724,7 @@ def _add_act() -> _List[_BackendPatternConfig]:
     FakeQuant ->
     """
     acts = _mod_activations + _func_activations + (_nn.ReLU, _F.relu, _torch.relu)
-    return _binary_op_relu_configs(ops=[_operator.add, _torch.add], acts=list(acts))
+    return _binary_op_act_configs(ops=[_operator.add, _torch.add], acts=list(acts))
 
 
 @_BackendConfigRegistry.register()
@@ -741,7 +741,7 @@ def _mul_act() -> _List[_BackendPatternConfig]:
     FakeQuant ->
     """
     acts = _mod_activations + _func_activations + (_nn.ReLU, _F.relu, _torch.relu)
-    return _binary_op_relu_configs(ops=[_operator.mul, _torch.mul], acts=list(acts))
+    return _binary_op_act_configs(ops=[_operator.mul, _torch.mul], acts=list(acts))
 
 
 @_BackendConfigRegistry.register()
@@ -758,7 +758,23 @@ def _matmul_act() -> _List[_BackendPatternConfig]:
     FakeQuant ->
     """
     acts = _mod_activations + _func_activations + (_nn.ReLU, _F.relu, _torch.relu)
-    return _binary_op_relu_configs(ops=[_torch.matmul], acts=list(acts))
+    return _binary_op_act_configs(ops=[_torch.matmul], acts=list(acts))
+
+
+@_BackendConfigRegistry.register()
+def _einsum_act() -> _List[_BackendPatternConfig]:
+    """
+    float:
+    input_1 ->
+                einsum -> Act -> output
+    input_2 ->
+    qat:
+    FakeQuant ->
+                 einsum -> Act -> FakeQuant
+    FakeQuant ->
+    """
+    acts = _mod_activations + _func_activations + (_nn.ReLU, _F.relu, _torch.relu)
+    return _binary_op_act_configs(ops=[_torch.einsum], acts=list(acts))
 
 
 @_BackendConfigRegistry.register()
@@ -807,6 +823,21 @@ def _matmul() -> _List[_BackendPatternConfig]:
     FakeQuant ->
     """
     return _binary_op_configs(ops=[_torch.matmul])
+
+
+@_BackendConfigRegistry.register()
+def _einsum() -> _List[_BackendPatternConfig]:
+    """
+    float:
+    input_1 ->
+                einsum -> output
+    input_2 ->
+    qat:
+    FakeQuant ->
+                 einsum -> FakeQuant
+    FakeQuant ->
+    """
+    return _binary_op_configs(ops=[_torch.einsum])
 
 
 @_BackendConfigRegistry.register()

--- a/coremltools/optimize/torch/quantization/_utils.py
+++ b/coremltools/optimize/torch/quantization/_utils.py
@@ -3,6 +3,7 @@
 #  Use of this source code is governed by a BSD-3-clause license that can be
 #  found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
+import math
 import operator as _operator
 from collections import defaultdict
 from enum import Enum as _Enum
@@ -205,11 +206,23 @@ def get_quant_range(n_bits: int, dtype: _torch.dtype) -> _Tuple[int, int]:
         quant_max = max_q / 2 - 1
     return int(quant_min), int(quant_max)
 
+def get_n_bits_from_range(quant_min: int, quant_max: int) -> int:
+    """
+    Returns quantization n_bits for given quantization range
+    """
+    n_bits = int(math.log2(quant_max + 1))
+    if quant_min < 0:
+        n_bits += 1
 
-def register_compression_metadata(submodule, config):
+    return n_bits
+
+
+def register_compression_metadata(submodule):
     metadata = _CompressionMetadata("weight")
     metadata.compression_type = ["quantization"]
-    metadata.quantization_n_bits = config.weight_n_bits
+    metadata.quantization_n_bits = get_n_bits_from_range(
+        submodule.weight_quant_min, submodule.weight_quant_max
+    )
     metadata.quantization_scale = (
         submodule.weight_scale.detach().clone().unsqueeze(-1)
         if submodule.weight_axis == 0

--- a/coremltools/optimize/torch/quantization/quantizer.py
+++ b/coremltools/optimize/torch/quantization/quantizer.py
@@ -283,8 +283,7 @@ class LinearQuantizer(Quantizer):
         _register_metadata_version(finalized_model)
         for name, submodule in finalized_model.named_modules(remove_duplicate=True):
             if hasattr(submodule, "weight_scale"):
-                submod_config = self._config.get_module_config(name, submodule)
-                _register_compression_metadata(submodule, submod_config)
+                _register_compression_metadata(submodule)
 
         if model is None:
             self._model = finalized_model

--- a/coremltools/test/api/test_api_visibilities.py
+++ b/coremltools/test/api/test_api_visibilities.py
@@ -45,6 +45,8 @@ EXPECTED_MODULES = [
     "libmilstoragepython",
     "optimize",
     "StateType",
+    "ReshapeFrequency",
+    "SpecializationStrategy",
 ]
 
 

--- a/coremltools/test/neural_network/test_compiled_model.py
+++ b/coremltools/test/neural_network/test_compiled_model.py
@@ -3,12 +3,14 @@
 # Use of this source code is governed by a BSD-3-clause license that can be
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
+
+import itertools
 from shutil import copytree, rmtree
 from tempfile import TemporaryDirectory
 
 import pytest
 
-from coremltools import ComputeUnit
+from coremltools import ComputeUnit, ReshapeFrequency, SpecializationStrategy, utils
 from coremltools.models import CompiledMLModel, MLModel
 from coremltools.models.utils import compile_model, load_spec, save_spec
 from coremltools.proto import Model_pb2
@@ -35,6 +37,12 @@ class TestCompiledModel:
 
         spec.description.predictedFeatureName = 'y'
         self.spec = spec
+
+        self.compiled_model_path = compile_model(self.spec)
+
+
+    def teardown_class(self):
+        rmtree(self.compiled_model_path)
 
 
     def _test_compile_model_path(self, compiled_model_path, compute_units=ComputeUnit.ALL):
@@ -114,3 +122,24 @@ class TestCompiledModel:
             my_spec = load_spec(file_path)
             compiled_model_path = compile_model(my_spec)
         self._test_compile_model_path(compiled_model_path)
+
+
+    @pytest.mark.skipif(utils._macos_version() < (15, 0),
+                        reason="optimization hints available only on macOS15+")
+    @pytest.mark.parametrize("reshapeFrequency, specializationStrategy",
+                             itertools.product(
+                                 (ReshapeFrequency.Frequent, ReshapeFrequency.Infrequent, None),
+                                 (SpecializationStrategy.FastPrediction, SpecializationStrategy.Default, None),
+                             ))
+    def test_optimization_hints(self, reshapeFrequency, specializationStrategy):
+        optimization_hints={}
+        if reshapeFrequency is not None:
+            optimization_hints['reshapeFrequency'] = reshapeFrequency
+        if specializationStrategy is not None:
+            optimization_hints["specializationStrategy"] = specializationStrategy
+        if len(optimization_hints) == 0:
+            optimization_hints = None
+
+        m = CompiledMLModel(self.compiled_model_path, optimization_hints=optimization_hints)
+        assert isinstance(m, CompiledMLModel)
+        assert(m.optimization_hints == optimization_hints)

--- a/coremltools/test/neural_network/test_tf_numeric.py
+++ b/coremltools/test/neural_network/test_tf_numeric.py
@@ -165,11 +165,6 @@ class StressTest(CorrectnessTest):
         self.test_data_reorganize(cpu_only=True)
 
     def test_depthwise_conv(self, cpu_only=False):
-        if not cpu_only:
-            pytest.xfail(
-                "rdar://116060011: re-activate coremltools tests blocked by Core ML regressions"
-            )
-
         def get_coreml_model_depthwise(X, params, w):
             eval = True
             mlmodel = None

--- a/coremltools/test/optimize/torch/quantization/test_utils.py
+++ b/coremltools/test/optimize/torch/quantization/test_utils.py
@@ -6,7 +6,7 @@
 import pytest
 import torch
 
-from coremltools.optimize.torch.quantization._utils import get_quant_range
+from coremltools.optimize.torch.quantization._utils import get_n_bits_from_range, get_quant_range
 
 
 @pytest.mark.parametrize("n_bits", list(range(2, 8)))
@@ -37,3 +37,11 @@ def test_quant_range(dtype, n_bits):
     else:
         assert quant_min == signed_expected_values[n_bits][0]
         assert quant_max == signed_expected_values[n_bits][1]
+
+
+@pytest.mark.parametrize("n_bits", list(range(2, 8)))
+@pytest.mark.parametrize("dtype", [torch.quint8, torch.uint8, torch.qint8, torch.int8])
+def test_n_bits_from_range(dtype, n_bits):
+    quant_min, quant_max = get_quant_range(n_bits, dtype)
+    output_n_bits = get_n_bits_from_range(quant_min, quant_max)
+    assert output_n_bits == n_bits

--- a/coremltools/version.py
+++ b/coremltools/version.py
@@ -4,4 +4,4 @@
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
 
-__version__ = "8.0b2"  # VERSION_STRING
+__version__ = "8.0"  # VERSION_STRING

--- a/docs-guides/source/flexible-inputs.md
+++ b/docs-guides/source/flexible-inputs.md
@@ -162,6 +162,18 @@ You can open the saved ML package in Xcode and click the **Predictions** tab to 
 ![Range shape](images/range_shape.png)
 
 
+## Reshape Frequency Optimization Hint
+
+Setting the Reshape Frequency Optimization Hint to `Frequent` can allow flexible shaped models to run on the Neural Engine. This option can be set when loading your model:
+
+```python
+model = ct.model.MLModel(
+    'path/to/the/saved/model.mlmodel',
+    optimization_hints={ 'reshapeFrequency': ct.ReshapeFrequency.Frequent }
+)
+p```
+
+
 ## Enable Unbounded Ranges
 
 ```{warning}

--- a/docs-guides/source/model-prediction.md
+++ b/docs-guides/source/model-prediction.md
@@ -67,6 +67,17 @@ In previous versions of coremltools, you would restrict execution to the CPU by 
 
 For more information and values for this parameter, see [Set the Compute Units](load-and-convert-model.md#set-the-compute-units).
 
+## Fast Predictions
+
+A Model can be loaded using the Fast Prediction Optimization Hint. This will prefer the prediction latency at the potential cost of specialization time, memory footprint, and the disk space usage.
+
+```python
+model = ct.model.MLModel(
+    'path/to/the/saved/model.mlmodel',
+    optimization_hints={ 'specializationStrategy': ct.SpecializationStrategy.FastPrediction }
+)
+```
+
 ## Multi-array Prediction
 
 A model that takes a `MultiArray` input requires a NumPy array as an input with the `predict()` call. For example:

--- a/reqs/test.pip
+++ b/reqs/test.pip
@@ -31,15 +31,16 @@ gast==0.4.0
 
 # torch 2.3 dropped support for x86 macOS
 torch==2.2.0; platform_machine != "arm64"
-torch==2.3.0; platform_machine == "arm64"
-executorch==0.2.0; platform_machine == "arm64" and python_version >= '3.10' and python_version <= '3.11'
+torch==2.4.0; platform_machine == "arm64"
+executorch==0.3.0; platform_machine == "arm64" and python_version >= '3.10' and python_version <= '3.11'
 torchaudio==2.2.0; platform_machine != "arm64"
-torchaudio==2.3.0; platform_machine == "arm64"
+torchaudio==2.4.0; platform_machine == "arm64"
 torchvision==0.17.0; platform_machine != "arm64"
-torchvision==0.18.0; platform_machine == "arm64"
+torchvision==0.19.0; platform_machine == "arm64"
+torchao==0.4.0; platform_machine == "arm64" and python_version == '3.10'
 
-torchsr==1.0.4; platform_machine == "arm64" and python_version >= '3.10' and python_version <= '3.11'
-timm==0.6.13; platform_machine == "arm64" and python_version >= '3.10' and python_version <= '3.11'
+torchsr==1.0.4; platform_machine == "arm64"
+timm==0.6.13; platform_machine == "arm64"
 xgboost==1.4.2; platform_machine != "arm64"
 mock
 wrapt


### PR DESCRIPTION
CI: https://gitlab.com/coremltools1/coremltools/-/pipelines/1453101217

## Release Notes

Compare to 7.2 (including features from 8.0b1 and 8.0b2)

* Support for Latest Dependencies
    * Compatible with the latest `protobuf` python package which improves serialization latency.
    * Support `torch 2.4.0`, `numpy 2.0`, `scikit-learn 1.5`.
* Support stateful Core ML models
    * Updates to the converter to produce Core ML models with the State Type (new type introduced in iOS18/macOS15).
    * Adds a toy stateful attention example model to show how to use in-place kv-cache.
* Increase conversion support coverage for models produced by `torch.export`
    * Op translation support is at 56% parity with our mature `torch.jit.trace` converter
    * Representative deep learning models (mobilebert, deeplab, edsr, mobilenet, vit, inception, resnet, wav2letter, emformer) have been supported
    * Representative foundation models (llama, stable diffusion) have been supported
    * The model quantized by `ct.optimize.torch` could be exported by `torch.export` and then convert.
* New Compression Features
    * coremltools.optimize
        * Support compression with more granularities: blockwise quantization, grouped channel wise palettization
        * 4 bit weight quantization and 3 bit palettization
        * Support joint compression modes (8 bit look-up-tables for palettization, pruning+quantization/palettization)
        * Vector palettization by setting `cluster_dim > 1` and palettization with per channel scale by setting `enable_per_channel_scale=True`.
        * Experimental activation quantization (take a W16A16 Core ML model and produce a W8A8 model)
        * API updates for `coremltools.optimize.coreml` and `coremltools.optimize.torch` 
    * Support some models quantized by `torchao` (including the ops produced by torchao such as `_weight_int4pack_mm`).
    * Support more ops in `quantized_decomposed` namespace, such as `embedding_4bit`, etc.
* Support new ops and fixes bugs for old ops
    * compression related ops: `constexpr_blockwise_shift_scale`, `constexpr_lut_to_dense`, `constexpr_sparse_to_dense`, etc
    * updates to the GRU op
    * SDPA op `scaled_dot_product_attention`
    * `clip` op
* Updated the model loading API
    * Support `optimizationHints`.
    * Support loading specific functions for prediction.
* New utilities in `coremltools.utils`
    * `coremltools.utils.MultiFunctionDescriptor` and `coremltools.utils.save_multifunction`, for creating an mlprogram with multiple functions in it, that can share weights. 
    * `coremltools.models.utils.bisect_model` can break a large Core ML model into two smaller models with similar sizes.
    * `coremltools.models.utils.materialize_dynamic_shape_mlmodel` can convert a flexible input shape model into a static input shape model.
* Various other bug fixes, enhancements, clean ups and optimizations


