### PR TITLE
Add torch.jit.script shape support

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -4193,6 +4193,12 @@ def tupleunpack(context, node):
     inputs = _get_inputs(context, node, expected=1)
     values = inputs[0]
 
+    if isinstance(values, (Var)) and values.op.op_type == "shape":
+        for i in range(len(node.outputs)):
+            val = _list_select(values, i)
+            context.add(val, node.outputs[i])
+        return
+
     # Node input could have been turned into constant array in @tupleconstruct
     if not isinstance(values, (tuple, list)):
         if values.val is not None:

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -237,6 +237,24 @@ class TestScriptedModels(TorchBaseTest):
             use_scripting=True,
         )
 
+    @pytest.mark.parametrize("compute_unit, backend", itertools.product(compute_units, backends))
+    def test_shape_dynamic(self, compute_unit, backend):
+        class Model(nn.Module):
+            def forward(self, x):
+                a, _, b = x.shape
+                return torch.zeros([a, b])
+        model = Model().eval()
+        
+        input_shape = torch.randint(1, 10, [3]).tolist()
+        input_type = ct.TensorType(shape=ct.Shape([input_shape[0], input_shape[1], ct.RangeDim(1, 1_000)]))
+        self.run_compare_torch(
+            [input_shape],
+            model,
+            backend=backend,
+            compute_unit=compute_unit,
+            converter_input_type=[input_type],
+            use_scripting=True,
+        )
 
 class TestAffineGrid(TorchBaseTest):
     @pytest.mark.parametrize(


### PR DESCRIPTION
This PR adds support for converting the following model:

```Python
import torch
from torch import nn
import coremltools as ct
from typing import Final

class Model(nn.Module):
    def forward(self, x: torch.Tensor) -> torch.Tensor:
        a, _, b = x.shape
        return torch.zeros([a, b])

model = Model().eval()
traced_model = torch.jit.script(model)

var_dim: Final[ct.RangeDim] = ct.RangeDim(1, 10_000)
mlmodel = ct.convert(
    traced_model,
    inputs=[ct.TensorType(name="x", shape=ct.Shape([1, 3, var_dim]))],
    outputs=[ct.TensorType(name="y")],
)
mlmodel.save("tmp.mlpackage")
```
