### PR TITLE
MLModelBenchmarker fixes

### DIFF
--- a/coremltools/models/ml_program/experimental/async_wrapper.py
+++ b/coremltools/models/ml_program/experimental/async_wrapper.py
@@ -248,7 +248,9 @@ class LocalMLModelAsyncWrapper(MLModelAsyncWrapper):
             raise ValueError("Failed to load model")
 
         self._model = model
-        self.temp_asset_path = self._model.package_path
+        # Perform cleanup only when a model is being created.
+        if isinstance(self.spec_or_path, proto.Model_pb2.Model): 
+            self.temp_asset_path = self._model.package_path
 
     def make_state_if_needed(self) -> Optional["MLState"]:
         if self._model._is_stateful():

--- a/coremltools/models/ml_program/experimental/perf_utils.py
+++ b/coremltools/models/ml_program/experimental/perf_utils.py
@@ -44,9 +44,9 @@ def _gen_random_multiarray_value(type: "proto.FeatureTypes_pb2.ArrayFeatureType"
 
     shape = tuple(type.shape)
     if np_data_type == np.int32:
-        return np.random.randint(0, 10, shape)
+        return np.random.randint(0, 10, shape, dtype=np.int32)
 
-    return np.random.random(shape)
+    return np.random.random(shape).astype(np.float32)
 
 
 def _gen_random_image_value(type: "proto.FeatureTypes_pb2.ImageFeatureType") -> np.array:

--- a/coremltools/test/ml_program/experimental/test_async_wrapper.py
+++ b/coremltools/test/ml_program/experimental/test_async_wrapper.py
@@ -1,0 +1,44 @@
+#  Copyright (c) 2025, Apple Inc. All rights reserved.
+import gc
+import os
+
+import coremltools as ct
+from coremltools.converters.mil import Builder as mb
+import pytest
+
+from coremltools.models.ml_program.experimental.async_wrapper import (
+    MLModelAsyncWrapper,
+)
+
+class TestMLModelAsyncWrapper:
+    @staticmethod
+    def get_test_model():
+        @mb.program(
+            input_specs=[
+                mb.TensorSpec(shape=(1, 2, 3, 4)),
+            ]
+        )
+        def prog(x):
+            y = mb.const(val=1.2, name="y")
+            x = mb.add(x=x, y=y, name="add")
+            return x
+
+        return prog
+    
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_source_model_remains_intact():
+        prog = TestMLModelAsyncWrapper.get_test_model()
+        mlmodel = ct.convert(prog, convert_to="mlprogram", compute_precision=ct.precision.FLOAT32)
+        async_wrapper = MLModelAsyncWrapper.from_spec_or_path(
+            spec_or_path=mlmodel.package_path, 
+            weights_dir=mlmodel.weights_dir
+        )
+
+        await async_wrapper.load()
+        del(async_wrapper)
+        gc.collect()
+
+        assert os.path.isdir(mlmodel.package_path) and len(os.listdir(mlmodel.package_path)) > 0, (
+            f"Model resources unexpectedly deleted from {mlmodel.package_path}\n"
+            "Expected: Source model directory remains intact after wrapper destruction\n")


### PR DESCRIPTION
This PR addresses two issues. 

- It resolves a datatype inconsistency by explicitly specifying the dtype when generating input data during benchmarking, ensuring reliable behavior when inputs are not provided. 

- It fixes a problem in the MLModelAsyncWrapper where the source model directory was inadvertently deleted when initializing the wrapper with a model path instead of a specification.

CI
https://gitlab.com/coremltools1/coremltools/-/commit/f8eeed06e9b244d0dcc685835a09824d604284a2

fixes #2525
