### PR TITLE
Enhance torch.zeros_like for GPU inference in dynamic shape

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,7 +11,7 @@ stages:
 
 check_python_flake8:
   tags:
-    - macOS13
+    - macOS_M1
   stage: check
   script:
     - python -m pip install --upgrade pip
@@ -37,21 +37,21 @@ check_python_flake8:
 build_wheel_macos_py37_intel:
   <<: *build_macos
   tags:
-    - macOS13
+    - macOS_intel
   variables:
     PYTHON: "3.7"
 
 build_wheel_macos_py39_intel:
   <<: *build_macos
   tags:
-    - macOS13
+    - macOS_intel
   variables:
     PYTHON: "3.9"
 
 build_wheel_macos_py310:
   <<: *build_macos
   tags:
-    - macOS13_M1
+    - macOS_M1
   variables:
     PYTHON: "3.10"
 
@@ -71,7 +71,7 @@ build_wheel_macos_py310:
 test_py39_coremltools_test_intel:
   <<: *test_macos_pkg
   tags:
-    - macOS13
+    - macOS_intel
   dependencies:
     - build_wheel_macos_py39_intel
   variables:
@@ -83,7 +83,7 @@ test_py39_coremltools_test_intel:
 test_py39_pytorch_intel:
   <<: *test_macos_pkg
   tags:
-    - macOS13
+    - macOS_intel
   dependencies:
     - build_wheel_macos_py39_intel
   variables:
@@ -95,7 +95,7 @@ test_py39_pytorch_intel:
 test_py37_tf1_intel:
   <<: *test_macos_pkg
   tags:
-    - macOS13
+    - macOS_intel
   dependencies:
     - build_wheel_macos_py37_intel
   variables:
@@ -107,7 +107,7 @@ test_py37_tf1_intel:
 test_py39_tf2_intel-1:
   <<: *test_macos_pkg
   tags:
-    - macOS13
+    - macOS_intel
   dependencies:
     - build_wheel_macos_py39_intel
   variables:
@@ -119,7 +119,7 @@ test_py39_tf2_intel-1:
 test_py39_tf2_intel-2:
   <<: *test_macos_pkg
   tags:
-    - macOS13
+    - macOS_intel
   dependencies:
     - build_wheel_macos_py39_intel
   variables:
@@ -131,7 +131,7 @@ test_py39_tf2_intel-2:
 test_py39_mil_intel:
   <<: *test_macos_pkg
   tags:
-    - macOS13
+    - macOS_intel
   dependencies:
     - build_wheel_macos_py39_intel
   variables:
@@ -143,7 +143,7 @@ test_py39_mil_intel:
 test_py39_backends_intel:
   <<: *test_macos_pkg
   tags:
-    - macOS13
+    - macOS_intel
   dependencies:
     - build_wheel_macos_py39_intel
   variables:
@@ -155,7 +155,7 @@ test_py39_backends_intel:
 test_py39_shapes_intel:
   <<: *test_macos_pkg
   tags:
-    - macOS13
+    - macOS_intel
   dependencies:
     - build_wheel_macos_py39_intel
   variables:
@@ -167,7 +167,7 @@ test_py39_shapes_intel:
 test_py39_milproto_intel:
   <<: *test_macos_pkg
   tags:
-    - macOS13
+    - macOS_intel
   dependencies:
     - build_wheel_macos_py39_intel
   variables:
@@ -181,7 +181,7 @@ test_py39_milproto_intel:
 test_py310_coremltools_test:
   <<: *test_macos_pkg
   tags:
-    - macOS13_M1
+    - macOS_M1
   dependencies:
     - build_wheel_macos_py310
   variables:
@@ -193,7 +193,7 @@ test_py310_coremltools_test:
 test_py310_pytorch:
   <<: *test_macos_pkg
   tags:
-    - macOS13_M1
+    - macOS_M1
   dependencies:
     - build_wheel_macos_py310
   variables:
@@ -205,7 +205,7 @@ test_py310_pytorch:
 test_py310_tf2-1:
   <<: *test_macos_pkg
   tags:
-    - macOS13_M1
+    - macOS_M1
   dependencies:
     - build_wheel_macos_py310
   variables:
@@ -217,7 +217,7 @@ test_py310_tf2-1:
 test_py310_tf2-2:
   <<: *test_macos_pkg
   tags:
-    - macOS13_M1
+    - macOS_M1
   dependencies:
     - build_wheel_macos_py310
   variables:
@@ -229,7 +229,7 @@ test_py310_tf2-2:
 test_py310_mil:
   <<: *test_macos_pkg
   tags:
-    - macOS13_M1
+    - macOS_M1
   dependencies:
     - build_wheel_macos_py310
   variables:
@@ -241,7 +241,7 @@ test_py310_mil:
 test_py310_backends:
   <<: *test_macos_pkg
   tags:
-    - macOS13_M1
+    - macOS_M1
   dependencies:
     - build_wheel_macos_py310
   variables:
@@ -253,7 +253,7 @@ test_py310_backends:
 test_py310_shapes:
   <<: *test_macos_pkg
   tags:
-    - macOS13_M1
+    - macOS_M1
   dependencies:
     - build_wheel_macos_py310
   variables:
@@ -265,7 +265,7 @@ test_py310_shapes:
 test_py310_milproto:
   <<: *test_macos_pkg
   tags:
-    - macOS13_M1
+    - macOS_M1
   dependencies:
     - build_wheel_macos_py310
   variables:
@@ -283,18 +283,18 @@ test_py310_milproto:
 #########################################################################
 build_documentation:
   tags:
-    - macOS13
+    - macOS_M1
   stage: test
   script:
     - export PATH=$PATH:/opt/anaconda/bin/
     - bash -e scripts/build_docs.sh --wheel-path=${WHEEL_PATH} --python=${PYTHON}
   dependencies:
-    - build_wheel_macos_py39_intel
+    - build_wheel_macos_py310
   artifacts:
     when: always
     expire_in: 2 weeks
     paths:
       - _build/html/
   variables:
-    WHEEL_PATH: build/dist/coremltools*cp39-none-macosx_10_15_x86_64.whl
-    PYTHON: "3.9"
+    WHEEL_PATH: build/dist/coremltools*cp310-none-macosx_11_0_arm64.whl
+    PYTHON: "3.10"

--- a/coremltools/converters/mil/backend/mil/test_load.py
+++ b/coremltools/converters/mil/backend/mil/test_load.py
@@ -64,26 +64,15 @@ class TestWeightFileSerialization:
             minimum_deployment_target=opset_version,
             pass_pipeline=pipeline,
         )
-        saved_package_path = tempfile.mkdtemp(suffix=".mlpackage")
-        mlmodel.save(saved_package_path)
 
         # check the weights are serialized as file value
         if ct.utils._macos_version() >= (15, 0):
-            with tempfile.TemporaryDirectory() as serialize_dir:
-                os.system(f"coremlcompiler compile {saved_package_path} {serialize_dir}")
-                model_name_with_extension = os.path.basename(saved_package_path)
-                model_name_wo_extension, _ = os.path.splitext(model_name_with_extension)
-                mil_file = open(
-                    os.path.join(serialize_dir, f"{model_name_wo_extension}.mlmodelc", "model.mil")
-                )
-                mil_txt = mil_file.read()
-                if should_serialize_weight:
-                    assert f"tensor<{dtype}, [1000]>(BLOBFILE" in mil_txt
-                else:
-                    assert f"tensor<{dtype}, [1000]>(BLOBFILE" not in mil_txt
-
-        # cleanup
-        shutil.rmtree(saved_package_path)
+            mil_file = open(os.path.join(mlmodel.get_compiled_model_path(), "model.mil"))
+            mil_txt = mil_file.read()
+            if should_serialize_weight:
+                assert f"tensor<{dtype}, [1000]>(BLOBFILE" in mil_txt
+            else:
+                assert f"tensor<{dtype}, [1000]>(BLOBFILE" not in mil_txt
 
 
 class TestMILFlexibleShapes:

--- a/coremltools/converters/mil/frontend/tensorflow/test/test_ops.py
+++ b/coremltools/converters/mil/frontend/tensorflow/test/test_ops.py
@@ -1935,6 +1935,11 @@ class TestConvTranspose(TensorFlowBaseTest):
         if _macos_version() < (12, 0) and strides == (1, 2, 3) and padding == "VALID":
             # Behavior changed in macOS 12
             return
+        if (platform.machine() == "x86_64" and compute_unit == ct.ComputeUnit.CPU_ONLY
+          and backend == ('mlprogram', 'fp16') and padding == "SAME"
+          and DHWkDkHkW in ((4, 6, 8, 2, 3, 1), (5, 7, 9, 2, 4, 2))
+          and strides == (1, 2, 3) and dilations == (1, 1, 1) and dynamic):
+            pytest.xfail("rdar://137132151")
 
         D, H, W, kD, kH, kW = DHWkDkHkW
         N, C_in, C_out = 2, 1, 2

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -1501,7 +1501,7 @@ def rrelu(context, node):
 def softplus(context, node):
     inputs = _get_inputs(context, node, expected=3)
     x, beta, threshold = inputs[0], inputs[1].val, inputs[2].val
-    
+
     np_type = nptype_from_builtin(x.dtype)
     b = mb.const(val=np_type(beta))
     t = mb.const(val=np_type(threshold))
@@ -1523,7 +1523,7 @@ def softplus(context, node):
         # And this implementation is slightly faster than mb.softplus * mask for inference on the GPU.
         xb = mb.mul(x=x, y=b)
         m = mb.less_equal(x=xb, y=t)
-        
+
         x_dtype = TYPE_TO_DTYPE_STRING[x.dtype]
         m0 = mb.cast(x=m, dtype=x_dtype)
         xb0 = mb.mul(x=xb, y=m0)
@@ -1531,10 +1531,10 @@ def softplus(context, node):
         exp0 = mb.add(x=exp, y=m0)
         log = mb.log(x=exp0)
         log0 = mb.real_div(x=log, y=b)
-        
+
         m1 = mb.logical_not(x=m)
         x0 = mb.mul(x=x, y=mb.cast(x=m1, dtype=x_dtype))
-        
+
         res = mb.add(x=log0, y=x0)
     context.add(res, torch_name=node.name)
 
@@ -2383,7 +2383,8 @@ def cat(context, node):
         # PyTorch can have empty tensor, which is then ignored
         # However, CoreML does not allow such empty tensor, so remove them now
         if np.any([is_tensor_empty(x) for x in xs]):
-            xs = [x for x in xs if not is_tensor_empty(x)]
+            filtered_xs = [x for x in xs if not is_tensor_empty(x)]
+            xs = filtered_xs if len(filtered_xs) > 0 else [xs[0]]
 
         dim = inputs[1] if nargs > 1 else 0
 

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -7562,3 +7562,13 @@ def multinomial(context, node):
     # Based on PyTorch documentations, the input to `torch.multinomial` is probability, not logit.
     x = mb.random_categorical(x=x, size=num_samples, mode="probs", name=node.name)
     context.add(x)
+
+
+@register_torch_op
+def one_hot(context, node):
+    inputs = _get_inputs(context, node, expected=2)
+    labels = inputs[0]
+    num_classes = inputs[1].val
+    
+    res = mb.one_hot(indices=labels, one_hot_vector_size=num_classes, name=node.name)
+    context.add(res)

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_export_conversion_api.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_export_conversion_api.py
@@ -80,9 +80,6 @@ class TestTorchExportConversionAPI(TorchBaseTest):
         itertools.product(compute_units, backends, frontends),
     )
     def test_dynamic_input(self, compute_unit, backend, frontend):
-        if ct.utils._macos_version() <= (14, 2):
-            pytest.xfail("rdar://135925921 ([CI] Upgrade External CI Machine OS)")
-
         class Model(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -158,9 +155,6 @@ class TestExecuTorchExamples(TorchBaseTest):
         itertools.product(compute_units, backends, frontends, (True, False)),
     )
     def test_mul(self, compute_unit, backend, frontend, dynamic):
-        if ct.utils._macos_version() <= (14, 2) and dynamic:
-            pytest.xfail("rdar://135925921 ([CI] Upgrade External CI Machine OS)")
-
         class MulModule(torch.nn.Module):
             def forward(self, input, other):
                 return input * other
@@ -242,9 +236,6 @@ class TestExecuTorchExamples(TorchBaseTest):
         itertools.product(compute_units, backends, frontends, (True, False)),
     )
     def test_linear(self, compute_unit, backend, frontend, dynamic):
-        if ct.utils._macos_version() <= (14, 2) and dynamic:
-            pytest.xfail("rdar://135925921 ([CI] Upgrade External CI Machine OS)")
-
         class LinearModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -424,9 +415,6 @@ class TestExecuTorchExamples(TorchBaseTest):
         itertools.product(compute_units, backends, frontends, (True, False)),
     )
     def test_add_mul(self, compute_unit, backend, frontend, dynamic):
-        if ct.utils._macos_version() <= (14, 2) and dynamic:
-            pytest.xfail("rdar://135925921 ([CI] Upgrade External CI Machine OS)")
-
         class AddMulModule(torch.nn.Module):
             def forward(self, a, x, b):
                 y = torch.mm(a, x)
@@ -542,9 +530,6 @@ class TestExecuTorchExamples(TorchBaseTest):
         itertools.product(compute_units, backends, frontends, (True, False)),
     )
     def test_softmax(self, compute_unit, backend, frontend, dynamic):
-        if ct.utils._macos_version() <= (14, 2) and dynamic:
-            pytest.xfail("rdar://135925921 ([CI] Upgrade External CI Machine OS)")
-
         class SoftmaxModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -3657,6 +3657,24 @@ class TestConcat(TorchBaseTest):
     @pytest.mark.parametrize(
         "compute_unit, backend, frontend", itertools.product(compute_units, backends, frontends)
     )
+    def test_cat_with_empty_tensors(self, compute_unit, backend, frontend):
+        class TestNet(nn.Module):
+            def forward(self, x):
+                y = torch.cat((torch.empty(1, 0, 3), torch.empty(1, 0, 3)), axis=1)
+                return torch.cat([x, y], axis=1)
+
+        model = TestNet()
+        self.run_compare_torch(
+            (1, 2, 3),
+            model,
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+        )
+
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend", itertools.product(compute_units, backends, frontends)
+    )
     def test_cat_input_types_promotion(self, compute_unit, backend, frontend):
         if frontend == TorchFrontend.EXECUTORCH:
             pytest.skip("executorch does not allow mixed dtypes")
@@ -12400,7 +12418,7 @@ class TestSoftplus(TorchBaseTest):
             backend=backend,
             compute_unit=compute_unit,
         )
-    
+
     @pytest.mark.parametrize(
         "compute_unit, backend",
         itertools.product(compute_units, backends),
@@ -12408,13 +12426,13 @@ class TestSoftplus(TorchBaseTest):
     def test_softplus_no_default(self, compute_unit, backend):
         model = ModuleWrapper(function=torch.nn.functional.softplus, kwargs={"beta": 2, "threshold": 2}).eval()
         self.run_compare_torch(
-            torch.arange(0, 3).float() + 0.5, 
-            model, 
-            backend=backend, 
+            torch.arange(0, 3).float() + 0.5,
+            model,
+            backend=backend,
             compute_unit=compute_unit,
             input_as_shape=False,
         )
-    
+
     @pytest.mark.parametrize(
         "compute_unit, backend, value",
         itertools.product(compute_units, backends, [1.0, 3.0, 1e5, 1e7, 1e9]),

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -12428,3 +12428,21 @@ class TestSoftplus(TorchBaseTest):
             compute_unit=compute_unit,
             input_as_shape=False,
         )
+
+
+class TestOneHot(TorchBaseTest):
+    @pytest.mark.parametrize(
+        "compute_unit, backend, num_classes, rank",
+        itertools.product(compute_units, backends, range(1, 5), range(1, 5)),
+    )
+    def test_one_hot(self, compute_unit, backend, num_classes, rank):
+        model = ModuleWrapper(function=torch.nn.functional.one_hot, kwargs={"num_classes": num_classes}).eval()
+        shape = torch.randint(1, 10, (rank,)).tolist()
+        labels = torch.randint(0, num_classes, shape)
+        self.run_compare_torch(
+            torch.LongTensor(labels),
+            model,
+            backend=backend,
+            compute_unit=compute_unit,
+            input_as_shape=False,
+        )

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -467,6 +467,10 @@ class TestFrac(TorchBaseTest):
             backend=backend,
             compute_unit=compute_unit,
             rand_range=(-10.0, 10.0),
+
+            # Casting from fp32 to fp16 can produce very different result when value close to whole number.
+            input_dtype=np.float16,
+            minimum_deployment_target=ct.target.iOS16,
         )
 
 
@@ -860,7 +864,7 @@ class TestWeightNorm(TorchBaseTest):
         ),
     )
     def test_conv3d(self, compute_unit, backend):
-        x = torch.randn(20, 16, 5, 50, 100)
+        x = torch.randn(15, 16, 5, 20, 10)
 
         for dim in (None,) + tuple(range(-5, 5)):
             model = nn.utils.weight_norm(nn.Conv3d(16, 33, 3), dim=dim)
@@ -6243,8 +6247,8 @@ class TestMatMul(TorchBaseTest):
         ),
     )
     def test_bmm_with_fp16_inputs(self, compute_unit, backend, frontend):
-        if platform.machine() == "x86_64" and ct.utils._macos_version() <= (14, 2):
-            pytest.xfail("rdar://135925921 ([CI] Upgrade External CI Machine OS)")
+        if platform.machine() == "x86_64":
+            pytest.xfail("rdar://137157493")
 
         class TestModel(torch.nn.Module):
             def forward(self, x, y):

--- a/coremltools/converters/mil/mil/builder.py
+++ b/coremltools/converters/mil/mil/builder.py
@@ -90,8 +90,8 @@ class Builder:
             err_msg = f"Cannot add const {val}"
             if any_symbolic(val):
                 err_msg += (
-                    "\nPython native vals (list, tuple), np.array that are"
-                    + "operation inputs cannot have symbolic values. Consider feeding"
+                    "\nPython native vals (list, tuple), np.array that are "
+                    + "operation inputs cannot have symbolic values. Consider feeding "
                     + "symbolic shape in through placeholder and use mb.shape() "
                     + f"operator. Input {name}: {val}"
                 )

--- a/coremltools/models/model.py
+++ b/coremltools/models/model.py
@@ -626,6 +626,9 @@ class MLModel:
         the compiled model to persist, you need to make a copy.
 
         """
+        if self.__proxy__ is None:
+            raise Exception("This model was not loaded or compiled with the Core ML Framework.")
+
         return self.__proxy__.get_compiled_model_path()
 
 
@@ -804,6 +807,8 @@ class MLModel:
         """
         if not _is_macos() or _macos_version() < (15, 0):
             raise Exception("State functionality is only supported on macOS 15+")
+        if self.__proxy__ is None:
+            raise Exception("This model was not loaded with the Core ML Framework. Cannot get state.")
 
         return MLState(self.__proxy__.newState())
 

--- a/coremltools/models/nearest_neighbors/builder.py
+++ b/coremltools/models/nearest_neighbors/builder.py
@@ -226,7 +226,7 @@ class KNearestNeighborsClassifierBuilder:
         """
         return self.spec.description.metadata.license
 
-    @author.setter
+    @license.setter
     def license(self, license):
         """
         Add a license for the KNearestNeighborsClassifier model.

--- a/coremltools/test/optimize/coreml/test_post_training_quantization.py
+++ b/coremltools/test/optimize/coreml/test_post_training_quantization.py
@@ -5,6 +5,7 @@
 
 import itertools
 import logging
+import platform
 import re
 import shutil
 import tempfile
@@ -392,6 +393,9 @@ class TestLinearQuantizeWeights:
         ),
     )
     def test_blockwise_quanitzation_stress(compute_unit, backend, mode, nbits, signed, block_size):
+        if platform.machine() == "x86_64":
+            pytest.xfail("rdar://137153993 ([CI] Quantization Tests Failing only on *native* x86_64 (not with Rosetta))")
+
         model, inputs, torch_input_values, coreml_input_values = get_test_model_and_data()
         torchmodel = torch.jit.trace(model, torch_input_values)
         mlmodel = ct.convert(
@@ -461,6 +465,9 @@ class TestLinearQuantizeWeights:
         ),
     )
     def test_per_tensor_quantization_with_blockwise_op(compute_unit, backend, mode, nbits):
+        if platform.machine() == "x86_64":
+            pytest.xfail("rdar://137153993 ([CI] Quantization Tests Failing only on *native* x86_64 (not with Rosetta))")
+
         op_config = cto.coreml.OpLinearQuantizerConfig(
             mode=mode, dtype=f"int{nbits}", granularity="per_tensor"
         )
@@ -1050,6 +1057,9 @@ class TestPalettizeWeights:
     def test_channelwise_palettization_stress(
         compute_unit, backend, mode, nbits, channel_axis, channel_group_size
     ):
+        if platform.machine() == "x86_64":
+            pytest.xfail("rdar://137153993 ([CI] Quantization Tests Failing only on *native* x86_64 (not with Rosetta))")
+
         model, inputs, torch_input_values, coreml_input_values = get_test_model_and_data()
         torchmodel = torch.jit.trace(model, torch_input_values)
         mlmodel = ct.convert(
@@ -1347,6 +1357,9 @@ class TestPalettizeWeights:
     )
     def test_palettization_pcs(self, compute_unit, backend):
         """Test the palettization with per-channel-scale."""
+        if platform.machine() == "x86_64":
+            pytest.xfail("rdar://137153993 ([CI] Quantization Tests Failing only on *native* x86_64 (not with Rosetta))")
+
         model, inputs, torch_input_values, coreml_input_values = get_test_model_and_data()
 
         torchmodel = torch.jit.trace(model, torch_input_values)

--- a/docs/source/coremltools.converters.mil.mil.ops.defs.rst
+++ b/docs/source/coremltools.converters.mil.mil.ops.defs.rst
@@ -48,7 +48,7 @@ classify
 
    .. autoclass:: classify
 
-constexpr_ops
+constexpr_ops (iOS 16+)
 ---------------------------------------------------
 
 .. automodule:: coremltools.converters.mil.mil.ops.defs.iOS16.constexpr_ops
@@ -57,6 +57,18 @@ constexpr_ops
    .. autoclass:: constexpr_cast
    .. autoclass:: constexpr_lut_to_dense
    .. autoclass:: constexpr_sparse_to_dense
+
+constexpr_ops (iOS 18+)
+---------------------------------------------------------------------
+
+.. automodule:: coremltools.converters.mil.mil.ops.defs.iOS18.compression
+
+   .. autoclass:: constexpr_blockwise_shift_scale
+   .. autoclass:: constexpr_lut_to_dense
+   .. autoclass:: constexpr_sparse_to_dense
+   .. autoclass:: constexpr_lut_to_sparse
+   .. autoclass:: constexpr_sparse_blockwise_shift_scale
+   .. autoclass:: constexpr_cast
 
 control\_flow
 ------------------------------------------------------------
@@ -280,6 +292,14 @@ recurrent (iOS 17+)
    .. autoclass:: gru
    .. autoclass:: lstm
    .. autoclass:: rnn
+
+recurrent (iOS 18+)
+--------------------------------------------------------
+
+.. automodule:: coremltools.converters.mil.mil.ops.defs.iOS18.recurrent
+
+   .. autoclass:: gru
+
 
 reduction (iOS 15+)
 --------------------------------------------------------

--- a/reqs/docs.pip
+++ b/reqs/docs.pip
@@ -1,7 +1,7 @@
 Babel
 MarkupSafe
 Pygments
-Sphinx==7.3.1
+Sphinx==7.4.7
 alabaster
 certifi
 chardet


### PR DESCRIPTION
The old implementation of `torch.zeros_like` for dynamic shape will make model fallback to CPU.

`mb.shape` is CPU only op.

`mb.fill_like` forces subsequent inference to run on the CPU.

```Python
import torch
from torch import nn
from torch.nn import functional as F
from typing import Final
import coremltools as ct

var_dim: Final[ct.RangeDim] = ct.RangeDim(1, 1_000)

class Model(nn.Module):
    def forward(self, x):
        x0 = x + 1
        x1 = torch.zeros_like(x0) + 1 
        return x1 + F.softmax(x)

x = torch.randn(1, 3, 5)
traced_model = torch.jit.trace(Model().eval(), (x))
mlmodel = ct.convert(
    traced_model,
    inputs=[ct.TensorType(name="input", shape=ct.Shape([1, 3, var_dim]))],
    # minimum_deployment_target=ct.target.iOS16,
)
mlmodel.save("tmp.mlpackage")
```

Berfor:

- mb.fill

![old_i15](https://github.com/user-attachments/assets/316fc1db-9bfc-4aa2-9cf7-4ce4a8248852)

- mb.fill_like

![old_i16](https://github.com/user-attachments/assets/01b95b71-13bc-4297-b950-51a68073562f)

After:

![new_cpu](https://github.com/user-attachments/assets/4d02da0f-4082-43d0-b1de-fd2e4da2e4f9)

![new_gpu](https://github.com/user-attachments/assets/f54f5a90-efe4-4927-bd6c-e29dcaeaf9d4)
