### PR TITLE
Add linear as a supported op for activation quantization.

### DIFF
--- a/coremltools/converters/mil/mil/passes/defs/optimize_activation_quantization.py
+++ b/coremltools/converters/mil/mil/passes/defs/optimize_activation_quantization.py
@@ -159,8 +159,8 @@ class insert_suffix_quantize_dequantize_pair(AbstractGraphPass):
         - (`quantize` ->) dequantize` -> `conv` -> `relu` -> `quantize` -> `dequantize`
         """
 
-        # Reject if 1st operation is not `conv`/`add`/`pool`.
-        SUPPORTED_OP_TYPES = ["conv", "add", "avg_pool", "max_pool"]
+        # Reject if 1st operation is not `conv`/`add`/`pool`/`linear`.
+        SUPPORTED_OP_TYPES = ["conv", "add", "avg_pool", "max_pool", "linear"]
         if any(_check_child_op_type(dequantize_op, val) for val in SUPPORTED_OP_TYPES):
             pass
         else:

--- a/coremltools/optimize/coreml/_quantization_passes.py
+++ b/coremltools/optimize/coreml/_quantization_passes.py
@@ -1640,7 +1640,7 @@ class insert_prefix_quantize_dequantize_pair(AbstractActCompressionPass):
 
     _SUPPORTED_CONFIG_TYPE = OpLinearQuantizerConfig
 
-    SUPPORTED_UNARY_OP_TYPES = ["conv", "avg_pool", "max_pool"]
+    SUPPORTED_UNARY_OP_TYPES = ["conv", "avg_pool", "max_pool", "linear"]
     SUPPORTED_BINARY_OP_TYPES = ["add"]
     SUPPORTED_OP_TYPES = SUPPORTED_UNARY_OP_TYPES + SUPPORTED_BINARY_OP_TYPES
 


### PR DESCRIPTION
Add support for linear op in activation quantization.
One unit test is added.