### PR TITLE
Move cmake to env create

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -7,7 +7,6 @@ This page describes how to build Core ML Tools (coremltools) from the source rep
 
 To build coremltools from source, you need the following:
 
-* [CMake](https://cmake.org/)
 * [Miniconda](https://docs.conda.io/en/latest/miniconda.html) (or [Anaconda](https://www.anaconda.com/))
 * [Zsh shell](http://zsh.sourceforge.net/) (the default shell for macOS 10.16+) installed in /usr/bin
 * A C++17 compatible compiler (if using GCC, need GCC 9.0 or later)

--- a/docs-guides/source/installing-coremltools.md
+++ b/docs-guides/source/installing-coremltools.md
@@ -126,8 +126,6 @@ pip install coremltools-4.0-cp38-none-macosx_10_12_intel.whl
 
 ## Build From Source
 
-To build Core ML Tools and its dependent libraries from source, you need to install [CMake](https://cmake.org/) to configure the project.
-
 To perform the build, fork and clone the [`coremltools` repository](https://github.com/apple/coremltools) and run the [`build.sh`](https://github.com/apple/coremltools/blob/master/scripts/build.sh) script:
 
 ```shell

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -107,9 +107,6 @@ CMAKE_COMMAND=""
 if [[ $OSTYPE == darwin* ]]; then
   CMAKE_COMMAND="xcrun --sdk ${sdk} "
 fi
-if [ -z "`which cmake`" ] || [ "`which cmake`" = "cmake not found" ]; then
-  conda install cmake -y
-fi
 CMAKE_COMMAND+="cmake $ADDITIONAL_CMAKE_OPTIONS \
   -DCMAKE_BUILD_TYPE=$BUILD_MODE \
   -DPYTHON_EXECUTABLE:FILEPATH=$PYTHON_EXECUTABLE \

--- a/scripts/env_create.sh
+++ b/scripts/env_create.sh
@@ -110,6 +110,7 @@ if [[ $DEV == 1 ]]; then
   python -m pip install -e "$COREMLTOOLS_HOME/../coremltools" --upgrade
 fi
 
+conda install -y cmake
 conda deactivate
 
 echo


### PR DESCRIPTION
I had a previous PR for this, however, I had made some edits to my fork that closed the pull request and added commits from another feature I was working on. I guess that's a reminder to me to make new branches in git 😄 . Apologies for a duplicate PR. Here's the original description:

This PR simplifies the build setup process by installing `cmake` via `conda`.

## Current Behavior:

In the `build.sh` script, this if statement exists:

```bash
if [ -z "`which cmake`" ] || [ "`which cmake`" = "cmake not found" ]; then
  conda install cmake -y
fi
```

If `cmake` does not exist on the machine used to build `coremltools`, then `cmake` will be installed via `conda`. `BUILDING.md` states that the user needs to install `cmake`. However, if the `build`.sh script already installs `cmake` then the following refactor can be done:

1. Install `cmake` by default into the `conda` environment
2. Remove the requirement for the user to install `cmake` outside of the `coremltools` build

## New Behavior:

1. This `env_create.sh` script installs `cmake` via the `anaconda` channel.
2. The CMake requirement is removed from the requirements section (the user who builds the project no longer needs to install `cmake` themselves)

This refactor makes it so that the user no longer needs to install `cmake` before building `coremltools` (as the build itself will install `cmake` via `conda`)

## Checks

Running `./scripts/build.sh --python=3.8` created a working build for me locally, but I'm not sure how to run the GitLab CI job. Could I get some help on that? Thanks in advance 😄 