### PR TITLE
[Quantization (cto.coreml)] Ensure inputs are non-const before adding Q/DQ pair

### DIFF
--- a/coremltools/optimize/coreml/_quantization_passes.py
+++ b/coremltools/optimize/coreml/_quantization_passes.py
@@ -1704,6 +1704,10 @@ class insert_prefix_quantize_dequantize_pair(AbstractActCompressionPass):
         if op_config is None:
             return
 
+        x_is_const = op.inputs["x"].op is not None and op.inputs["x"].op.op_type == "const"
+        if x_is_const:
+            return  # Input x needs to be non-const.
+
         new_op_args = dict()
         new_op_args.update(op.inputs.items())
         new_op_args["x"] = self._construct_quant_dequant_op(
@@ -1722,9 +1726,8 @@ class insert_prefix_quantize_dequantize_pair(AbstractActCompressionPass):
                     quantize -> dequantize |
             So we need to quantize y in the same way.
             """
-            x_is_const = op.inputs["x"].op is not None and op.inputs["x"].op.op_type == "const"
             y_is_const = op.inputs["y"].op is not None and op.inputs["y"].op.op_type == "const"
-            if x_is_const or y_is_const:
+            if y_is_const:
                 return  # Both inputs x and y need to be non-const.
             new_op_args["y"] = self._construct_quant_dequant_op(
                 op.inputs["y"], op_config.dtype, op_config.mode


### PR DESCRIPTION
For unary and/or binary ops, we want to ensure that input X is non-const when creating Q/DQ pair. Activation stats are not tracked for const ops
https://github.com/apple/coremltools/blob/30a96886b59c8202a67e6b64451c3b1156c79da5/coremltools/optimize/coreml/experimental/_post_training_quantization.py#L228

and trying to run activation quantization yields the following:
```bash
Running activation compression pass insert_prefix_quantize_dequantize_pair:  15%|█████████▉                                                        | 187/1238 [00:00<00:00, 311738.81 ops/s]
Traceback (most recent call last):
  File "/Users/jamxu/Documents/coreml/ios-experiments/w8a8_quantize.py”, line 63, in <module>
    compressed_model_a8 = cto.coreml.linear_quantize_activations(
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jamxu/Documents/coreml/miniconda3/envs/coreml-ios/lib/python3.12/site-packages/coremltools/optimize/coreml/_post_training_quantization.py", line 623, in linear_quantize_activations
    mlmodel_activation_quantized = _model_utils._apply_graph_pass(
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jamxu/Documents/coreml/miniconda3/envs/coreml-ios/lib/python3.12/site-packages/coremltools/models/utils.py", line 1369, in _apply_graph_pass
    cur_graph_pass.apply(prog)
  File "/Users/jamxu/Documents/coreml/miniconda3/envs/coreml-ios/lib/python3.12/site-packages/coremltools/optimize/coreml/_quantization_passes.py", line 1587, in apply
    apply_block(f)
  File "/Users/jamxu/Documents/coreml/miniconda3/envs/coreml-ios/lib/python3.12/site-packages/coremltools/converters/mil/mil/passes/helper.py", line 64, in wrapper
    return _func(*args)
           ^^^^^^^^^^^^
  File "/Users/jamxu/Documents/coreml/miniconda3/envs/coreml-ios/lib/python3.12/site-packages/coremltools/optimize/coreml/_quantization_passes.py", line 1584, in apply_block
    self.transform_op(op)
  File "/Users/jamxu/Documents/coreml/miniconda3/envs/coreml-ios/lib/python3.12/site-packages/coremltools/optimize/coreml/_quantization_passes.py", line 1709, in transform_op
    new_op_args["x"] = self._construct_quant_dequant_op(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jamxu/Documents/coreml/miniconda3/envs/coreml-ios/lib/python3.12/site-packages/coremltools/optimize/coreml/_quantization_passes.py", line 1664, in _construct_quant_dequant_op
    input_min_max = optimize_utils.get_min_and_max_values(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jamxu/Documents/coreml/miniconda3/envs/coreml-ios/lib/python3.12/site-packages/coremltools/optimize/_utils.py", line 856, in get_min_and_max_values
    [activation_stats[var_name]["rmin"], activation_stats[var_name]["rmax"]], dtype=np.float16
     ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
KeyError: 'rmin'
```

Instead, we should skip adding Q/DQ pairs to const ops.

---

sample quantization script:
```python
import coremltools as ct
import coremltools.optimize as cto
import numpy as np

BATCH_SIZE_CALIB = 2
INPUT_CONFIG = {
    "latent_model_input": {
        "shape": (BATCH_SIZE_CALIB, 6930, 128),
        "dtype": np.float16
    },
    "prompt_embeds": {
        "shape": (BATCH_SIZE_CALIB, 128, 4096),
        "dtype": np.float16
    },
    "timestep": {
        "shape": (BATCH_SIZE_CALIB,),
        "dtype": np.float16
    },
    "prompt_attention_mask": {
        "shape": (BATCH_SIZE_CALIB, 128),
        "dtype": np.float16
    }
}

BASELINE_MODEL_PATH = "model.mlpackage"
QUANTIZED_MODEL_PATH = "model_w8a8.mlpackage"
NUM_SAMPLES_FOR_CALIBRATION = 4

sample_data_for_coreml = []
print(f"Preparing {NUM_SAMPLES_FOR_CALIBRATION} samples for CoreML calibration data...")
for i in range(NUM_SAMPLES_FOR_CALIBRATION):
    current_sample = {}
    for input_name, config in INPUT_CONFIG.items():
        if input_name == "timestep":
            random_data = np.random.randint(0, 1000, size=config["shape"]).astype(config["dtype"])
        elif input_name == "prompt_attention_mask":
            random_data = np.random.choice([0.0, 1.0], size=config["shape"]).astype(config["dtype"])
        else:
            random_data = np.random.rand(*config["shape"]).astype(config["dtype"])
        current_sample[input_name] = random_data
    sample_data_for_coreml.append(current_sample)

print(f"Loading FP16 CoreML model: {BASELINE_MODEL_PATH}")
baseline_model = ct.models.MLModel(BASELINE_MODEL_PATH)

if sample_data_for_coreml:
    print("Attempting test predictions with ALL calibration samples...")
    all_predictions_succeeded = True
    for idx, sample_for_prediction in enumerate(sample_data_for_coreml):
        print(f"  Predicting with sample {idx+1}/{len(sample_data_for_coreml)}...")
        predictions = baseline_model.predict(sample_for_prediction) # This will raise an error if it fails
    print("All test predictions with calibration samples were successful.")
else:
    print("No calibration data generated, skipping test prediction.")
    exit()

print("\nAttempting W8A8 PTQ using coremltools.optimize...")

print("Step 1: Configuring and applying activation quantization (A8)...")
activation_op_config = cto.coreml.OpLinearQuantizerConfig(mode="linear_symmetric")
activation_config = cto.coreml.OptimizationConfig(global_config=activation_op_config)

compressed_model_a8 = cto.coreml.linear_quantize_activations(
        baseline_model, config=activation_config, sample_data=sample_data_for_coreml
)

print("Step 2: Configuring and applying weight quantization (W8) to the A8 model...")
weight_op_config = cto.coreml.OpLinearQuantizerConfig(mode="linear_symmetric")
weight_config = cto.coreml.OptimizationConfig(global_config=weight_op_config)

compressed_model_w8a8 = cto.coreml.linear_quantize_weights(
    compressed_model_a8, config=weight_config
)

compressed_model_w8a8.save(QUANTIZED_MODEL_PATH)
print(f"Saved W8A8 quantized model to: {QUANTIZED_MODEL_PATH}")
```

sample fp16 model:
[model.mlpackage.zip](https://github.com/user-attachments/files/20493421/model.mlpackage.zip)