### PR TITLE
Fix `ModelDebugger.step` to use only `intermediate_outputs`

### DIFF
--- a/coremltools/optimize/coreml/experimental/_model_debugger.py
+++ b/coremltools/optimize/coreml/experimental/_model_debugger.py
@@ -325,5 +325,5 @@ class ModelDebugger:
                 key: value for key, value in outputs.items() if key not in model_output_names
             }
 
-            for output_name, output_value in outputs.items():
+            for output_name, output_value in intermediate_outputs.items():
                 self.record_intermediate_output(output_value, output_name, activation_stats_dict)


### PR DESCRIPTION
### Issue
Calling `cto.coreml.experimental.linear_quantize_activations` on a model with `ct.ImageType` output(s) fails at the model output because `record_intermediate_output` expects `output_value` to be a `np.ndarray` but the model's final output is `PIL.Image`.

Ultimately, `record_intermediate_output` only expects intermediate outputs, not model outputs which could be of type `PIL.Image`.

### Followup From
#2385 