### PR TITLE
Fix dequantize_affine before iOS18

### DIFF
--- a/coremltools/converters/mil/frontend/torch/quantization_ops.py
+++ b/coremltools/converters/mil/frontend/torch/quantization_ops.py
@@ -803,7 +803,6 @@ def dequantize_affine(context, node):
         int_data.astype(quantized_np_dtype),
         zero_point,
         scale,
-        axis=-1,
         name=node.name,
     )
     context.add(output, node.name)


### PR DESCRIPTION
dequantize_affine does not work correctly before iOS18, when the op gets translated to constexpr_affine_dequantize instead of constexpr_blockwise_shift_scale.

This is because the axis should be None (default value) instead of -1.  In this case, the axis gets inferred from the shape of scales.

This is similar to the change in the ExecuTorch PR: https://github.com/pytorch/executorch/pull/13896