### PR TITLE
support for zero dimension tensors as an input for cat operation

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -2384,7 +2384,7 @@ def cat(context, node):
         # However, CoreML does not allow such empty tensor, so remove them now
         if np.any([is_tensor_empty(x) for x in xs]):
             filtered_xs = [x for x in xs if not is_tensor_empty(x)]
-            xs = filtered_xs if filtered_xs else [xs[0]]
+            xs = filtered_xs if len(filtered_xs) > 0 else [xs[0]]
 
         dim = inputs[1] if nargs > 1 else 0
 

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -1501,7 +1501,7 @@ def rrelu(context, node):
 def softplus(context, node):
     inputs = _get_inputs(context, node, expected=3)
     x, beta, threshold = inputs[0], inputs[1].val, inputs[2].val
-    
+
     np_type = nptype_from_builtin(x.dtype)
     b = mb.const(val=np_type(beta))
     t = mb.const(val=np_type(threshold))
@@ -1523,7 +1523,7 @@ def softplus(context, node):
         # And this implementation is slightly faster than mb.softplus * mask for inference on the GPU.
         xb = mb.mul(x=x, y=b)
         m = mb.less_equal(x=xb, y=t)
-        
+
         x_dtype = TYPE_TO_DTYPE_STRING[x.dtype]
         m0 = mb.cast(x=m, dtype=x_dtype)
         xb0 = mb.mul(x=xb, y=m0)
@@ -1531,10 +1531,10 @@ def softplus(context, node):
         exp0 = mb.add(x=exp, y=m0)
         log = mb.log(x=exp0)
         log0 = mb.real_div(x=log, y=b)
-        
+
         m1 = mb.logical_not(x=m)
         x0 = mb.mul(x=x, y=mb.cast(x=m1, dtype=x_dtype))
-        
+
         res = mb.add(x=log0, y=x0)
     context.add(res, torch_name=node.name)
 
@@ -2383,7 +2383,8 @@ def cat(context, node):
         # PyTorch can have empty tensor, which is then ignored
         # However, CoreML does not allow such empty tensor, so remove them now
         if np.any([is_tensor_empty(x) for x in xs]):
-            xs = [x for x in xs if not is_tensor_empty(x)]
+            filtered_xs = [x for x in xs if not is_tensor_empty(x)]
+            xs = filtered_xs if filtered_xs else [xs[0]]
 
         dim = inputs[1] if nargs > 1 else 0
 

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -3657,6 +3657,24 @@ class TestConcat(TorchBaseTest):
     @pytest.mark.parametrize(
         "compute_unit, backend, frontend", itertools.product(compute_units, backends, frontends)
     )
+    def test_cat_with_empty_tensors(self, compute_unit, backend, frontend):
+        class TestNet(nn.Module):
+            def forward(self, x):
+                y = torch.cat((torch.empty(1, 0, 3), torch.empty(1, 0, 3)), axis=1)
+                return torch.cat([x, y], axis=1)
+
+        model = TestNet()
+        self.run_compare_torch(
+            (1, 2, 3),
+            model,
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+        )
+
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend", itertools.product(compute_units, backends, frontends)
+    )
     def test_cat_input_types_promotion(self, compute_unit, backend, frontend):
         if frontend == TorchFrontend.EXECUTORCH:
             pytest.skip("executorch does not allow mixed dtypes")
@@ -12400,7 +12418,7 @@ class TestSoftplus(TorchBaseTest):
             backend=backend,
             compute_unit=compute_unit,
         )
-    
+
     @pytest.mark.parametrize(
         "compute_unit, backend",
         itertools.product(compute_units, backends),
@@ -12408,13 +12426,13 @@ class TestSoftplus(TorchBaseTest):
     def test_softplus_no_default(self, compute_unit, backend):
         model = ModuleWrapper(function=torch.nn.functional.softplus, kwargs={"beta": 2, "threshold": 2}).eval()
         self.run_compare_torch(
-            torch.arange(0, 3).float() + 0.5, 
-            model, 
-            backend=backend, 
+            torch.arange(0, 3).float() + 0.5,
+            model,
+            backend=backend,
             compute_unit=compute_unit,
             input_as_shape=False,
         )
-    
+
     @pytest.mark.parametrize(
         "compute_unit, backend, value",
         itertools.product(compute_units, backends, [1.0, 3.0, 1e5, 1e7, 1e9]),


### PR DESCRIPTION
This PR introduces support for conversion of torch cat operation that has as an input a list of empty tensors (tensors with one of its dimensions being zero).

Without this fix we'd filter all these empty tensors and subsequently fail on determining the dtype of the output (as we'd have nothing in the input). We basically keep at least one of the empty tensors in the input to make sure dtype information is still available.

Fixes the bug in https://github.com/apple/coremltools/issues/2296.

CI pipeline: https://gitlab.com/coremltools1/coremltools/-/pipelines/1479158242