### PR TITLE
Add split copy

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -5896,7 +5896,7 @@ def slice(context, node):
     context.add(res)
 
 
-@register_torch_op(torch_alias=["split_with_sizes", "split_with_sizes_copy"])
+@register_torch_op(torch_alias=["split_with_sizes", "split_with_sizes_copy", "split_copy"])
 def split(context, node):
     def _parse_positional_args(context, node) -> Tuple[Var]:
         inputs = _get_inputs(context, node, min_expected=2)


### PR DESCRIPTION
This adds coremltools support for split_copy, the copy variant of split. Many view ops in coremltools already register the copy variant as an alias, e.g.,

view: https://github.com/apple/coremltools/blob/main/coremltools/converters/mil/frontend/torch/ops.py#L2316
permute: https://github.com/apple/coremltools/blob/main/coremltools/converters/mil/frontend/torch/ops.py#L1011

But it looks like for split this was missed.

Similar PR for transpose_copy: https://github.com/apple/coremltools/pull/2556