### PR TITLE
Optimize torch.mm

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -1035,21 +1035,11 @@ def pixel_unshuffle(context, node):
     context.add(perm)
 
 
-def _construct_matmul(x: Var, y: Var, name: Optional[str] = None) -> Var:
-    if (len(y.shape) == 2 and len(x.shape) <= 3) and (_is_const(y) or y.is_descendant_of_const):
-        linear_x, weight = x, y
-        transposed_weight = mb.transpose(x=weight, perm=(1, 0))
-        res = mb.linear(x=linear_x, weight=transposed_weight, name=name)
-    else:
-        x, y = promote_input_dtypes([x, y])
-        res = mb.matmul(x=x, y=y, name=name)
-    return res
-
-
 @register_torch_op(torch_alias=["bmm", "mm"])
 def matmul(context, node):
     x, y = _get_inputs(context, node, expected=2)
-    res = _construct_matmul(x, y, node.name)
+    x, y = promote_input_dtypes([x, y])
+    res = mb.matmul(x=x, y=y, name=node.name)
     context.add(res)
 
 

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_conversion_api.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_conversion_api.py
@@ -3215,15 +3215,3 @@ class TestTorchao:
 
         with pytest.raises(err_type, match=err_msg):
             ct.convert(exported_model, inputs=inputs, minimum_deployment_target=ct.target.iOS17)
-
-
-class TestUtilsImport:
-    @staticmethod
-    def test_import_construct_matmul():
-        """
-        _construct_matmul is an utility function that used by some 3rd party codes,
-        so here we make sure that this method is exposed.
-        """
-        from coremltools.converters.mil.frontend.torch.ops import _construct_matmul
-
-        assert _construct_matmul is not None


### PR DESCRIPTION
```Python
import torch
import coremltools as ct


edge = 512

class Model(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.weight = torch.randint(0, 100, (edge, edge)).to(torch.int32)
    def forward(self, x):
        return torch.mm(x, self.weight)

model = Model()
x = torch.randn(edge, edge).to(torch.int32)

exported_model = torch.export.export(model, (x,)).run_decompositions({})
mlmodel = ct.convert(exported_model)
```

When converting `torch.mm` to `mb.linear`, verification fails with 512x512 tensors:

```log
/private/var/folders/mf/kt300sj9377frczhqr6m2z3w0000gn/T/tmpxm2ooutu.mlmodelc/model.mil:7:12: note: see current operation: %4 = "mps.matmul"(%1, %2) <{transpose_lhs = false, transpose_rhs = true}> : (tensor<512x512xsi32>, tensor<512x512xsi32>) -> tensor<512x512xsi32>
/AppleInternal/Library/BuildRoots/4~B5E4ugDCh2RsPWAjMEoPu8LC5w1yXEwd7XweDhg/Library/Caches/com.apple.xbs/Sources/MetalPerformanceShadersGraph/mpsgraph/MetalPerformanceShadersGraph/Core/Files/MPSGraphExecutable.mm:1232: failed assertion `original module failed verification'
```

Unify `torch.mm` implementation to use `mb.matmul`. It will support 512x512 tensors and resolve issue #2575.

## Unit test

```sh
pytest coremltools/converters/mil/frontend/torch/test/test_torch_ops.py::TestMatMul::test_matmul_const_mat2
```