### PR TITLE
Fix immediate output getattr

### DIFF
--- a/coremltools/converters/mil/frontend/torch/torchir_passes.py
+++ b/coremltools/converters/mil/frontend/torch/torchir_passes.py
@@ -231,10 +231,9 @@ def populate_native_const_model_hierarchy(graph: InternalTorchIRGraph) -> None:
 
 def remove_getattr_nodes(graph: InternalTorchIRGraph) -> None:
     """
-    Remove the getattr nodes in the graph
+    Remove the getattr nodes in the graph that are not output nodes
     """
 
-    getattr_nodes = []
     new_nodes = []
 
     for node in graph.nodes:
@@ -243,16 +242,20 @@ def remove_getattr_nodes(graph: InternalTorchIRGraph) -> None:
             remove_getattr_nodes(block)
 
         if node.kind == "getattr":
-            getattr_nodes.append(node)
+            if node.name in graph.outputs:
+                # create and add new constant node
+                new_nodes.append(
+                        InternalTorchIRNode(
+                            inputs=[],
+                            outputs=node.outputs,
+                            kind="constant",
+                            name="internal_immediate_output_attr",
+                            attr={"value": node.parent.params[node.name]}
+                        )
+                    )
         else:
             new_nodes.append(node)
 
-    # check the getattr nodes not in the outputs
-    for node in getattr_nodes:
-        if node.name in graph.outputs:
-            raise RuntimeError("{} should not be in the graph outputs.".format(node.name))
-
-    # remove the getattr nodes
     graph.nodes = new_nodes
 
 

--- a/coremltools/converters/mil/frontend/torch/torchir_passes.py
+++ b/coremltools/converters/mil/frontend/torch/torchir_passes.py
@@ -231,7 +231,8 @@ def populate_native_const_model_hierarchy(graph: InternalTorchIRGraph) -> None:
 
 def remove_getattr_nodes(graph: InternalTorchIRGraph) -> None:
     """
-    Remove the getattr nodes in the graph that are not output nodes
+    Remove the getattr nodes in the graph
+    If they are output nodes, convert them to constant nodes
     """
 
     new_nodes = []

--- a/coremltools/converters/mil/frontend/torch/torchir_passes.py
+++ b/coremltools/converters/mil/frontend/torch/torchir_passes.py
@@ -251,7 +251,7 @@ def remove_getattr_nodes(graph: InternalTorchIRGraph) -> None:
                             outputs=node.outputs,
                             kind="constant",
                             name="internal_immediate_output_attr",
-                            attr={"value": node.parent.params[node.name]}
+                            attr={"value": node.parent.params[node.name].detach()}
                         )
                     )
         else:


### PR DESCRIPTION
Fixes #2538.

Changed `remove_getattr_nodes()` such that it adds a new constant op if it encounters a getattr op that is part of the graph's output. Before it raised an error wich caused some networks not to convert.

Added a unit test for the scenario.