### PR TITLE
Fixed exception on linear_quantize_activations for ImageType output

### DIFF
--- a/coremltools/optimize/coreml/experimental/_model_debugger.py
+++ b/coremltools/optimize/coreml/experimental/_model_debugger.py
@@ -312,6 +312,9 @@ class ModelDebugger:
 
     # The function will get called for each intermediate output, return `False` if you want to stop the enumeration otherwise `True`.
     def check_intermediate_output(output_value, output_name, operation, activation_stats_dict):
+        if not isinstance(output_value, np.ndarray):
+            # output_value may be a PIL image, convert it to numpy array
+            output_value = np.array(output_value)
         tensor_min = np.min(output_value.flatten())
         tensor_max = np.max(output_value.flatten())
         activation_stats_dict[output_name]["rmin"] = tensor_min


### PR DESCRIPTION
## Issue
Calling `cto.coreml.experimental.linear_quantize_activations` on a model with `ct.ImageType` output(s) fails at the model output because `check_intermediate_output` expects `output_value` to be a `np.ndarray` but the model's final output is `PIL.Image`.

## Solution
This patch adds a simple attempt to convert the `output_value` to `np.ndarray` before the computations.