### PR TITLE
Fix the randn conversion failure encountered in torch.export.

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -5485,11 +5485,17 @@ def rand_like(context, node):
 
 @register_torch_op
 def randn(context, node):
-    inputs = _get_inputs(context, node, expected=[5, 6])
+    inputs = _get_inputs(
+        context,
+        node,
+        expected={TorchFrontend.TORCHSCRIPT: [5, 6]},
+        min_expected={TorchFrontend.TORCHEXPORT: 1, TorchFrontend.EXECUTORCH: 1},
+    )
 
     shape = inputs[0]
-    dtype = inputs[1]
-    _assert_torch_dtype_num_is_not_complex_number(dtype)
+    if len(inputs) >= 2:
+        dtype = inputs[1]
+        _assert_torch_dtype_num_is_not_complex_number(dtype)
     rand_normal = mb.random_normal(shape=shape)
     rand_fp32 = mb.cast(x=rand_normal, dtype="fp32", name=node.name)
     context.add(rand_fp32)

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -4573,7 +4573,7 @@ class TestRandn(TorchBaseTest):
             [(1,), (2, 3)],
         ),
     )
-    def test_randn(self, compute_unit, backend, frontend, shape):
+    def test_randn_shape_only(self, compute_unit, backend, frontend, shape):
         class TestModel(nn.Module):
             def forward(self, x):
                 y = torch.randn(*x.shape)
@@ -4588,6 +4588,30 @@ class TestRandn(TorchBaseTest):
             compute_unit=compute_unit,
             backend=backend,
             frontend=frontend,
+        )
+
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend",
+        itertools.product(
+            compute_units,
+            backends,
+            frontends,
+        ),
+    )
+    def test_randn(self, compute_unit, backend, frontend):
+        class TestModel(torch.nn.Module):
+            def forward(self, x):
+                noise = torch.randn(x.shape)
+                return x + noise
+
+        self.run_compare_torch(
+            (1, 3, 16, 16),
+            TestModel(),
+            compute_unit=compute_unit,
+            backend=backend,
+            frontend=frontend,
+            atol=100.0,  # Don't verify numerical results due to randomness.
+            rtol=100.0,  # Don't verify numerical results due to randomness.
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
It's due to that torchscript produces 5/6 inputs, while torch.export only produces 1 input for that specific model.

Fixes https://github.com/apple/coremltools/issues/2443.

Testing: https://gitlab.com/coremltools1/coremltools/-/pipelines/1664432907