### PR TITLE
Add torchao.dequantize_affine

### DIFF
--- a/coremltools/converters/mil/frontend/torch/quantization_ops.py
+++ b/coremltools/converters/mil/frontend/torch/quantization_ops.py
@@ -737,3 +737,73 @@ def _weight_int4pack_mm(context, node):
 
     res = mb.linear(x=x, weight=dequant_weights, name=node.name)
     context.add(res)
+
+
+@register_torch_op(
+    torch_alias=["torchao::dequantize_affine", "torchao.dequantize_affine"],
+)
+def dequantize_affine(context, node):
+    if not _HAS_TORCHAO:
+        raise AssertionError(
+            f"{MSG_TORCHAO_NOT_FOUND}\n torchao is needed to convert torchao.dequantize_affine"
+        )
+
+    inputs = _get_inputs(context, node, expected=[7, 8])
+    int_data = inputs[0].val
+    block_size = inputs[1].val
+    scale = inputs[2].val
+    zero_point = (
+        inputs[3].val if inputs[3] is not None and inputs[3].val is not None else None
+    )
+    # I do not think we need to worry about input_dtype b/c it gets cast to int4/int8
+    # For now, we just check that it is int8 or int32
+    input_dtype = inputs[4].val  # noqa: F841
+    assert NUM_TO_TORCH_DTYPE[input_dtype] in [
+        _torch.int8,
+        _torch.int32,
+    ], "input_dtype should be int8 or int32"
+
+    quant_min = inputs[5].val
+    quant_max = inputs[6].val
+
+    assert len(int_data.shape) == 2, "dequantize_affine only supports rank 2 inputs"
+
+    assert len(int_data.shape) == len(
+        block_size
+    ), "block_size must have the same length as int_data.shape"
+    assert block_size[0] == 1, "block_size[0] must be 1"
+    group_size = block_size[1]
+    k = int_data.shape[1]
+    assert k % group_size == 0, "k must be divisible by group_size"
+    scales_per_row = k // group_size
+    scale = scale.reshape(-1, scales_per_row)
+    if zero_point is not None:
+        zero_point = zero_point.reshape(-1, scales_per_row)
+
+    # TODO: I don't know if CoreML can make use of this
+    # We could add a cast op to the output, but I'm pretty CoreML will remove this during a later pass
+    # For now, we just log a warning
+    out_np_dtype = None
+    if len(inputs) > 7:
+        out_np_dtype = NUM_TO_NUMPY_DTYPE[inputs[7].val]
+        logger.warning(
+            f"Core ML ignores output_dtype {out_np_dtype} on torchao.dequantize_affine and instead uses the native precision."
+        )
+
+    if quant_min == -8 and quant_max == 7:
+        quantized_np_dtype = types.nptype_from_builtin(types.string_to_builtin("int4"))
+    elif quant_min == -128 and quant_max == 127:
+        quantized_np_dtype = types.nptype_from_builtin(types.string_to_builtin("int8"))
+    else:
+        raise ValueError(
+            f"Unsupported quantization range: {quant_min} to {quant_max}.  CoreML only supports 4-bit and 8-bit quantization."
+        )
+
+    output = _utils._construct_constexpr_dequant_op(
+        int_data.astype(quantized_np_dtype),
+        zero_point,
+        scale,
+        axis=-1,
+        name=node.name,
+    )
+    context.add(output, node.name)

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_quantization_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_quantization_ops.py
@@ -11,7 +11,6 @@ import numpy as np
 import numpy.testing
 import pytest
 import torch
-from torchao.quantization import granularity
 import torchvision
 from packaging.version import Version
 
@@ -43,7 +42,6 @@ from .testing_utils import TorchBaseTest, frontends
 if _HAS_TORCHAO:
     import torchao
     from torchao.quantization import quant_primitives as torchao_quant
-    from torchao.quantization import quantize_, PerGroup, PerAxis, IntxWeightOnlyConfig
 
 pytest.mark.skipif(not _HAS_TORCH, reason=MSG_TORCH_NOT_FOUND)
 
@@ -222,18 +220,47 @@ class TestPyTorchQuantizationOps(TorchQuantizationBaseTest):
     
     @pytest.mark.skipif(not _HAS_TORCHAO, reason=MSG_TORCHAO_NOT_FOUND)
     @pytest.mark.parametrize(
-        "compute_unit, granularity, weight_dtype",
-        itertools.product(compute_units, [PerGroup(32), PerGroup(64), PerAxis(0)], [torch.int4, torch.int8]),
+        "compute_unit, group_size, bit_width, has_zeros",
+        itertools.product(compute_units, [32, 64], [4, 8], [True, False]),
     )
-    def test_dequantize_affine(self, compute_unit, granularity, weight_dtype):
-        model = torch.nn.Sequential(*[torch.nn.Linear(128, 128)])
+    def test_dequantize_affine(self, compute_unit, group_size, bit_width, has_zeros):
+
+        if bit_width == 4:
+            quant_min = -8
+            quant_max = 7
+        elif bit_width == 8:
+            quant_min = -128
+            quant_max = 127
+        else:
+            raise ValueError(f"Unsupported bit width: {bit_width}")
+
+        n = 4
+        k = 128
+        input_dtype = torch.int8
+        int_data = torch.randint(low=quant_min, high=quant_max, size=(n, k)).to(input_dtype)
+        scale = torch.rand(n, k // group_size)
+
+        zero_point = None
+        if has_zeros:
+            zero_point = torch.randint(low=quant_min, high=quant_max, size=(n, k // group_size)).to(input_dtype)
+
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("int_data", int_data)
+                self.register_buffer("scale", scale)
+                self.register_buffer("zero_point", zero_point)
+
+            def forward(self, x):
+                w = torchao_quant.dequantize_affine(self.int_data, [1, group_size], self.scale, self.zero_point, input_dtype, quant_min, quant_max)
+                return torch.nn.functional.linear(x, w)
+
+
+        model = Model()
         model = model.to(torch.device("cpu"))
-        quantize_(
-            model,
-            IntxWeightOnlyConfig(weight_dtype=weight_dtype, granularity=granularity),
-        )
-        
-        input_shape = [(2, 128)]
+       
+        input_shape = [(3, k)]
         res = self.run_compare_torch(
             input_shape,
             model,


### PR DESCRIPTION
This adds support for torchao's dequantize affine to coremltools.  With this change, users can now quantize PyTorch models with torchao APIs like this:

```
quantize_(
    model,
    IntxWeightOnlyConfig(torch.int4, PerGroup(32)),
)
```

This model can then be exported and converted to CoreML:

```
ep = torch.export.export(model, example_inputs)
mlmodel = ct.convert(ep)
```

This corresponds to similar support in ExecuTorch's codebase added here: https://github.com/pytorch/executorch/pull/12664 

I do have some questions about compatibility with coremltools versions of torch/torchao.  This change is tested on torch 2.7 and torchao 0.10, both of which are older than what coremltools uses.