### PR TITLE
Add transpose copy

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -979,7 +979,7 @@ def gt(context, node):
     context.add(greater)
 
 
-@register_torch_op(torch_alias=["t", "numpy_t"])
+@register_torch_op(torch_alias=["t", "numpy_t", "transpose_copy"])
 def transpose(context, node):
     assert len(node.outputs) == 1
     inputs = _get_inputs(context, node)

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -7166,6 +7166,20 @@ class TestTranspose(TorchBaseTest):
         )
 
 
+class TestTransposeCopy(TorchBaseTest):
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend, shape, dims",
+        itertools.product(
+            compute_units, backends, frontends, COMMON_SHAPES, [(0, 1), (-2, -1), (1, 0), (-1, -2)]
+        ),
+    )
+    def test(self, compute_unit, backend, frontend, shape, dims):
+        model = ModuleWrapper(function=torch.transpose_copy, kwargs={"dim0": dims[0], "dim1": dims[1]})
+        self.run_compare_torch(
+            shape, model, compute_unit=compute_unit, backend=backend, frontend=frontend
+        )
+
+
 class TestTo(TorchBaseTest):
     @pytest.mark.parametrize(
         "compute_unit, backend, frontend",


### PR DESCRIPTION
This adds coremltools support for transpose_copy, the copy variant of transpose.  Many view ops in coremltools already register the copy variant as an alias, e.g.,

* view: https://github.com/apple/coremltools/blob/main/coremltools/converters/mil/frontend/torch/ops.py#L2316
* permute: https://github.com/apple/coremltools/blob/main/coremltools/converters/mil/frontend/torch/ops.py#L1011

But it looks like for transpose this was missed.