### PR TITLE
Update minimum required CMake versions for compatibility with CMake 4.x

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.10.0)
 project(deps)
 
 set(protobuf_BUILD_TESTS OFF CACHE BOOL "Build tests")

--- a/deps/protobuf/cmake/CMakeLists.txt
+++ b/deps/protobuf/cmake/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Minimum CMake required
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.0)
 
 if(protobuf_VERBOSE)
   message(STATUS "Protocol Buffers Configuring...")


### PR DESCRIPTION
## Summary
This PR updates the minimum required CMake versions in the build scripts to make sure coremltools can be built with newer versions of CMake (like 4.x).

## Details
When trying to build coremltools from source with CMake 4.x, I ran into errors because the old minimum version requirements are no longer supported. Updating these to 3.5 and 3.10 fixes the issue and lets the build complete successfully.

- Updated `cmake_minimum_required` to 3.10.0 in CMakeLists.txt
- Updated `cmake_minimum_required` to 3.5.0 in CMakeLists.txt

This should help anyone using a modern CMake version build coremltools without running into compatibility errors. No changes to the actual code—just a small tweak to the build setup.