### PR TITLE
Add torch cumsum dtype support

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -965,10 +965,17 @@ def add(context, node):
 
 @register_torch_op
 def cumsum(context, node):
-    inputs = _get_inputs(context, node, expected=3)
+    inputs = _get_inputs(context, node, min_expected=2)
     x = inputs[0]
     if is_bool(x.dtype):
         x = mb.cast(x=x, dtype='int32')
+    src_dtype = builtin_to_string(x.dtype)
+    dst_dtype = src_dtype
+    if len(inputs) > 2 and inputs[2] and inputs[2].val:
+        dst_dtype = NUM_TO_DTYPE_STRING[inputs[2].val]    
+    
+    if src_dtype != dst_dtype:
+        x = mb.cast(x=x, dtype=dst_dtype)
     res = mb.cumsum(x=x, axis=inputs[1], name=node.name)
     context.add(res)
 


### PR DESCRIPTION
```Python
import torch
from torch import nn
import coremltools as ct
from coremltools.converters.mil.mil import types

class Model(nn.Module):
    def forward(self, x: torch.Tensor) -> torch.Tensor:
        return x.cumsum(dim=-1, dtype=torch.int32)

model = Model().eval()
x = torch.tensor([0.5, 1.5, 2.5])
y = model(x)
print(y)

traced_model = torch.jit.trace(model, (x))
mlmodel = ct.convert(
    traced_model,
    inputs=[
        ct.TensorType(name="x", shape=x.shape, dtype=types.fp32),
    ],
    outputs=[
        ct.TensorType(name="y"),
    ],
)
mlmodel.save("tmp.mlpackage")
```

It will get the right result.