### PR TITLE
perf: Prefer generator expressions over list comprehensions

### DIFF
--- a/coremltools/converters/_converters_entry.py
+++ b/coremltools/converters/_converters_entry.py
@@ -750,14 +750,14 @@ def _validate_outputs_argument(outputs):
                                  'or of types ct.ImageType/ct.TensorType'
         if isinstance(outputs[0], str):
             # if one of the elements is a string, all elements must be strings
-            if not all([isinstance(t, str) for t in outputs]):
+            if not all(isinstance(t, str) for t in outputs):
                 raise ValueError(msg_inconsistent_types)
             return outputs, [TensorType(name=name) for name in outputs]
 
         if isinstance(outputs[0], InputType):
-            if not all([isinstance(t, TensorType) or isinstance(t, ImageType) for t in outputs]):
+            if not all(isinstance(t, TensorType) or isinstance(t, ImageType) for t in outputs):
                 raise ValueError(msg_inconsistent_types)
-            if any([t.shape is not None for t in outputs]):
+            if any(t.shape is not None for t in outputs):
                 msg = "The 'shape' argument must not be specified for the outputs, since it is " \
                       "automatically inferred from the input shapes and the ops in the model"
                 raise ValueError(msg)
@@ -777,9 +777,9 @@ def _validate_outputs_argument(outputs):
             output_names = [t.name for t in outputs]
             # verify that either all of the entries in output_names is "None" or none of them is "None"
             msg_consistent_names = 'Either none or all the outputs must have the "name" argument specified'
-            if output_names[0] is None and not all([name is None for name in output_names]):
+            if output_names[0] is None and not all(name is None for name in output_names):
                 raise ValueError(msg_consistent_names)
-            if output_names[0] is not None and not all([name is not None for name in output_names]):
+            if output_names[0] is not None and not all(name is not None for name in output_names):
                 raise ValueError(msg_consistent_names)
             if output_names[0] is not None:
                 if len(set(output_names)) != len(output_names):
@@ -914,7 +914,7 @@ def _validate_conversion_arguments(
         if inputs is not None:
             raise_if_duplicated(inputs)
 
-        if inputs is not None and not all([isinstance(_input, InputType) for _input in inputs]):
+        if inputs is not None and not all(isinstance(_input, InputType) for _input in inputs):
             raise ValueError("Input should be a list of TensorType or ImageType")
 
     elif exact_source == "pytorch":

--- a/coremltools/converters/mil/backend/mil/load.py
+++ b/coremltools/converters/mil/backend/mil/load.py
@@ -551,7 +551,7 @@ def _add_classify_op(prog, classifier_config):
         classes = classes.splitlines()
     elif isinstance(classes_in, list):  # list[int or str]
         classes = classes_in
-        assert all([isinstance(x, (int, str)) for x in classes]), message
+        assert all(isinstance(x, (int, str)) for x in classes), message
     else:
         raise ValueError(message)
 

--- a/coremltools/converters/mil/backend/nn/load.py
+++ b/coremltools/converters/mil/backend/nn/load.py
@@ -266,7 +266,7 @@ def load(prog, **kwargs):
 
     proto = builder.spec
     # image input
-    has_image_input = any([isinstance(s, ImageType) for s in input_types])
+    has_image_input = any(isinstance(s, ImageType) for s in input_types)
     if has_image_input:
         proto = _convert_to_image_input(proto, input_types,
                                         skip_model_load=kwargs.get("skip_model_load", False))
@@ -284,7 +284,7 @@ def load(prog, **kwargs):
                 shape = var.sym_type.get_shape()
                 if any_variadic(shape):
                     raise ValueError("Variable rank model outputs, that are ImageTypes, are not supported")
-                if any([is_symbolic(d) for d in shape]):
+                if any(is_symbolic(d) for d in shape):
                     raise NotImplementedError("Image output '{}' has symbolic dimensions in its shape".
                                               format(var.name))
                 _validate_image_input_output_shapes(output_types[i].color_layout, shape, var.name, is_input=False)

--- a/coremltools/converters/mil/backend/nn/op_mapping.py
+++ b/coremltools/converters/mil/backend/nn/op_mapping.py
@@ -196,7 +196,7 @@ def _try_convert_global_pool(const_context, builder, op, mode):
 
     if tuple(op.outputs[0].shape[:-2]) != tuple(op.inputs["x"].shape[:-2]):
         return False
-    if not all([s == 1 for s in op.outputs[0].shape[-2:]]):
+    if not all(s == 1 for s in op.outputs[0].shape[-2:]):
         return False
 
     builder.add_pooling(
@@ -795,11 +795,11 @@ def _add_elementwise_binary(
                 # INTERNAL_MUL_XYKN not implemented
                 continue
             if all(shape_x[indices] == shape_y[indices]):
-                if all([True if i in indices else s == 1 for i, s in enumerate(shape_x)]):
+                if all(True if i in indices else s == 1 for i, s in enumerate(shape_x)):
                     internal_y = op.x
                     internal_x = op.y
                     break
-                if all([True if i in indices else s == 1 for i, s in enumerate(shape_y)]):
+                if all(True if i in indices else s == 1 for i, s in enumerate(shape_y)):
                     internal_x = op.x
                     internal_y = op.y
                     break
@@ -3323,7 +3323,7 @@ def stack(const_context, builder, op):
 def split(const_context, builder, op):
     split = op.sizes
     split = [size for size in split if size != 0]
-    has_equal_splits = all([size == split[0] for size in split])
+    has_equal_splits = all(size == split[0] for size in split)
     num_splits = len(split)
     output_names = [op.outputs[i].name for i in range(len(op.sizes)) if op.sizes[i] != 0]
 
@@ -3545,7 +3545,7 @@ def _realloc_list(const_context, builder, ls_var, index_var, value_var, mode):
 
     # check if elem_shape is runtime-determined
     elem_shape = tuple(value_var.shape)
-    has_dynamic_shape = any([is_symbolic(i) for i in elem_shape])
+    has_dynamic_shape = any(is_symbolic(i) for i in elem_shape)
 
     # get the fill shape of the tensor array
     # [length, elem_dim1, elem_dim2, ...]

--- a/coremltools/converters/mil/converter.py
+++ b/coremltools/converters/mil/converter.py
@@ -58,7 +58,7 @@ class MILFrontend:
                         type(inputs)
                     )
                 )
-            if not all([isinstance(i, input_types.InputType) for i in inputs]):
+            if not all(isinstance(i, input_types.InputType) for i in inputs):
                 raise ValueError(
                     "Type of inputs should be list or tuple of TensorType or ImageType, got {} instead.".format(
                         [type(i) for i in inputs]

--- a/coremltools/converters/mil/debugging_utils.py
+++ b/coremltools/converters/mil/debugging_utils.py
@@ -84,7 +84,7 @@ def extract_submodel(
                 else:
                     input_values.append(v)
 
-            if all([x in reachable_vars for x in input_values]):
+            if all(x in reachable_vars for x in input_values):
                 reachable_vars.update(op.outputs)
 
         for out in func.outputs:

--- a/coremltools/converters/mil/frontend/_utils.py
+++ b/coremltools/converters/mil/frontend/_utils.py
@@ -293,7 +293,7 @@ def build_einsum_mil(vars: List[Var], equation: str, name: str) -> Var:
         return b, a
 
     a_var, b_var = vars
-    is_dynamic = any([any_symbolic(var.shape) for var in vars])
+    is_dynamic = any(any_symbolic(var.shape) for var in vars)
     # list of equations supported for explicit mil translations
     vec_bnqd_bnkd_bnqk = (
         [0, 1, 2, 3],
@@ -436,10 +436,10 @@ def get_output_names(outputs) -> Optional[List[str]]:
 
     output_names = None
     if outputs is not None:
-        assert all([isinstance(t, InputType) for t in outputs]), \
+        assert all(isinstance(t, InputType) for t in outputs), \
             "outputs must be a list of ct.ImageType or ct.TensorType"
         output_names = [t.name for t in outputs]
-        if all([name is None for name in output_names]):
+        if all(name is None for name in output_names):
             output_names = None
     return output_names
 

--- a/coremltools/converters/mil/frontend/tensorflow/converter.py
+++ b/coremltools/converters/mil/frontend/tensorflow/converter.py
@@ -179,7 +179,7 @@ class TFConverter:
                         type(inputs)
                     )
                 )
-            if not all([isinstance(i, InputType) for i in inputs]):
+            if not all(isinstance(i, InputType) for i in inputs):
                 raise ValueError(
                     "Type of inputs should be list or tuple of TensorType or ImageType, got {} instead.".format(
                         [type(i) for i in inputs]
@@ -238,7 +238,7 @@ class TFConverter:
         for inputtype in self.inputs:
             if not isinstance(inputtype.shape, InputShape):
                 continue
-            if any([isinstance(s, RangeDim) for s in inputtype.shape.shape]):
+            if any(isinstance(s, RangeDim) for s in inputtype.shape.shape):
                 continue
             if inputtype.name not in graph:
                 raise ValueError(

--- a/coremltools/converters/mil/frontend/tensorflow/ops.py
+++ b/coremltools/converters/mil/frontend/tensorflow/ops.py
@@ -633,7 +633,7 @@ def ExtractImagePatches(context, node):
     padding = node.attr.get("padding")
     if x.rank != 4:
         raise ValueError("input for ExtractImagePatches should be a 4D tensor.")
-    if not all([rate == 1 for rate in rates]):
+    if not all(rate == 1 for rate in rates):
         raise NotImplementedError(
             "only rates with all 1s is implemented for ExtractImagePatches."
         )
@@ -3022,7 +3022,7 @@ def Pack(context, node):
         else:
             x = mb.expand_dims(x=values[0], axes=[axis], name=node.name)
     else:
-        if all([_is_scalar(input.sym_type) for input in values]):
+        if all(_is_scalar(input.sym_type) for input in values):
             x = mb.concat(values=values, axis=axis, name=node.name)
         else:
             x = mb.stack(values=values, axis=axis, name=node.name)

--- a/coremltools/converters/mil/frontend/tensorflow/ssa_passes/tf_lstm_to_core_lstm.py
+++ b/coremltools/converters/mil/frontend/tensorflow/ssa_passes/tf_lstm_to_core_lstm.py
@@ -106,7 +106,7 @@ def _try_get_last_cell_state_in_tf_lstm_block(op: Operation) -> Var:
         return cs
     if len(cs.consuming_blocks) > 1:
         return None
-    if not all([child_op.op_type == "slice_by_index" for child_op in cs.child_ops]):
+    if not all(child_op.op_type == "slice_by_index" for child_op in cs.child_ops):
         return None
     child_ops = cs.child_ops[:]
     block = op.enclosing_block

--- a/coremltools/converters/mil/frontend/tensorflow/test/test_ops.py
+++ b/coremltools/converters/mil/frontend/tensorflow/test/test_ops.py
@@ -1767,7 +1767,7 @@ class TestSeparableConv(TensorFlowBaseTest):
             )
 
         test_static_W()
-        if not any([True if d > 1 else False for d in dilations]):
+        if not any(True if d > 1 else False for d in dilations):
             if backend[0] == "neuralnetwork":
                 pytest.skip("dynamic conv with groups > 1 is not supported on the neuralnetwork backend")
             test_dynamic_W()

--- a/coremltools/converters/mil/frontend/tensorflow/test/testing_utils.py
+++ b/coremltools/converters/mil/frontend/tensorflow/test/testing_utils.py
@@ -164,7 +164,7 @@ def tf_graph_to_mlmodel(
             input_types.append(
                 ct.TensorType(name=input_placeholder.name.split(":")[0], shape=input_shape)
             )
-            if any([dim.value is None for dim in input_placeholder.shape]):
+            if any(dim.value is None for dim in input_placeholder.shape):
                 has_dynamic_shape = True
         if has_dynamic_shape:
             inputs_for_conversion = input_types

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -6217,7 +6217,7 @@ def meshgrid(context, node):
         assert isinstance(tensor_inputs, (list, tuple))
         if len(tensor_inputs) < 2:
             raise ValueError("Requires >= 2 tensor inputs.")
-        if any([tensor_input.rank > 1 for tensor_input in tensor_inputs]):
+        if any(tensor_input.rank > 1 for tensor_input in tensor_inputs):
             raise ValueError("meshgrid received non-1d tensor.")
 
         if indexing not in ("ij", "xy"):
@@ -7200,7 +7200,7 @@ def where(context, node):
     if not types.is_bool(cond.dtype):
         # cond must be bool type
         cond = mb.cast(x=cond, dtype="bool")
-    if not any([any_symbolic(x.shape) for x in (cond, a, b)]):
+    if not any(any_symbolic(x.shape) for x in (cond, a, b)):
         # broadcast all tensors to the same shape
         cond, a, b = _utils.pymil_broadcast_tensors([cond, a, b])
     result = mb.select(cond=cond, a=a, b=b, name=node.name)
@@ -7692,7 +7692,7 @@ def _pad_packed_sequence(context, node):
 
     # we only support pack and unpack translation for static tensor shape,
     # i.e., the three dimensions are all known during compile time.
-    if any([is_symbolic(x) for x in input_tensor.shape]):
+    if any(is_symbolic(x) for x in input_tensor.shape):
         raise NotImplementedError("Only static shape of PackedSequence object is supported.")
 
     # the input always has batch first layout.

--- a/coremltools/converters/mil/mil/block.py
+++ b/coremltools/converters/mil/mil/block.py
@@ -1126,7 +1126,7 @@ class Function(Block):
         if outputs is not None:
             if not (
                 isinstance(outputs, list)
-                and all([isinstance(out, _input_types.InputType) for out in outputs])
+                and all(isinstance(out, _input_types.InputType) for out in outputs)
             ):
                 raise TypeError(
                     "main outputs should be a list of type ct.TensorType or ct.ImageType"
@@ -1136,6 +1136,6 @@ class Function(Block):
     def set_input_types(self, input_types: List["_input_types.InputType"]):
         if not isinstance(input_types, tuple):
             raise ValueError("main inputs should be tuple of TensorType or ImageType")
-        elif not all([isinstance(inp, _input_types.InputType) for inp in input_types]):
+        elif not all(isinstance(inp, _input_types.InputType) for inp in input_types):
             raise ValueError("main inputs should be tuple of InputSpec")
         self.input_types = input_types

--- a/coremltools/converters/mil/mil/ops/defs/iOS15/conv.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS15/conv.py
@@ -182,7 +182,7 @@ class conv(Operation):
         custom_pad = None if self.pad_type.val != 'custom' else self.pad.val
 
         is_weight_dynamic = not self.weight.is_descendant_of_const
-        if is_weight_dynamic and any([True if d > 1 else False for d in dilations]):
+        if is_weight_dynamic and any(True if d > 1 else False for d in dilations):
             raise ValueError("Convolution with dynamic weights does not support dilations!")
 
         N = inshape[0]

--- a/coremltools/converters/mil/mil/ops/defs/iOS15/elementwise_binary.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS15/elementwise_binary.py
@@ -65,7 +65,7 @@ class elementwise_binary(Operation):
         """
         If one of the input is tensor, cast the result to tensor.
         """
-        to_cast = any([isinstance(x, np.ndarray) for x in [a, b]])
+        to_cast = any(isinstance(x, np.ndarray) for x in (a, b))
         result = self.get_operator()(a, b)
         return result if not to_cast else np.array(result)
 

--- a/coremltools/converters/mil/mil/ops/defs/iOS15/normalization.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS15/normalization.py
@@ -283,7 +283,7 @@ class layer_norm(Operation):
 
         # check valid axes
         positive_axes = [axis + rank if axis < 0 else axis for axis in self.axes.val]
-        if not all([axis >= 0 and axis < rank for axis in positive_axes]):
+        if not all(axis >= 0 and axis < rank for axis in positive_axes):
             raise ValueError("axes must in the range of [-x.rank, x.rank-1].")
 
         # check shape of gamma and beta

--- a/coremltools/converters/mil/mil/ops/defs/iOS15/tensor_operation.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS15/tensor_operation.py
@@ -1091,7 +1091,7 @@ class concat(Operation):
             symbolic_tensor = np.reshape(np.array(symbolic_tensor), shape)
             values.append(symbolic_tensor)
 
-        if any([val is None for val in values]):
+        if any(val is None for val in values):
             return None
 
         if not isinstance(values[0], np.ndarray) or values[0].shape == ():
@@ -1301,13 +1301,13 @@ class stack(Operation):
     @precondition(allow=VALUE | SYMBOL | NONE)
     def value_inference(self):
 
-        is_all_rank_zero = all([v.rank == 0 for v in self.values])
+        is_all_rank_zero = all(v.rank == 0 for v in self.values)
         values = [
             v.sym_val if v.sym_val is not None else get_new_symbol()
             for v in self.values
         ]
 
-        if any([is_symbolic(v) for v in values]) and not is_all_rank_zero:
+        if any(is_symbolic(v) for v in values) and not is_all_rank_zero:
             return None
 
         return np.stack(values, self.axis.val)

--- a/coremltools/converters/mil/mil/ops/tests/iOS14/test_scatter_gather.py
+++ b/coremltools/converters/mil/mil/ops/tests/iOS14/test_scatter_gather.py
@@ -478,7 +478,7 @@ class TestGather:
             res = mb.gather(x=params, indices=indices, axis=-1)
             return res
 
-        if any([idx > 2 for idx in indices_val]):
+        if any(idx > 2 for idx in indices_val):
             with pytest.raises(IndexError, match="index 3 is out of bounds for axis 1 with size 3"):
                 mb.program(
                     input_specs=[mb.TensorSpec(shape=(1,), dtype=types.fp32)],
@@ -672,7 +672,7 @@ class TestGatherAlongAxis:
             res = mb.gather_along_axis(x=params, indices=indices, axis=0)
             return res
 
-        if any([idx > 1 for sub_indices in indices_val for idx in sub_indices]):
+        if any(idx > 1 for sub_indices in indices_val for idx in sub_indices):
             with pytest.raises(IndexError, match="index 2 is out of bounds for axis 0 with size 2"):
                 mb.program(
                     input_specs=[mb.TensorSpec(shape=(1,), dtype=types.fp32)],

--- a/coremltools/converters/mil/mil/ops/tests/iOS17/test_scatter_gather.py
+++ b/coremltools/converters/mil/mil/ops/tests/iOS17/test_scatter_gather.py
@@ -131,7 +131,7 @@ class TestScatter:
 
         if not isinstance(expected_error_msg, tuple):
             expected_error_msg = expected_error_msg
-        assert any([err in str(excinfo.value) for err in expected_error_msg])
+        assert any(err in str(excinfo.value) for err in expected_error_msg)
 
 class TestScatterAlongAxis:
     @pytest.mark.parametrize(
@@ -224,7 +224,7 @@ class TestScatterAlongAxis:
 
         if not isinstance(expected_error_msg, tuple):
             expected_error_msg = expected_error_msg
-        assert any([err in str(excinfo.value) for err in expected_error_msg])
+        assert any(err in str(excinfo.value) for err in expected_error_msg)
 
 
 class TestScatterNd:
@@ -295,7 +295,7 @@ class TestScatterNd:
             )
         if not isinstance(expected_error_msg, tuple):
             expected_error_msg = expected_error_msg
-        assert any([err in str(excinfo.value) for err in expected_error_msg])
+        assert any(err in str(excinfo.value) for err in expected_error_msg)
 
 
 class TestGather(_TestGatherIOS16):
@@ -333,7 +333,7 @@ class TestGather(_TestGatherIOS16):
                     input_specs=[mb.TensorSpec(shape=(1,), dtype=types.fp32)],
                     opset_version=backend.opset_version,
                 )(prog)
-        elif any([idx > 2 for idx in indices_val]):
+        elif any(idx > 2 for idx in indices_val):
             # If the indices are not validated during type inference for IOS17, the `gather` op's
             # value inference will raise error for out-of-bound index.
             with pytest.raises(IndexError, match="index 3 is out of bounds for axis 1 with size 3"):
@@ -410,7 +410,7 @@ class TestGatherAlongAxis:
                     input_specs=[mb.TensorSpec(shape=(1,), dtype=types.fp32)],
                     opset_version=backend.opset_version,
                 )(prog)
-        elif any([idx > 1 for sub_indices in indices_val for idx in sub_indices]):
+        elif any(idx > 1 for sub_indices in indices_val for idx in sub_indices):
             # If the indices are not validated during type inference for IOS17, the `gather` op's
             # value inference will raise error for out-of-bound index.
             with pytest.raises(IndexError, match="index 2 is out of bounds for axis 0 with size 2"):

--- a/coremltools/converters/mil/mil/passes/defs/cleanup/noop_elimination.py
+++ b/coremltools/converters/mil/mil/passes/defs/cleanup/noop_elimination.py
@@ -127,7 +127,7 @@ class noop_elimination(AbstractGraphPass):
 
             if op.stride is not None and op.stride.val is not None:
                 stride = op.stride.val.flatten().tolist()
-                if any([x < 0 for x in stride]):
+                if any(x < 0 for x in stride):
                     return False
 
             if op.enclosing_block.try_replace_uses_of_var_after_op(

--- a/coremltools/converters/mil/mil/passes/defs/optimize_activation_quantization.py
+++ b/coremltools/converters/mil/mil/passes/defs/optimize_activation_quantization.py
@@ -161,7 +161,7 @@ class insert_suffix_quantize_dequantize_pair(AbstractGraphPass):
 
         # Reject if 1st operation is not `conv`/`add`/`pool`.
         SUPPORTED_OP_TYPES = ["conv", "add", "avg_pool", "max_pool"]
-        if any([_check_child_op_type(dequantize_op, val) for val in SUPPORTED_OP_TYPES]):
+        if any(_check_child_op_type(dequantize_op, val) for val in SUPPORTED_OP_TYPES):
             pass
         else:
             return False

--- a/coremltools/converters/mil/mil/passes/defs/optimize_linear.py
+++ b/coremltools/converters/mil/mil/passes/defs/optimize_linear.py
@@ -239,7 +239,7 @@ class fuse_matmul_weight_bias(AbstractGraphPass):
         d_out = weight.shape[1] if not transpose_weight else weight.shape[0]
         bias = add_op.x.val if add_op.x.val is not None else add_op.y.val
         if len(bias.shape) > 1:
-            if any([d != 1 for d in bias.shape[:-1]]):
+            if any(d != 1 for d in bias.shape[:-1]):
                 return  # cannot transform
 
             # squeeze leading dims of size 1

--- a/coremltools/converters/mil/mil/passes/defs/optimize_state.py
+++ b/coremltools/converters/mil/mil/passes/defs/optimize_state.py
@@ -199,7 +199,7 @@ class prefer_state_in_downstream(AbstractGraphPass):
                 return
 
             # if the var only feeds into coreml_update_state ops, this pass should do nothing
-            if all([val.op_type == "coreml_update_state" for val in other_child_ops]):
+            if all(val.op_type == "coreml_update_state" for val in other_child_ops):
                 return
 
             block.try_replace_uses_of_var_after_op(

--- a/coremltools/converters/mil/mil/passes/tests/test_passes.py
+++ b/coremltools/converters/mil/mil/passes/tests/test_passes.py
@@ -2259,7 +2259,7 @@ class TestCastOptimizationComplexPatterns:
             "identity",
         ]
         cast_ops = block.find_ops(op_type="cast")
-        assert all([v.dtype.val == "int32" for v in cast_ops])
+        assert all(v.dtype.val == "int32" for v in cast_ops)
 
         apply_pass_and_basic_check(prog, "common::remove_redundant_ops")
         _, _, block = apply_pass_and_basic_check(prog, "common::dead_code_elimination")
@@ -2352,7 +2352,7 @@ class TestCastOptimizationComplexPatterns:
             "abs",
         ]
         cast_ops = block.find_ops(op_type="cast")
-        assert all([v.dtype.val == "int32" for v in cast_ops])
+        assert all(v.dtype.val == "int32" for v in cast_ops)
 
         apply_pass_and_basic_check(prog, "common::remove_redundant_ops")
         _, _, block = apply_pass_and_basic_check(prog, "common::dead_code_elimination")
@@ -5875,7 +5875,7 @@ class TestUpdateOutputDtypes:
             "common::update_output_dtypes",
         )
         warning_msg = "Output var 'input' is also an input var, hence the dtype cannot be changed: output var 'input' remains dtype fp32"
-        assert any([warning_msg in rec.message for rec in caplog.records])
+        assert any(warning_msg in rec.message for rec in caplog.records)
         assert get_op_types_in_program(prog) == []
         assert block.outputs[0].dtype == types.fp32
 

--- a/coremltools/converters/mil/mil/passes/tests/test_quantization_passes.py
+++ b/coremltools/converters/mil/mil/passes/tests/test_quantization_passes.py
@@ -2535,7 +2535,7 @@ class TestTransformFunctionSignatures:
         assert block.outputs[2] is block.inputs["x"]
         assert block.outputs[3] is block.inputs["x"]
 
-        assert all([x.dtype == types.fp16 for x in block.output_types])
+        assert all(x.dtype == types.fp16 for x in block.output_types)
 
         assert get_op_types_in_program(prog) == ["cast", "relu"]
         cast_op = block.find_ops(op_type="cast")[0]

--- a/coremltools/converters/mil/mil/tests/test_debug.py
+++ b/coremltools/converters/mil/mil/tests/test_debug.py
@@ -119,7 +119,7 @@ class TestExtractSubModel:
         names = [output.name for output in outputs]
         assert len(outputs) == 2
         assert "cos" in names and "relu" in names
-        assert all([o.dtype == types.fp16 for o in outputs]), "all fp16 dtypes"
+        assert all(o.dtype == types.fp16 for o in outputs), "all fp16 dtypes"
 
     def test_extract_submodel_complex(self):
         """

--- a/coremltools/converters/mil/mil/tests/test_programs.py
+++ b/coremltools/converters/mil/mil/tests/test_programs.py
@@ -241,13 +241,13 @@ class TestMILProgramVersionHandling:
         prog = get_simple_nested_block_program()
         main_func = prog.functions["main"]
         topk_ops = main_func.find_ops(op_type="topk")
-        assert all([topk.opset_version == ct.target.iOS13 for topk in topk_ops])
+        assert all(topk.opset_version == ct.target.iOS13 for topk in topk_ops)
 
         # pick up iOS16 version topk
         prog = get_simple_nested_block_program(opset_version=ct.target.iOS16)
         main_func = prog.functions["main"]
         topk_ops = main_func.find_ops(op_type="topk")
-        assert all([topk.opset_version == ct.target.iOS16 for topk in topk_ops])
+        assert all(topk.opset_version == ct.target.iOS16 for topk in topk_ops)
 
     @staticmethod
     def test_pymil_opset_version_inference():

--- a/coremltools/converters/mil/mil/var.py
+++ b/coremltools/converters/mil/mil/var.py
@@ -179,7 +179,7 @@ class Var:
         ):
             return True
         flattened_inputs = op.get_flattened_inputs()
-        return all([x.is_descendant_of_const for x in flattened_inputs])
+        return all(x.is_descendant_of_const for x in flattened_inputs)
 
     def _set_nonreplaceable_vars_upstream(self):
         """

--- a/coremltools/models/neural_network/builder.py
+++ b/coremltools/models/neural_network/builder.py
@@ -5965,7 +5965,7 @@ class NeuralNetworkBuilder:
                 or self.spec.specificationVersion < _SPECIFICATION_VERSION_IOS_14
             ):
                 self.spec.specificationVersion = _SPECIFICATION_VERSION_IOS_14
-        assert all([i > 0 for i in reps])
+        assert all(i > 0 for i in reps)
         spec_layer_params.reps.extend(reps)
         return spec_layer
 

--- a/coremltools/models/neural_network/utils.py
+++ b/coremltools/models/neural_network/utils.py
@@ -125,8 +125,7 @@ def make_nn_classifier(
         classes = classes.splitlines()
     elif isinstance(classes_in, list):  # list[int or str]
         classes = classes_in
-        assert all([isinstance(x, \
-            (int, str)) for x in classes]), message
+        assert all(isinstance(x, (int, str)) for x in classes), message
     else:
         raise ValueError(message)
 

--- a/coremltools/models/utils.py
+++ b/coremltools/models/utils.py
@@ -2369,7 +2369,7 @@ def change_input_output_tensor_type(
     def _get_input_vars(var_name: str) -> _Iterable[_Tuple[_Optional[_mil.block.Function], _Optional[_mil.Var]]]:
         for name in function_names:
             func = prog.functions[name]
-            var = next(iter([v for k, v in func.inputs.items() if k == var_name]), None)
+            var = next(iter(v for k, v in func.inputs.items() if k == var_name), None)
             if var:
                 if func.opset_version < _ct.target.iOS16:
                     _logger.warning(f"upgrading opset_version for function {func.name} to iOS16")
@@ -2379,7 +2379,7 @@ def change_input_output_tensor_type(
     def _get_output_vars(var_name: str) -> _Iterable[_Tuple[_Optional[_mil.block.Function], _Optional[_mil.Var]]]:
         for name in function_names:
             func = prog.functions[name]
-            var = next(iter([v for v in func.outputs if v.name == var_name]), None)
+            var = next(iter(v for v in func.outputs if v.name == var_name), None)
             if var:
                 if func.opset_version < _ct.target.iOS16:
                     _logger.warning(f"upgrading opset_version for function {func.name} to iOS16")

--- a/coremltools/test/optimize/coreml/test_passes.py
+++ b/coremltools/test/optimize/coreml/test_passes.py
@@ -223,7 +223,7 @@ class TestCompressionNumerical:
         )
         assert result is None
         expected_warning_msg = "Invalid block_sizes"
-        assert any([expected_warning_msg in rec.message for rec in caplog.records])
+        assert any(expected_warning_msg in rec.message for rec in caplog.records)
 
     @pytest.mark.parametrize(
         "mode, nbits, shape",
@@ -1815,7 +1815,7 @@ class TestLinearQuantizer(TestCompressionPasses):
         prog = self._get_test_program_3()
         compressor.apply(prog)
         warning_msg = "Invalid block_sizes; On 1th axis, the dim size 30 is not divisible by block size 13. Unable to perform structured quantization."
-        assert any([re.match(warning_msg, rec.message) for rec in caplog.records])
+        assert any(re.match(warning_msg, rec.message) for rec in caplog.records)
 
 
 class TestPruner(TestCompressionPasses):
@@ -2530,7 +2530,7 @@ class TestPalettizer(TestCompressionPasses):
                 f"Can't perform palettization: The number of channels at {axis}th axis .* is not "
                 "divisible by channel_group_size"
             )
-            assert any([re.match(warning_msg, rec.message) for rec in caplog.records])
+            assert any(re.match(warning_msg, rec.message) for rec in caplog.records)
         # Only the conv get compressed.
         lut_ops = prog.find_ops(op_type="constexpr_lut_to_dense")
         assert len(lut_ops) == 1

--- a/coremltools/test/optimize/coreml/test_post_training_quantization.py
+++ b/coremltools/test/optimize/coreml/test_post_training_quantization.py
@@ -972,7 +972,7 @@ class TestPalettizeWeights:
         # converter should warn the user that one weight is not compressed
         mlmodel_palettized = palettize_weights(mlmodel, mode="unique")
         warning_msg = "Unique values in weight cannot be represented by 8 bits palettization."
-        assert any([warning_msg in rec.message for rec in caplog.records])
+        assert any(warning_msg in rec.message for rec in caplog.records)
 
         expected_ops = ['constexpr_lut_to_dense', 'cast', 'conv', 'conv', 'cast']
         assert get_op_types_in_program(mlmodel_palettized._mil_program) == expected_ops
@@ -1545,7 +1545,7 @@ class TestPalettizeWeights:
 
         # As the effective dim size (1) is not divisible by cluster_dim, the op won't be palettized.
         warning_msg = "The `cluster_dim` is invalid for .* Skipped this op."
-        assert any([re.match(warning_msg, rec.message) for rec in caplog.records])
+        assert any(re.match(warning_msg, rec.message) for rec in caplog.records)
         assert get_op_types_in_program(mlmodel._mil_program) == get_op_types_in_program(
             mlmodel_palettized._mil_program
         )


### PR DESCRIPTION
### Performance
Prefer generator expressions over list comprehensions for short-circuiting functions like `any()`, `all()` and `next(iter())`.

### TODO
I reverted the other possible list comprehensions even when it feels more pythonic to me.
Where large temporary lists are being built generator comprehensions could be beneficial too, but I couldn't determine the memory vs. performance implications myself, I suggest looking at profiling data.