### PR TITLE
Fix for 2474 Bug in CoreMLTools when converting XGBoost models

### DIFF
--- a/coremltools/converters/xgboost/_tree_ensemble.py
+++ b/coremltools/converters/xgboost/_tree_ensemble.py
@@ -208,6 +208,11 @@ def convert_tree_ensemble(
             feature_names = model.feature_names
         if feature_names is None:
             feature_names = model.feature_names
+        else:  
+            # When XGboost model artefact does not have feature names
+            # (seems to be the default in new Xgboost releases),
+            # but the user provides them, use them as they are expecting later.
+            model.feature_names=feature_names
 
         xgb_model_str = model.get_dump(with_stats=True, dump_format="json")
 


### PR DESCRIPTION
The XGboost model artefact does not have feature names (seems to be the default in new Xgboost releases at least when passing a custom objective and loss function). To compensate for this, the user provides them through the feature_name variable, but the code then refers to, model.feature_names so update the model representation with the user provided feature_names