### PR TITLE
Update macOS on CI machines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,7 +11,7 @@ stages:
 
 check_python_flake8:
   tags:
-    - macOS13
+    - macOS_M1
   stage: check
   script:
     - python -m pip install --upgrade pip
@@ -37,21 +37,21 @@ check_python_flake8:
 build_wheel_macos_py37_intel:
   <<: *build_macos
   tags:
-    - macOS13
+    - macOS_intel
   variables:
     PYTHON: "3.7"
 
 build_wheel_macos_py39_intel:
   <<: *build_macos
   tags:
-    - macOS13
+    - macOS_intel
   variables:
     PYTHON: "3.9"
 
 build_wheel_macos_py310:
   <<: *build_macos
   tags:
-    - macOS13_M1
+    - macOS_M1
   variables:
     PYTHON: "3.10"
 
@@ -71,7 +71,7 @@ build_wheel_macos_py310:
 test_py39_coremltools_test_intel:
   <<: *test_macos_pkg
   tags:
-    - macOS13
+    - macOS_intel
   dependencies:
     - build_wheel_macos_py39_intel
   variables:
@@ -83,7 +83,7 @@ test_py39_coremltools_test_intel:
 test_py39_pytorch_intel:
   <<: *test_macos_pkg
   tags:
-    - macOS13
+    - macOS_intel
   dependencies:
     - build_wheel_macos_py39_intel
   variables:
@@ -95,7 +95,7 @@ test_py39_pytorch_intel:
 test_py37_tf1_intel:
   <<: *test_macos_pkg
   tags:
-    - macOS13
+    - macOS_intel
   dependencies:
     - build_wheel_macos_py37_intel
   variables:
@@ -107,7 +107,7 @@ test_py37_tf1_intel:
 test_py39_tf2_intel-1:
   <<: *test_macos_pkg
   tags:
-    - macOS13
+    - macOS_intel
   dependencies:
     - build_wheel_macos_py39_intel
   variables:
@@ -119,7 +119,7 @@ test_py39_tf2_intel-1:
 test_py39_tf2_intel-2:
   <<: *test_macos_pkg
   tags:
-    - macOS13
+    - macOS_intel
   dependencies:
     - build_wheel_macos_py39_intel
   variables:
@@ -131,7 +131,7 @@ test_py39_tf2_intel-2:
 test_py39_mil_intel:
   <<: *test_macos_pkg
   tags:
-    - macOS13
+    - macOS_intel
   dependencies:
     - build_wheel_macos_py39_intel
   variables:
@@ -143,7 +143,7 @@ test_py39_mil_intel:
 test_py39_backends_intel:
   <<: *test_macos_pkg
   tags:
-    - macOS13
+    - macOS_intel
   dependencies:
     - build_wheel_macos_py39_intel
   variables:
@@ -155,7 +155,7 @@ test_py39_backends_intel:
 test_py39_shapes_intel:
   <<: *test_macos_pkg
   tags:
-    - macOS13
+    - macOS_intel
   dependencies:
     - build_wheel_macos_py39_intel
   variables:
@@ -167,7 +167,7 @@ test_py39_shapes_intel:
 test_py39_milproto_intel:
   <<: *test_macos_pkg
   tags:
-    - macOS13
+    - macOS_intel
   dependencies:
     - build_wheel_macos_py39_intel
   variables:
@@ -181,7 +181,7 @@ test_py39_milproto_intel:
 test_py310_coremltools_test:
   <<: *test_macos_pkg
   tags:
-    - macOS13_M1
+    - macOS_M1
   dependencies:
     - build_wheel_macos_py310
   variables:
@@ -193,7 +193,7 @@ test_py310_coremltools_test:
 test_py310_pytorch:
   <<: *test_macos_pkg
   tags:
-    - macOS13_M1
+    - macOS_M1
   dependencies:
     - build_wheel_macos_py310
   variables:
@@ -205,7 +205,7 @@ test_py310_pytorch:
 test_py310_tf2-1:
   <<: *test_macos_pkg
   tags:
-    - macOS13_M1
+    - macOS_M1
   dependencies:
     - build_wheel_macos_py310
   variables:
@@ -217,7 +217,7 @@ test_py310_tf2-1:
 test_py310_tf2-2:
   <<: *test_macos_pkg
   tags:
-    - macOS13_M1
+    - macOS_M1
   dependencies:
     - build_wheel_macos_py310
   variables:
@@ -229,7 +229,7 @@ test_py310_tf2-2:
 test_py310_mil:
   <<: *test_macos_pkg
   tags:
-    - macOS13_M1
+    - macOS_M1
   dependencies:
     - build_wheel_macos_py310
   variables:
@@ -241,7 +241,7 @@ test_py310_mil:
 test_py310_backends:
   <<: *test_macos_pkg
   tags:
-    - macOS13_M1
+    - macOS_M1
   dependencies:
     - build_wheel_macos_py310
   variables:
@@ -253,7 +253,7 @@ test_py310_backends:
 test_py310_shapes:
   <<: *test_macos_pkg
   tags:
-    - macOS13_M1
+    - macOS_M1
   dependencies:
     - build_wheel_macos_py310
   variables:
@@ -265,7 +265,7 @@ test_py310_shapes:
 test_py310_milproto:
   <<: *test_macos_pkg
   tags:
-    - macOS13_M1
+    - macOS_M1
   dependencies:
     - build_wheel_macos_py310
   variables:
@@ -283,18 +283,18 @@ test_py310_milproto:
 #########################################################################
 build_documentation:
   tags:
-    - macOS13
+    - macOS_M1
   stage: test
   script:
     - export PATH=$PATH:/opt/anaconda/bin/
     - bash -e scripts/build_docs.sh --wheel-path=${WHEEL_PATH} --python=${PYTHON}
   dependencies:
-    - build_wheel_macos_py39_intel
+    - build_wheel_macos_py310
   artifacts:
     when: always
     expire_in: 2 weeks
     paths:
       - _build/html/
   variables:
-    WHEEL_PATH: build/dist/coremltools*cp39-none-macosx_10_15_x86_64.whl
-    PYTHON: "3.9"
+    WHEEL_PATH: build/dist/coremltools*cp310-none-macosx_11_0_arm64.whl
+    PYTHON: "3.10"

--- a/coremltools/converters/mil/backend/mil/test_load.py
+++ b/coremltools/converters/mil/backend/mil/test_load.py
@@ -64,26 +64,15 @@ class TestWeightFileSerialization:
             minimum_deployment_target=opset_version,
             pass_pipeline=pipeline,
         )
-        saved_package_path = tempfile.mkdtemp(suffix=".mlpackage")
-        mlmodel.save(saved_package_path)
 
         # check the weights are serialized as file value
         if ct.utils._macos_version() >= (15, 0):
-            with tempfile.TemporaryDirectory() as serialize_dir:
-                os.system(f"coremlcompiler compile {saved_package_path} {serialize_dir}")
-                model_name_with_extension = os.path.basename(saved_package_path)
-                model_name_wo_extension, _ = os.path.splitext(model_name_with_extension)
-                mil_file = open(
-                    os.path.join(serialize_dir, f"{model_name_wo_extension}.mlmodelc", "model.mil")
-                )
-                mil_txt = mil_file.read()
-                if should_serialize_weight:
-                    assert f"tensor<{dtype}, [1000]>(BLOBFILE" in mil_txt
-                else:
-                    assert f"tensor<{dtype}, [1000]>(BLOBFILE" not in mil_txt
-
-        # cleanup
-        shutil.rmtree(saved_package_path)
+            mil_file = open(os.path.join(mlmodel.get_compiled_model_path(), "model.mil"))
+            mil_txt = mil_file.read()
+            if should_serialize_weight:
+                assert f"tensor<{dtype}, [1000]>(BLOBFILE" in mil_txt
+            else:
+                assert f"tensor<{dtype}, [1000]>(BLOBFILE" not in mil_txt
 
 
 class TestMILFlexibleShapes:

--- a/coremltools/converters/mil/frontend/tensorflow/test/test_ops.py
+++ b/coremltools/converters/mil/frontend/tensorflow/test/test_ops.py
@@ -1935,6 +1935,11 @@ class TestConvTranspose(TensorFlowBaseTest):
         if _macos_version() < (12, 0) and strides == (1, 2, 3) and padding == "VALID":
             # Behavior changed in macOS 12
             return
+        if (platform.machine() == "x86_64" and compute_unit == ct.ComputeUnit.CPU_ONLY
+          and backend == ('mlprogram', 'fp16') and padding == "SAME"
+          and DHWkDkHkW in ((4, 6, 8, 2, 3, 1), (5, 7, 9, 2, 4, 2))
+          and strides == (1, 2, 3) and dilations == (1, 1, 1) and dynamic):
+            pytest.xfail("rdar://137132151")
 
         D, H, W, kD, kH, kW = DHWkDkHkW
         N, C_in, C_out = 2, 1, 2

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_export_conversion_api.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_export_conversion_api.py
@@ -80,9 +80,6 @@ class TestTorchExportConversionAPI(TorchBaseTest):
         itertools.product(compute_units, backends, frontends),
     )
     def test_dynamic_input(self, compute_unit, backend, frontend):
-        if ct.utils._macos_version() <= (14, 2):
-            pytest.xfail("rdar://135925921 ([CI] Upgrade External CI Machine OS)")
-
         class Model(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -158,9 +155,6 @@ class TestExecuTorchExamples(TorchBaseTest):
         itertools.product(compute_units, backends, frontends, (True, False)),
     )
     def test_mul(self, compute_unit, backend, frontend, dynamic):
-        if ct.utils._macos_version() <= (14, 2) and dynamic:
-            pytest.xfail("rdar://135925921 ([CI] Upgrade External CI Machine OS)")
-
         class MulModule(torch.nn.Module):
             def forward(self, input, other):
                 return input * other
@@ -242,9 +236,6 @@ class TestExecuTorchExamples(TorchBaseTest):
         itertools.product(compute_units, backends, frontends, (True, False)),
     )
     def test_linear(self, compute_unit, backend, frontend, dynamic):
-        if ct.utils._macos_version() <= (14, 2) and dynamic:
-            pytest.xfail("rdar://135925921 ([CI] Upgrade External CI Machine OS)")
-
         class LinearModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -424,9 +415,6 @@ class TestExecuTorchExamples(TorchBaseTest):
         itertools.product(compute_units, backends, frontends, (True, False)),
     )
     def test_add_mul(self, compute_unit, backend, frontend, dynamic):
-        if ct.utils._macos_version() <= (14, 2) and dynamic:
-            pytest.xfail("rdar://135925921 ([CI] Upgrade External CI Machine OS)")
-
         class AddMulModule(torch.nn.Module):
             def forward(self, a, x, b):
                 y = torch.mm(a, x)
@@ -542,9 +530,6 @@ class TestExecuTorchExamples(TorchBaseTest):
         itertools.product(compute_units, backends, frontends, (True, False)),
     )
     def test_softmax(self, compute_unit, backend, frontend, dynamic):
-        if ct.utils._macos_version() <= (14, 2) and dynamic:
-            pytest.xfail("rdar://135925921 ([CI] Upgrade External CI Machine OS)")
-
         class SoftmaxModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -860,7 +860,7 @@ class TestWeightNorm(TorchBaseTest):
         ),
     )
     def test_conv3d(self, compute_unit, backend):
-        x = torch.randn(20, 16, 5, 50, 100)
+        x = torch.randn(15, 16, 5, 20, 10)
 
         for dim in (None,) + tuple(range(-5, 5)):
             model = nn.utils.weight_norm(nn.Conv3d(16, 33, 3), dim=dim)

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -6247,8 +6247,8 @@ class TestMatMul(TorchBaseTest):
         ),
     )
     def test_bmm_with_fp16_inputs(self, compute_unit, backend, frontend):
-        if platform.machine() == "x86_64" and ct.utils._macos_version() <= (14, 2):
-            pytest.xfail("rdar://135925921 ([CI] Upgrade External CI Machine OS)")
+        if platform.machine() == "x86_64":
+            pytest.xfail("rdar://137157493")
 
         class TestModel(torch.nn.Module):
             def forward(self, x, y):

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -467,6 +467,10 @@ class TestFrac(TorchBaseTest):
             backend=backend,
             compute_unit=compute_unit,
             rand_range=(-10.0, 10.0),
+
+            # Casting from fp32 to fp16 can produce very different result when value close to whole number.
+            input_dtype=np.float16,
+            minimum_deployment_target=ct.target.iOS16,
         )
 
 

--- a/coremltools/converters/mil/mil/builder.py
+++ b/coremltools/converters/mil/mil/builder.py
@@ -90,8 +90,8 @@ class Builder:
             err_msg = f"Cannot add const {val}"
             if any_symbolic(val):
                 err_msg += (
-                    "\nPython native vals (list, tuple), np.array that are"
-                    + "operation inputs cannot have symbolic values. Consider feeding"
+                    "\nPython native vals (list, tuple), np.array that are "
+                    + "operation inputs cannot have symbolic values. Consider feeding "
                     + "symbolic shape in through placeholder and use mb.shape() "
                     + f"operator. Input {name}: {val}"
                 )

--- a/coremltools/models/model.py
+++ b/coremltools/models/model.py
@@ -626,6 +626,9 @@ class MLModel:
         the compiled model to persist, you need to make a copy.
 
         """
+        if self.__proxy__ is None:
+            raise Exception("This model was not loaded or compiled with the Core ML Framework.")
+
         return self.__proxy__.get_compiled_model_path()
 
 
@@ -804,6 +807,8 @@ class MLModel:
         """
         if not _is_macos() or _macos_version() < (15, 0):
             raise Exception("State functionality is only supported on macOS 15+")
+        if self.__proxy__ is None:
+            raise Exception("This model was not loaded with the Core ML Framework. Cannot get state.")
 
         return MLState(self.__proxy__.newState())
 

--- a/coremltools/test/ml_program/test_utils.py
+++ b/coremltools/test/ml_program/test_utils.py
@@ -686,6 +686,7 @@ class TestMultiFunctionModelEnd2End:
                 x = self.linear1(torch.flatten(x))
                 return x
 
+
         model = TestModel().eval()
         example_input = torch.rand(1, 1, 28, 28)
         return torch.jit.trace(model, example_input)
@@ -704,6 +705,7 @@ class TestMultiFunctionModelEnd2End:
             def forward(self, x):
                 return self.linear1(x)
 
+
         class TestModel(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -716,6 +718,7 @@ class TestMultiFunctionModelEnd2End:
                 x = self.bn1(x)
                 x = self.linear1(torch.flatten(x))
                 return x
+
 
         example_input = torch.rand(1, 1, 28, 28)
         model = TestModel().eval()
@@ -737,6 +740,9 @@ class TestMultiFunctionModelEnd2End:
 
         After merging model_1 with model_2, the base weights should be shared.
         """
+        if platform.machine() == "x86_64":
+            pytest.xfail("rdar://137217263")
+
         traced_model_1, traced_model_2 = self._get_test_model_2()
         input = np.random.rand(1, 1, 28, 28)
 
@@ -861,6 +867,9 @@ class TestMultiFunctionModelEnd2End:
         """
         Copy a single model 10 times and create a multi-functions model with 10 functions.
         """
+        if platform.machine() == "x86_64":
+            pytest.xfail("rdar://137217263")
+
         traced_model = self._get_test_model()
         input = np.random.rand(1, 1, 28, 28)
         NUM_MODEL = 10

--- a/coremltools/test/optimize/coreml/test_post_training_quantization.py
+++ b/coremltools/test/optimize/coreml/test_post_training_quantization.py
@@ -5,6 +5,7 @@
 
 import itertools
 import logging
+import platform
 import re
 import shutil
 import tempfile
@@ -392,6 +393,9 @@ class TestLinearQuantizeWeights:
         ),
     )
     def test_blockwise_quanitzation_stress(compute_unit, backend, mode, nbits, signed, block_size):
+        if platform.machine() == "x86_64":
+            pytest.xfail("rdar://137153993 ([CI] Quantization Tests Failing only on *native* x86_64 (not with Rosetta))")
+
         model, inputs, torch_input_values, coreml_input_values = get_test_model_and_data()
         torchmodel = torch.jit.trace(model, torch_input_values)
         mlmodel = ct.convert(
@@ -461,6 +465,9 @@ class TestLinearQuantizeWeights:
         ),
     )
     def test_per_tensor_quantization_with_blockwise_op(compute_unit, backend, mode, nbits):
+        if platform.machine() == "x86_64":
+            pytest.xfail("rdar://137153993 ([CI] Quantization Tests Failing only on *native* x86_64 (not with Rosetta))")
+
         op_config = cto.coreml.OpLinearQuantizerConfig(
             mode=mode, dtype=f"int{nbits}", granularity="per_tensor"
         )
@@ -1050,6 +1057,9 @@ class TestPalettizeWeights:
     def test_channelwise_palettization_stress(
         compute_unit, backend, mode, nbits, channel_axis, channel_group_size
     ):
+        if platform.machine() == "x86_64":
+            pytest.xfail("rdar://137153993 ([CI] Quantization Tests Failing only on *native* x86_64 (not with Rosetta))")
+
         model, inputs, torch_input_values, coreml_input_values = get_test_model_and_data()
         torchmodel = torch.jit.trace(model, torch_input_values)
         mlmodel = ct.convert(
@@ -1347,6 +1357,9 @@ class TestPalettizeWeights:
     )
     def test_palettization_pcs(self, compute_unit, backend):
         """Test the palettization with per-channel-scale."""
+        if platform.machine() == "x86_64":
+            pytest.xfail("rdar://137153993 ([CI] Quantization Tests Failing only on *native* x86_64 (not with Rosetta))")
+
         model, inputs, torch_input_values, coreml_input_values = get_test_model_and_data()
 
         torchmodel = torch.jit.trace(model, torch_input_values)


### PR DESCRIPTION
* Update CI runner tags. Change from outdated OS version specific tags to version agnostic tags.
* Any CI job which can run natively on Apple Silicon, should use an Apple Silicon machine, for load balancing.
* Make CI green.
* Use `MLModel.get_compiled_model_path` rather than a system call.
* Other minor improvements.

CI: https://gitlab.com/coremltools1/coremltools/-/pipelines/1480782609