### PR TITLE
Remove state cast to fp32

### DIFF
--- a/coremltools/converters/mil/frontend/torch/converter.py
+++ b/coremltools/converters/mil/frontend/torch/converter.py
@@ -336,11 +336,10 @@ class TranscriptionContext:
 
             %x(state, fp16), %y(tensor, fp32) -> {
                 %read_x = read_state(%x)
-                %read_x_cast = cast(%read_x, "fp32")
-                %1 = add(%read_x_cast, %y)
+                %1 = add(%read_x, %y)
             }
 
-        ``%read_x_cast`` is cached in ``name_to_source_state``, to make sure one
+        ``%read_x`` is cached in ``name_to_source_state``, to make sure one
         state feeds into only one ``read_state`` op.
         """
 
@@ -358,8 +357,7 @@ class TranscriptionContext:
                     in_node.op is None
                 ), f"A state type var must come from a placeholder. Got parent op {in_node.op.op_type} instead."
                 read_state = mb.read_state(input=in_node)
-                read_state_fp32 = mb.cast(x=read_state, dtype="fp32")
-                self.add(read_state_fp32, torch_name=val, override=True)
+                self.add(read_state, torch_name=val, override=True)
         return
 
     def process_inplace_op(self, node: InternalTorchIRNode) -> None:


### PR DESCRIPTION
Currently states are always cast to fp32 tensors. This causes a ValueError when, e.g., a fp16 KV cache is used with a fp16 model: 

`ValueError: In op, of type scaled_dot_product_attention, named attn_output.1, the named input 'key' must have the same data type as the named input 'query'. However, key has dtype fp32 whereas query has dtype fp16.`

It's unclear to me why these are cast to fp32's, and removing this fixes both full and half precision conversions at least in my case, but I'm not familiar enough with coremltools to know if there are any side effects to this change.