### PR TITLE
Fix the reflection padding optimization when slice_by_index's `end_mask` is not specified

### DIFF
--- a/coremltools/converters/mil/mil/passes/defs/optimize_tensor_operation.py
+++ b/coremltools/converters/mil/mil/passes/defs/optimize_tensor_operation.py
@@ -896,13 +896,9 @@ class use_reflection_padding(AbstractGraphPass):
 
             if end_mask is None:
                 end_mask = use_reflection_padding._resolve_end_mask(slice_op)
-                if end_mask is None:
+                if end_mask is None or False not in end_mask:
                     return False
-
                 axis = list(end_mask).index(False, 0, len(end_mask))
-
-            if axis != list(end_mask).index(False, 0, len(end_mask)):
-                return False
 
             # Check that we're only taking a slice of size 1
             end = slice_op.inputs["end"].val

--- a/coremltools/converters/mil/mil/passes/tests/test_passes.py
+++ b/coremltools/converters/mil/mil/passes/tests/test_passes.py
@@ -5308,6 +5308,30 @@ class TestUseReflectionPadding:
             expected_output_shapes={block.outputs[0].name: (3, 2, 6, 8)},
         )
 
+    def test_success_no_end_mask(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 2, 6, 8))])
+        def prog(x1):
+            left = mb.slice_by_index(
+                x=x1, begin=[0, 0, 0, 1], end=[1, 2, 6, 2],
+            )
+            right = mb.slice_by_index(
+                x=x1, begin=[0, 0, 0, -2], end=[1, 2, 6, -1],
+            )
+            x = mb.concat(values=[left, x1, right], axis=3)
+
+            return x
+
+        prev_prog, _, block = apply_pass_and_basic_check(prog, "common::use_reflection_padding")
+        assert get_op_types_in_program(prev_prog) == ["slice_by_index", "slice_by_index", "concat"]
+        assert get_op_types_in_program(prog) == ["pad"]
+
+        inputs = {"x1": (1, 2, 6, 8)}
+        assert_model_is_valid(
+            prog,
+            inputs,
+            expected_output_shapes={block.outputs[0].name: (1, 2, 6, 10)},
+        )
+
 
 class TestDivideToMultiply:
     def test_divide_to_multiply(self):


### PR DESCRIPTION
Before this PR, the added tests would error with an undefined attribute error, when `end_mask` was not specified on the `slice_by_index` operations.

Instead of bailing out of the optimization, if `end_mask` is not specified, this PR will infer the values of `end_mask`.