### PR TITLE
[Torch.Export] Support `torch.native_group_norm` Op

### DIFF
--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -1275,9 +1275,6 @@ class TestGroupNorm(TorchBaseTest):
         ),
     )
     def test_groupnorm(self, compute_unit, backend, frontend, group_features, eps, affine):
-        if frontend == TorchFrontend.EXECUTORCH:
-            pytest.skip("ExecuTorch uses native_group_norm")
-
         model = nn.GroupNorm(group_features[0], group_features[1], eps=eps, affine=affine)
         self.run_compare_torch(
             (6, group_features[1], 5, 5),
@@ -1296,9 +1293,6 @@ class TestGroupNorm(TorchBaseTest):
     def test_groupnorm_rank3_input(
         self, compute_unit, backend, frontend, group_features, eps, affine
     ):
-        if frontend == TorchFrontend.EXECUTORCH:
-            pytest.skip("ExecuTorch uses native_group_norm")
-
         model = nn.GroupNorm(group_features[0], group_features[1], eps=eps, affine=affine)
         self.run_compare_torch(
             (6, group_features[1], 5),
@@ -1317,9 +1311,6 @@ class TestGroupNorm(TorchBaseTest):
     def test_groupnorm_rank2_input(
         self, compute_unit, backend, frontend, group_features, eps, affine
     ):
-        if frontend == TorchFrontend.EXECUTORCH:
-            pytest.skip("ExecuTorch uses native_group_norm")
-
         model = nn.GroupNorm(group_features[0], group_features[1], eps=eps, affine=affine)
         self.run_compare_torch(
             (4, group_features[1]),
@@ -1336,9 +1327,6 @@ class TestGroupNorm(TorchBaseTest):
         ),
     )
     def test_groupnorm_dynamic(self, compute_unit, backend, frontend, group_features, eps, affine):
-        if frontend == TorchFrontend.EXECUTORCH:
-            pytest.skip("ExecuTorch uses native_group_norm")
-
         model = nn.GroupNorm(group_features[0], group_features[1], eps=eps, affine=affine)
 
         lower_bound = 5


### PR DESCRIPTION
Although we already have `torch.group_norm` support, [ExecuTorch issue #6817](https://github.com/pytorch/executorch/issues/6817) uses `torch.native_group_norm`, so we need to add it

This PR
1. Factors out the group norm implementation, so both `torch.group_norm` & `torch.native_group_norm` translation functions can share
2. Add `torch.native_group_norm` translation function

Testing:
✅ https://gitlab.com/coremltools1/coremltools/-/commit/83fa94df6d52f848be8b2f8577ff67dab117dca1/pipelines