### PR TITLE
Fix type casting error with `numpy` 2.4

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -3045,7 +3045,7 @@ def _cast(context, node, dtype, dtype_name):
         # If x is a compile-time constant, directly cast it to @dtype if it's
         # not one already.
         if not isinstance(x.val, dtype):
-            res = mb.const(val=x.val.astype(dtype), name=node.name)
+            res = mb.const(val=dtype(x.val.squeeze()), name=node.name)
         else:
             res = x
     elif len(x.shape) > 0:

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -3045,7 +3045,7 @@ def _cast(context, node, dtype, dtype_name):
         # If x is a compile-time constant, directly cast it to @dtype if it's
         # not one already.
         if not isinstance(x.val, dtype):
-            res = mb.const(val=dtype(x.val), name=node.name)
+            res = mb.const(val=x.val.astype(dtype), name=node.name)
         else:
             res = x
     elif len(x.shape) > 0:


### PR DESCRIPTION
Fixes https://github.com/apple/coremltools/issues/2633

**MRE**
1. Install `numpy` 2.4
2. Run the following export:

```python
import torch
import torch.nn as nn
import coremltools as ct

class ConstantFoldingModule(nn.Module):
    def __init__(self):
        super().__init__()
        # Register constant tensors that will be folded
        self.register_buffer('const_shape', torch.tensor([2, 3, 4]))
        self.register_buffer('multiplier', torch.tensor(10))
        
    def forward(self, x):
        batch_size = x.shape[0]
        output_dim = self.multiplier * 5  # Becomes constant 50
        channels = self.const_shape[1]  # Becomes constant 3
        x = x.view(batch_size, channels, -1)
        return x.mean(dim=-1)

model = ConstantFoldingModule()
x = torch.randn(1, 3, 224, 224)
ts = torch.jit.trace(model.eval(), x)
cmodel = ct.convert(ts, inputs=[ct.TensorType("x", shape=x.shape)])
```

**Error**
```
scikit-learn version 1.8.0 is not supported. Minimum required version: 0.17. Maximum required version: 1.5.1. Disabling scikit-learn conversion API.
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
E0000 00:00:1766324559.930811    8771 cuda_dnn.cc:8579] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered
E0000 00:00:1766324559.938827    8771 cuda_blas.cc:1407] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered
W0000 00:00:1766324559.960623    8771 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.
W0000 00:00:1766324559.960658    8771 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.
W0000 00:00:1766324559.960662    8771 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.
W0000 00:00:1766324559.960666    8771 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.
TensorFlow version 2.19.0 has not been tested with coremltools. You may run into unexpected errors. TensorFlow 2.12.0 is the most recent version that has been tested.
Torch version 2.8.0+cu128 has not been tested with coremltools. You may run into unexpected errors. Torch 2.7.0 is the most recent version that has been tested.
Failed to load _MLModelProxy: No module named 'coremltools.libcoremlpython'
Failed to load _MLCPUComputeDeviceProxy: No module named 'coremltools.libcoremlpython'
Failed to load _MLGPUComputeDeviceProxy: No module named 'coremltools.libcoremlpython'
Failed to load _MLNeuralEngineComputeDeviceProxy: No module named 'coremltools.libcoremlpython'
Failed to load _MLModelProxy: No module named 'coremltools.libcoremlpython'
Failed to load _MLComputePlanProxy: No module named 'coremltools.libcoremlpython'
Failed to load _MLModelProxy: No module named 'coremltools.libcoremlpython'
Failed to load _MLModelAssetProxy: No module named 'coremltools.libcoremlpython'
When both 'convert_to' and 'minimum_deployment_target' not specified, 'convert_to' is set to "mlprogram" and 'minimum_deployment_target' is set to ct.target.iOS15 (which is same as ct.target.macOS12). Note: the model will not run on systems older than iOS15/macOS12/watchOS8/tvOS15. In order to make your model run on older system, please set the 'minimum_deployment_target' to iOS14/iOS13. Details please see the link: https://apple.github.io/coremltools/docs-guides/source/target-conversion-formats.html
Converting PyTorch Frontend ==> MIL Ops:   0%|                                                                                                                                              | 0/16 [00:00<?, ? ops/s]

ERROR - converting 'int' op (located at: '6'):

Converting PyTorch Frontend ==> MIL Ops:  19%|████████████████████████▊                                                                                                           | 3/16 [00:00<00:00, 2757.60 ops/s]
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[1], line 22
     20 x = torch.randn(1, 3, 224, 224)
     21 ts = torch.jit.trace(model.eval(), x)
---> 22 cmodel = ct.convert(ts, inputs=[ct.TensorType("x", shape=x.shape)])

File /opt/conda/lib/python3.11/site-packages/coremltools/converters/_converters_entry.py:646, in convert(model, source, inputs, outputs, classifier_config, minimum_deployment_target, convert_to, compute_precision, skip_model_load, compute_units, package_dir, debug, pass_pipeline, states)
    643 if len(states) > 0 and exact_source != "pytorch":
    644     raise ValueError("'states' can only be passed with pytorch source model.")
--> 646 mlmodel = mil_convert(
    647     model,
    648     convert_from=exact_source,
    649     convert_to=exact_target,
    650     inputs=inputs,
    651     outputs=outputs_as_tensor_or_image_types,  # None or list[ct.ImageType/ct.TensorType]
    652     classifier_config=classifier_config,
    653     skip_model_load=skip_model_load,
    654     compute_units=compute_units,
    655     package_dir=package_dir,
    656     debug=debug,
    657     specification_version=specification_version,
    658     main_pipeline=pass_pipeline,
    659     use_default_fp16_io=use_default_fp16_io,
    660     states=states,
    661 )
    663 if exact_target == "mlprogram" and mlmodel._input_has_infinite_upper_bound():
    664     raise ValueError(
    665         "For mlprogram, inputs with infinite upper_bound is not allowed. Please set upper_bound"
    666         ' to a positive value in "RangeDim()" for the "inputs" param in ct.convert().'
    667     )

File /opt/conda/lib/python3.11/site-packages/coremltools/converters/mil/converter.py:186, in mil_convert(model, convert_from, convert_to, compute_units, **kwargs)
    147 @_profile
    148 def mil_convert(
    149     model,
   (...)    153     **kwargs
    154 ):
    155     """
    156     Convert model from a specified frontend `convert_from` to a specified
    157     converter backend `convert_to`.
   (...)    184         See `coremltools.converters.convert`
    185     """
--> 186     return _mil_convert(
    187         model,
    188         convert_from,
    189         convert_to,
    190         ConverterRegistry,
    191         ct.models.MLModel,
    192         compute_units,
    193         **kwargs,
    194     )

File /opt/conda/lib/python3.11/site-packages/coremltools/converters/mil/converter.py:218, in _mil_convert(model, convert_from, convert_to, registry, modelClass, compute_units, **kwargs)
    215     weights_dir = _tempfile.TemporaryDirectory()
    216     kwargs["weights_dir"] = weights_dir.name
--> 218 proto, mil_program = mil_convert_to_proto(
    219                         model,
    220                         convert_from,
    221                         convert_to,
    222                         registry,
    223                         **kwargs
    224                      )
    226 _reset_conversion_state()
    228 if convert_to == 'milinternal':

File /opt/conda/lib/python3.11/site-packages/coremltools/converters/mil/converter.py:294, in mil_convert_to_proto(model, convert_from, convert_to, converter_registry, main_pipeline, **kwargs)
    289 frontend_pipeline, backend_pipeline = _construct_other_pipelines(
    290     main_pipeline, convert_from, convert_to
    291 )
    293 frontend_converter = frontend_converter_type()
--> 294 prog = frontend_converter(model, **kwargs)
    295 PassPipelineManager.apply_pipeline(prog, frontend_pipeline)
    297 PassPipelineManager.apply_pipeline(prog, main_pipeline)

File /opt/conda/lib/python3.11/site-packages/coremltools/converters/mil/converter.py:106, in TorchFrontend.__call__(self, *args, **kwargs)
    103 def __call__(self, *args, **kwargs):
    104     from .frontend.torch.load import load
--> 106     return load(*args, **kwargs)

File /opt/conda/lib/python3.11/site-packages/coremltools/converters/mil/frontend/torch/load.py:87, in load(spec, inputs, specification_version, debug, outputs, cut_at_symbols, use_default_fp16_io, states, **kwargs)
     75     model = _torchscript_from_spec(spec)
     77 converter = TorchConverter(
     78     model,
     79     inputs,
   (...)     84     states,
     85 )
---> 87 return _perform_torch_convert(converter, debug)

File /opt/conda/lib/python3.11/site-packages/coremltools/converters/mil/frontend/torch/load.py:150, in _perform_torch_convert(converter, debug)
    148 def _perform_torch_convert(converter: TorchConverter, debug: bool) -> Program:
    149     try:
--> 150         prog = converter.convert()
    151     except RuntimeError as e:
    152         if debug and "convert function" in str(e):

File /opt/conda/lib/python3.11/site-packages/coremltools/converters/mil/frontend/torch/converter.py:1392, in TorchConverter.convert(self)
   1390 # Add the rest of the operations
   1391 has_states = len(getattr(self, "states", [])) > 0
-> 1392 convert_nodes(self.context, self.graph, early_exit=not has_states)
   1394 # Only torch script needs to convert memory layout
   1395 if self.context.frontend == TorchFrontend.TORCHSCRIPT:

File /opt/conda/lib/python3.11/site-packages/coremltools/converters/mil/frontend/torch/ops.py:118, in convert_nodes(context, graph, early_exit)
    116     op_location = '/'.join(scope_names)
    117     logger.error(f"\n\nERROR - converting '{node.kind}' op (located at: '{op_location}'):\n")
--> 118     raise e     # re-raise exception
    120 if early_exit and _all_outputs_present(context, graph):
    121     # We've generated all the outputs the graph needs, terminate conversion.
    122     break

File /opt/conda/lib/python3.11/site-packages/coremltools/converters/mil/frontend/torch/ops.py:113, in convert_nodes(context, graph, early_exit)
    111 for node in _tqdm(graph.nodes, desc="Converting PyTorch Frontend ==> MIL Ops", unit=" ops"):
    112     try:
--> 113         convert_single_node(context, node)
    114     except Exception as e:
    115         scope_names = node.get_scope_info()[0]

File /opt/conda/lib/python3.11/site-packages/coremltools/converters/mil/frontend/torch/ops.py:174, in convert_single_node(context, node)
    171 if context.frontend == TorchFrontend.TORCHSCRIPT:
    172     context.convert_input_to_tensor_type(node)
--> 174 add_op(context, node)
    175 if _TORCH_OPS_REGISTRY.is_inplace_op(op_lookup):
    176     context.process_inplace_op(node)

File /opt/conda/lib/python3.11/site-packages/coremltools/converters/mil/frontend/torch/ops.py:3066, in _int(context, node)
   3064 @register_torch_op(torch_alias=["int"])
   3065 def _int(context, node):
-> 3066     _cast(context, node, int, "int32")

File /opt/conda/lib/python3.11/site-packages/coremltools/converters/mil/frontend/torch/ops.py:3048, in _cast(context, node, dtype, dtype_name)
   3044 if x.can_be_folded_to_const():
   3045     # If x is a compile-time constant, directly cast it to @dtype if it's
   3046     # not one already.
   3047     if not isinstance(x.val, dtype):
-> 3048         res = mb.const(val=dtype(x.val), name=node.name)
   3049     else:
   3050         res = x

TypeError: only 0-dimensional arrays can be converted to Python scalars
```