### PR TITLE
Add torch one_hot op

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -7562,3 +7562,13 @@ def multinomial(context, node):
     # Based on PyTorch documentations, the input to `torch.multinomial` is probability, not logit.
     x = mb.random_categorical(x=x, size=num_samples, mode="probs", name=node.name)
     context.add(x)
+
+
+@register_torch_op
+def one_hot(context, node):
+    inputs = _get_inputs(context, node, expected=2)
+    labels = inputs[0]
+    num_classes = inputs[1].val
+    
+    res = mb.one_hot(indices=labels, one_hot_vector_size=num_classes, name=node.name)
+    context.add(res)

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -12424,3 +12424,21 @@ class TestSoftplus(TorchBaseTest):
             compute_unit=compute_unit,
             input_as_shape=False,
         )
+
+
+class TestOneHot(TorchBaseTest):
+    @pytest.mark.parametrize(
+        "compute_unit, backend, num_classes, rank",
+        itertools.product(compute_units, backends, range(1, 5), range(1, 5)),
+    )
+    def test_one_hot(self, compute_unit, backend, num_classes, rank):
+        model = ModuleWrapper(function=torch.nn.functional.one_hot, kwargs={"num_classes": num_classes}).eval()
+        shape = torch.randint(1, 10, (rank,)).tolist()
+        labels = torch.randint(0, num_classes, shape)
+        self.run_compare_torch(
+            torch.LongTensor(labels),
+            model,
+            backend=backend,
+            compute_unit=compute_unit,
+            input_as_shape=False,
+        )


### PR DESCRIPTION
Example:
```Python
import torch
from torch import nn
from torch.nn import functional as F
from typing import Final
from cp import coremltools as ct
from cp.coremltools.converters.mil.mil import types

class Model(nn.Module):
  def forward(self, x: torch.LongTensor) -> torch.Tensor:
      return F.one_hot(x, num_classes=10)

model = Model().eval()
x = torch.arange(10)
traced_model = torch.jit.trace(model, (x))

var_dim: Final[ct.RangeDim] = ct.RangeDim(1, 1_000)
mlmodel = ct.convert(
    traced_model,
    inputs=[
        ct.TensorType(name="x", shape=ct.Shape([var_dim]), dtype=types.int32),
    ],
    outputs=[
        ct.TensorType(name="y")
    ],
)
mlmodel.save("tmp.mlpackage")
```