### PR TITLE
[Doc] Update API doc and Sphinx version

### DIFF
--- a/docs/source/coremltools.converters.mil.mil.ops.defs.rst
+++ b/docs/source/coremltools.converters.mil.mil.ops.defs.rst
@@ -48,7 +48,7 @@ classify
 
    .. autoclass:: classify
 
-constexpr_ops
+constexpr_ops (iOS 16+)
 ---------------------------------------------------
 
 .. automodule:: coremltools.converters.mil.mil.ops.defs.iOS16.constexpr_ops
@@ -57,6 +57,18 @@ constexpr_ops
    .. autoclass:: constexpr_cast
    .. autoclass:: constexpr_lut_to_dense
    .. autoclass:: constexpr_sparse_to_dense
+
+constexpr_ops (iOS 18+)
+---------------------------------------------------------------------
+
+.. automodule:: coremltools.converters.mil.mil.ops.defs.iOS18.compression
+
+   .. autoclass:: constexpr_blockwise_shift_scale
+   .. autoclass:: constexpr_lut_to_dense
+   .. autoclass:: constexpr_sparse_to_dense
+   .. autoclass:: constexpr_lut_to_sparse
+   .. autoclass:: constexpr_sparse_blockwise_shift_scale
+   .. autoclass:: constexpr_cast
 
 control\_flow
 ------------------------------------------------------------
@@ -280,6 +292,14 @@ recurrent (iOS 17+)
    .. autoclass:: gru
    .. autoclass:: lstm
    .. autoclass:: rnn
+
+recurrent (iOS 18+)
+--------------------------------------------------------
+
+.. automodule:: coremltools.converters.mil.mil.ops.defs.iOS18.recurrent
+
+   .. autoclass:: gru
+
 
 reduction (iOS 15+)
 --------------------------------------------------------

--- a/reqs/docs.pip
+++ b/reqs/docs.pip
@@ -1,7 +1,7 @@
 Babel
 MarkupSafe
 Pygments
-Sphinx==7.3.1
+Sphinx==7.4.7
 alabaster
 certifi
 chardet


### PR DESCRIPTION
This PR includes:
- Add missing IOS18 ops into API doc source (the iOS18 compression ops and recurrent ops).
- Update Sphinx version to avoid regression in future doc update. The current documentation is produced by the latest 7.X Sphinx (`Sphinx==7.4.7`) as shown in https://github.com/apple/coremltools/pull/2343. 

Preview: https://junpeiz.github.io/coremltools/source/coremltools.converters.mil.mil.ops.defs.html
CI: https://gitlab.com/coremltools1/coremltools/-/pipelines/1462899116