### PR TITLE
[CI] Split PyTorch Test Suites by Frontends

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -190,7 +190,7 @@ test_py310_coremltools_test:
     PYTHON: "3.10"
     REQUIREMENTS: reqs/test.pip
 
-test_py310_pytorch:
+test_py310_pytorch_script:
   <<: *test_macos_pkg
   tags:
     - macOS_M1
@@ -201,6 +201,33 @@ test_py310_pytorch:
     TEST_PACKAGE: coremltools.converters.mil.frontend.torch
     WHEEL_PATH: build/dist/*cp310*11*
     REQUIREMENTS: reqs/test.pip
+    TORCH_FRONTENDS: TORCHSCRIPT
+
+test_py310_pytorch_export:
+  <<: *test_macos_pkg
+  tags:
+    - macOS_M1
+  dependencies:
+    - build_wheel_macos_py310
+  variables:
+    PYTHON: "3.10"
+    TEST_PACKAGE: coremltools.converters.mil.frontend.torch
+    WHEEL_PATH: build/dist/*cp310*11*
+    REQUIREMENTS: reqs/test.pip
+    TORCH_FRONTENDS: TORCHEXPORT
+
+test_py310_pytorch_executorch:
+  <<: *test_macos_pkg
+  tags:
+    - macOS_M1
+  dependencies:
+    - build_wheel_macos_py310
+  variables:
+    PYTHON: "3.10"
+    TEST_PACKAGE: coremltools.converters.mil.frontend.torch
+    WHEEL_PATH: build/dist/*cp310*11*
+    REQUIREMENTS: reqs/test.pip
+    TORCH_FRONTENDS: EXECUTORCH
 
 test_py310_tf2-1:
   <<: *test_macos_pkg


### PR DESCRIPTION
As we add torch.export conversion support & test, CI has become too slow: The [PyTorch test suite](https://gitlab.com/coremltools1/coremltools/-/jobs/8137627026) takes 10 hours to finish

Let us split it into 3 suites by frontends: torch script, torch.export, and executorch

Testing: ✅ https://gitlab.com/coremltools1/coremltools/-/commit/eae28eef97e108fc61091ea50bdb2f9cd09cf867/pipelines