### PR TITLE
fix: numpy 2 prefers asarray() instead of copy=False

### DIFF
--- a/coremltools/converters/mil/mil/ops/defs/iOS15/elementwise_unary.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS15/elementwise_unary.py
@@ -446,7 +446,7 @@ class inverse(Operation):
 
     @precondition(allow=VALUE)
     def value_inference(self):
-        return np.array(np.reciprocal(self.x.val + self.epsilon.val), copy=False)
+        return np.asarray(np.reciprocal(self.x.val + self.epsilon.val))
 
 
 @register_op


### PR DESCRIPTION
I read in an issue that in some cases `np.array(copy=False)` fails: https://github.com/apple/coremltools/issues/2479#issuecomment-2812736201
It's recommended to migrate to `np.asarray()` (without copy):
https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword