### PR TITLE
new change_output_tensor_types API under ct.models.utils

### DIFF
--- a/coremltools/converters/mil/mil/operation.py
+++ b/coremltools/converters/mil/mil/operation.py
@@ -603,9 +603,8 @@ class Operation:
 
         if print_attr:
             attr = "["
-            for k, v in self.scopes.items():
-                attr += f"{k}: {v}, "
-            attr += attr[:-2] + "]"
+            attr += ", ".join([f"{k}: {v}" for k, v in self.scopes.items()])
+            attr += "]"
         else:
             attr = ""
 

--- a/coremltools/converters/mil/mil/operation.py
+++ b/coremltools/converters/mil/mil/operation.py
@@ -605,7 +605,7 @@ class Operation:
             attr = "["
             for k, v in self.scopes.items():
                 attr += f"{k}: {v}, "
-            attr = attr[:-2] + "]"
+            attr += attr[:-2] + "]"
         else:
             attr = ""
 

--- a/coremltools/models/utils.py
+++ b/coremltools/models/utils.py
@@ -2263,7 +2263,7 @@ def change_input_output_tensor_type(
     output_names: _Optional[_List[str]] = None,
 ) -> "_ct.models.model.MLModel":
     """
-    Change input and/or output type of the Core ML model tensor outputs. Supported types are FLOAT16, FLOAT32.
+    Change the tensor data types of Core ML model inputs / outputs. Supported types are FLOAT16, FLOAT32.
 
     Parameters
     ----------

--- a/coremltools/models/utils.py
+++ b/coremltools/models/utils.py
@@ -48,7 +48,6 @@ from coremltools.converters.mil.mil.passes.pass_pipeline import (
 )
 from coremltools.converters.mil.mil.passes.pass_registry import PASS_REGISTRY as _PASS_REGISTRY
 from coremltools.converters.mil.mil.program import Placeholder as _Placeholder
-from coremltools.proto.FeatureTypes_pb2 import ArrayFeatureType
 
 from .._deps import _HAS_SCIPY
 
@@ -2253,11 +2252,10 @@ def _make_second_chunk_prog(prog: _mil.Program, op_idx: int) -> _mil.Program:
 
     return prog
 
-
 def change_input_output_tensor_type(
     ml_model: "_ct.models.model.MLModel",
-    from_type: ArrayFeatureType,
-    to_type: ArrayFeatureType,
+    from_type: "_ct.proto.FeatureTypes_pb2.ArrayFeatureType",
+    to_type: "_ct.proto.FeatureTypes_pb2.ArrayFeatureType",
     function_names: _Optional[_List[str]] = None,
     input_names: _Optional[_List[str]] = None,
     output_names: _Optional[_List[str]] = None,
@@ -2304,6 +2302,7 @@ def change_input_output_tensor_type(
     from coremltools.converters.mil import Var, Operation
     from coremltools.converters.mil.mil.block import Function
     from coremltools.converters.mil.mil.types import fp16, fp32, tensor, double
+    from coremltools.proto.FeatureTypes_pb2 import ArrayFeatureType
     from coremltools.proto.Model_pb2 import FeatureDescription, Model
     from typing import Iterable as _Iterable
     from typing import Type as _Type

--- a/coremltools/test/api/test_api_visibilities.py
+++ b/coremltools/test/api/test_api_visibilities.py
@@ -75,6 +75,7 @@ class TestApiVisibilities:
             "MultiFunctionDescriptor",
             "randomize_weights",
             "bisect_model",
+            "change_input_output_tensor_type",
         ]
         _check_visible_modules(_get_visible_items(ct.utils), expected)
 

--- a/docs-guides/source/mlmodel-utilities.md
+++ b/docs-guides/source/mlmodel-utilities.md
@@ -210,9 +210,9 @@ ct.models.utils.bisect_model(
 )
 ```
 
-## Change Model Tensor Output Types
+## Change Model Tensor Input/Output Types
 
-Consider a scenario when we have a CoreML model with an fp32 multiarray output, but we need to use a CoreML API that
+Consider a scenario when we have a Core ML model with an fp32 multiarray output, but we need to use a Core ML API that
 requires fp16 multiarrays instead. We can now easily change the model output types from fp32 to fp16 (and vice versa).
 
 An example how to update the output data types:
@@ -223,10 +223,37 @@ from coremltools.utils import change_array_output_type
 from coremltools.proto.FeatureTypes_pb2 import ArrayFeatureType
 
 model = MLModel("my_model.mlpackage")
-updated_model = change_output_tensor_type(
+updated_model = change_input_output_tensor_type(
     ml_model=model,
     from_type=ArrayFeatureType.FLOAT32,
     to_type=ArrayFeatureType.FLOAT16,
 )
 updated_model.save("my_updated_model.mlpackage")
 ```
+
+Another example is showing how to update data types of all the function inputs:
+```python
+from coremltools.models.model import MLModel
+from coremltools.utils import change_array_output_type
+from coremltools.proto.FeatureTypes_pb2 import ArrayFeatureType
+
+model = MLModel("my_model.mlpackage")
+updated_model = change_input_output_tensor_type(
+    ml_model=model,
+    from_type=ArrayFeatureType.FLOAT32,
+    to_type=ArrayFeatureType.FLOAT16,
+    function_names=["main_1", "main_2"],
+    input_names=["*"],
+    output_names=[],  # no output to be modified
+)
+updated_model.save("my_updated_model.mlpackage")
+```
+
+Optional arguments:
+* `function_names`: list of functions to be modified (by default only input / output of the `main` function is modified)
+* `input_names`: list of inputs that should be updated (by default none is modified)
+* `output_names`: list of outputs that should be updated (by default all the outputs matching the `from_type` type are updated)
+
+Special values for `input_names` and `output_names` arguments:
+* an empty list means nothing will be modified (default for `input_names`)
+* a list containing `"*"` string means all relevant inputs/outputs will be modified (those that will match the `from_type` type)

--- a/docs-guides/source/mlmodel-utilities.md
+++ b/docs-guides/source/mlmodel-utilities.md
@@ -209,3 +209,24 @@ ct.models.utils.bisect_model(
     merge_chunks_to_pipeline=True,
 )
 ```
+
+## Change Model Tensor Output Types
+
+Consider a scenario when we have a CoreML model with an fp32 multiarray output, but we need to use a CoreML API that
+requires fp16 multiarrays instead. We can now easily change the model output types from fp32 to fp16 (and vice versa).
+
+An example how to update the output data types:
+
+```python
+from coremltools.models.model import MLModel
+from coremltools.utils import change_array_output_type
+from coremltools.proto.FeatureTypes_pb2 import ArrayFeatureType
+
+model = MLModel("my_model.mlpackage")
+updated_model = change_output_tensor_type(
+    ml_model=model,
+    from_type=ArrayFeatureType.FLOAT32,
+    to_type=ArrayFeatureType.FLOAT16,
+)
+updated_model.save("my_updated_model.mlpackage")
+```


### PR DESCRIPTION
Introducing a utility function `change_output_tensor_types` that can change the model output tensor types (e.g. from fp32 to fp16). This function will, for a given CoreML model, return a new model that has updated output types for a required set of functions (by default only "main" function output is updated).

CI pipeline: https://gitlab.com/coremltools1/coremltools/-/pipelines/1486307878
