### PR TITLE
[CI] Limit Torch to older than 2.8

### DIFF
--- a/reqs/pytorch.pip
+++ b/reqs/pytorch.pip
@@ -5,7 +5,7 @@ torchaudio==2.2.0; platform_machine != "arm64"
 torchvision==0.17.0; platform_machine != "arm64"
 
 # Torch dependencies for ARM
-torch>=2.2.0; platform_machine == "arm64"
+torch>=2.2.0,<2.8; platform_machine == "arm64"
 torchaudio>=2.2.0; platform_machine == "arm64"
 torchvision>=0.17.0; platform_machine == "arm64"
 torchsr==1.0.4; platform_machine == "arm64"


### PR DESCRIPTION
Torch has released 2.8, but we support up to 2.7.1 for now. Before we upgrade coremltools to be compatible with torch 2.8, let us limit torch < 2.8 in CI for now

CI ✅ https://gitlab.com/coremltools1/coremltools/-/commit/463b494215a5f6f9ef73e913e8d60a25fe8c472d/pipelines