### PR TITLE
docs: update cto.coreml path in ptq docs

### DIFF
--- a/coremltools/optimize/coreml/_post_training_quantization.py
+++ b/coremltools/optimize/coreml/_post_training_quantization.py
@@ -578,9 +578,9 @@ def linear_quantize_activations(
 
         # (Optional) It's recommended to use with linear_quantize_weights.
         weight_config = cto.coreml.OptimizationConfig(
-            global_config=cto.OpLinearQuantizerConfig(mode="linear_symmetric")
+            global_config=cto.coreml.OpLinearQuantizerConfig(mode="linear_symmetric")
         )
-        compressed_model_w8a8 = cto.linear_quantize_weights(compressed_model_a8, weight_config)
+        compressed_model_w8a8 = cto.coreml.linear_quantize_weights(compressed_model_a8, weight_config)
     """
     # Validate Sample data. If the sample data name is not provided, try to infer it.
     for sample in sample_data:

--- a/coremltools/optimize/coreml/experimental/_post_training_quantization.py
+++ b/coremltools/optimize/coreml/experimental/_post_training_quantization.py
@@ -85,9 +85,9 @@ def linear_quantize_activations(
 
         # (Optional) It's recommended to use with linear_quantize_weights.
         weight_config = cto.coreml.OptimizationConfig(
-            global_config=cto.OpLinearQuantizerConfig(mode="linear_symmetric")
+            global_config=cto.coreml.OpLinearQuantizerConfig(mode="linear_symmetric")
         )
-        compressed_model_w8a8 = cto.linear_quantize_weights(compressed_model_a8, weight_config)
+        compressed_model_w8a8 = cto.coreml.linear_quantize_weights(compressed_model_a8, weight_config)
     """
     return _post_training_quantization.linear_quantize_activations(
         mlmodel, config, sample_data, calibration_op_group_size


### PR DESCRIPTION
Updated path since `coremltools.optimize.coreml` houses PTQ-related functions.

There to be inconsistencies of naming in the codebase; I see some usages of:
```python
import coremltools.optimize.coreml as cto
```
and some of:
```python
import coremltools.optimize as cto
cto.coreml.(...)
```

Not sure if there is a convention to follow here.