### PR TITLE
Fix failing MLModelValidator tests

### DIFF
--- a/coremltools/models/ml_program/experimental/debugging_utils.py
+++ b/coremltools/models/ml_program/experimental/debugging_utils.py
@@ -1028,7 +1028,8 @@ class MLModelValidator:
                         The operation did not pass validation, but its dependencies did.
                         This suggests that the failure likely comes from this operation.
                         """
-                        result.append(op)
+                        if op not in result:
+                            result.append(op)
 
                     queue.pop(0)
                 else:
@@ -1561,7 +1562,8 @@ class MLModelComparator:
                         The operation did not pass comparison check, but its dependencies did.
                         This suggests that the failure likely comes from this operation.
                         """
-                        result.append(op)
+                        if op not in result:
+                            result.append(op)
 
                     queue.pop(0)
                 else:

--- a/coremltools/test/ml_program/experimental/test_debugging_utils.py
+++ b/coremltools/test/ml_program/experimental/test_debugging_utils.py
@@ -162,11 +162,10 @@ class TestMLModelValidator:
         def prog(x, y):
             x1 = mb.add(x=x, y=y, name="add1")
             x2 = mb.real_div(x=x1, y=y, name="div1")
-            x3 = mb.real_div(x=x1, y=y, name="div2")
-            x4 = mb.add(x=x2, y=x3, name="add2")
-            x5 = mb.add(x=x3, y=x4, name="add3")
-            x6 = mb.mul(x=x4, y=x5, name="mul")
-            return x6
+            x3 = mb.add(x=x1, y=mb.const(val=1.0))
+            x4 = mb.real_div(x=x3, y=y, name="div2")
+            x5 = mb.add(x=x2, y=x4, name="add2")
+            return x5
 
         return prog
 


### PR DESCRIPTION

```
  x2 = mb.real_div(x=x1, y=y, name="div1")
  x3 = mb.real_div(x=x1, y=y, name="div2")
```

The following change ensures that x2 and x3 are treated as distinct operations, even though both are created using mb.real_div(x=x1, y=y, ...). Previously, x3 could be eliminated by common subexpression elimination (CSE) due to its identical inputs. By explicitly distinguishing these operations, we prevent unintended optimization.

Additionally, this update enhances both MLModelValidator and MLModelComparator by adding checks to ensure that the same operation is not added to the result list multiple times.

CI:
https://gitlab.com/coremltools1/coremltools/-/pipelines/1851846848