### PR TITLE
[#1946] Fix torch.nn.ConvTranspose1d conversion error when output_padding equals to padding

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -1384,12 +1384,16 @@ def _convolution(context, node):
             if len(post_crop) == 2 and conv.rank == 3:
                 # Number of elements to crop from right = post_crop[-1].
                 # Since slicing supports negative indexing, end_id = -1 * post_crop[-1]
+                end_mask = False
+                if post_crop[-1] == 0:
+                    end_mask = True
+
                 conv = mb.slice_by_index(
                     x=conv,
                     begin=[0, 0, post_crop[0]],
                     end=[0, 0, -1 * post_crop[-1]],
                     begin_mask=[True, True, False],
-                    end_mask=[True, True, False],
+                    end_mask=[True, True, end_mask],
                     name=node.name,
                 )
             elif len(post_crop) == 4 and conv.rank == 4:

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -1888,6 +1888,78 @@ class TestConvTranspose(TorchBaseTest):
                 "compute_unit",
                 "backend",
                 "frontend",
+                "width",
+                "in_channels",
+                "out_channels",
+                "kernel_size",
+                "stride",
+                "padding",
+                "dilation",
+                "output_padding",
+            ]
+        ),
+        [
+            (compute_unit, backend, frontend, *param)
+            for compute_unit, backend, frontend, param in itertools.product(
+                compute_units,
+                backends,
+                frontends,
+                [
+                    (5, 3, 3, 1, 3, 1, 3, 0),
+                    (5, 3, 3, 1, 3, 1, 1, 2),
+                    (5, 3, 3, 1, 3, 2, 1, 1),
+                    (5, 3, 3, 1, 3, 2, 1, 3),
+                    (5, 3, 3, 1, 3, 3, 3, 3),
+                    (5, 3, 3, 1, 3, 1, 3, 1),
+                    (5, 3, 3, 1, 3, 2, 1, 2),
+                ],
+            )
+        ],
+    )
+    def test_convolution_transpose1d_output_padding(
+        self,
+        compute_unit,
+        backend,
+        frontend,
+        width,
+        in_channels,
+        out_channels,
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        output_padding,
+    ):
+
+        # Output padding must be less than either stride or dilation
+        # Skip testing invalid combinations
+        if isinstance(output_padding, int):
+            if output_padding >= stride and output_padding >= dilation:
+                return
+
+        model = nn.ConvTranspose1d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            output_padding=output_padding,
+        )
+        self.run_compare_torch(
+            (1, in_channels, width),
+            model,
+            compute_unit=compute_unit,
+            backend=backend,
+            frontend=frontend,
+        )
+
+    @pytest.mark.parametrize(
+        ",".join(
+            [
+                "compute_unit",
+                "backend",
+                "frontend",
                 "height",
                 "width",
                 "in_channels",


### PR DESCRIPTION
### Changes
- Modified the _construct_conv_transpose method in converters/mil/frontend/torch/ops.py to add an ending mask in mb.slice_by_index when the end index is zero. This occurs when output_padding equals padding.
- Added the test case test_convolution_transpose1d_output_padding.

### Testing
- Verified that the test passes when output_padding equals padding and that normal cases are not affected.
- Executed the test_convolution_transpose1d_output_padding test case on macOS 11 with a CPU target. Verified that the Torch output is equal to the mlprogram/neuralnetwork output.

### Checklist
- Code changes adhere to the project's coding standards.
- Tests have been added/updated to verify the fix.