### PR TITLE
Update callsite for pt2e quant

### DIFF
--- a/coremltools/converters/mil/frontend/torch/test/test_torch_export_quantization.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_export_quantization.py
@@ -29,10 +29,11 @@ if _TORCH_VERSION < _EXPECTED_TORCH_VERSION:
     )
 
 from torch.export import export_for_training
-from torch.ao.quantization.quantize_pt2e import convert_pt2e, prepare_pt2e, prepare_qat_pt2e
-from torch.ao.quantization.quantizer.xnnpack_quantizer import (
-    XNNPACKQuantizer,
-    get_symmetric_quantization_config,
+from torchao.quantization.pt2e.quantize_pt2e import convert_pt2e, prepare_pt2e, prepare_qat_pt2e
+# TODO: need to remove this
+from torchao.testing.pt2e._xnnpack_quantizer import (
+   get_symmetric_quantization_config,
+   XNNPACKQuantizer,
 )
 
 import coremltools as ct

--- a/coremltools/optimize/torch/quantization/_annotation_config.py
+++ b/coremltools/optimize/torch/quantization/_annotation_config.py
@@ -8,7 +8,7 @@ from typing import Optional as _Optional
 import torch as _torch
 import torch.ao.quantization as _aoquant
 from attr import define as _define
-from torch.ao.quantization.quantizer.quantizer import (
+from torchao.quantization.pt2e.quantizer import (
     QuantizationSpec as _TorchQuantizationSpec,
 )
 

--- a/coremltools/optimize/torch/quantization/_coreml_quantizer.py
+++ b/coremltools/optimize/torch/quantization/_coreml_quantizer.py
@@ -9,8 +9,8 @@ from typing import List as _List
 from typing import Optional as _Optional
 
 import torch as _torch
-from torch.ao.quantization.quantizer.quantizer import Quantizer as _TorchQuantizer
-from torch.ao.quantization.quantizer.xnnpack_quantizer import _get_module_name_filter
+from torchao.quantization.pt2e.quantizer import Quantizer as _TorchQuantizer
+from torchao.quantization.pt2e.quantizer import get_module_name_filter
 from torch.fx import Node as _Node
 
 import coremltools.optimize.torch.quantization._coreml_quantizer_utils as _annotation_utils
@@ -519,7 +519,7 @@ class CoreMLQuantizer(_TorchQuantizer):
     """
     Annotates all recognized patterns using ``config``.
 
-    Extends py:class:`torch.ao.quantization.quantizer.quantizer.Quantizer` to
+    Extends py:class:`torchao.quantization.pt2e.quantizer.Quantizer` to
     add support for quantization patterns supported by Core ML.
 
     Use it in conjunction with PyTorch 2.0 ``prepare_pt2e`` and ``prepare_qat_pt2e`` APIs
@@ -532,7 +532,7 @@ class CoreMLQuantizer(_TorchQuantizer):
 
                 import torch.nn as nn
                 from torch.export import export_for_training
-                from torch.ao.quantization.quantize_pt2e import convert_pt2e, prepare_qat_pt2e
+                from torchao.quantization.pt2e.quantize_pt2e import convert_pt2e, prepare_qat_pt2e
 
                 from coremltools.optimize.torch.quantization._coreml_quantizer import CoreMLQuantizer
 
@@ -600,7 +600,7 @@ class CoreMLQuantizer(_TorchQuantizer):
         module_name_list = list(self._config.module_name_configs.keys())
         for module_name, config in self._config.module_name_configs.items():
             self._annotate_all_patterns(
-                model, config, _get_module_name_filter(module_name)
+                model, config, get_module_name_filter(module_name)
             )
 
         # Next annotate all modules/operations which have type based configs

--- a/coremltools/optimize/torch/quantization/quantization_config.py
+++ b/coremltools/optimize/torch/quantization/quantization_config.py
@@ -18,6 +18,10 @@ from typing import Union as _Union
 import cattrs as _cattrs
 import torch as _torch
 import torch.ao.quantization as _aoquant
+# torchao pt2e quant flow requires importing from torchao pt2e for observer/fake_quant
+# which is not compatible with torch.ao fx quant flow
+# we can only change the import when the old fx flow is deprecated
+# import torchao.quantization.pt2e as _aoquant
 from attr import define as _define
 from attr import field as _field
 from attrs import validators as _validators

--- a/coremltools/test/optimize/torch/quantization/test_coreml_quantizer.py
+++ b/coremltools/test/optimize/torch/quantization/test_coreml_quantizer.py
@@ -20,7 +20,7 @@ from coremltools.optimize.torch.quantization.quantization_config import (
 from coremltools._deps import _HAS_TORCH_EXPORT_API
 if _HAS_TORCH_EXPORT_API:
     from torch.export import export_for_training
-    from torch.ao.quantization.quantize_pt2e import (
+    from torchao.quantization.pt2e.quantize_pt2e import (
         convert_pt2e,
         prepare_pt2e,
         prepare_qat_pt2e,
@@ -184,6 +184,7 @@ def quantize_model(
 @pytest.mark.parametrize("is_qat", [True, False])
 @pytest.mark.skipif(not _HAS_TORCH_EXPORT_API or _TORCH_VERSION < _EXPECTED_TORCH_VERSION,
                     reason="This test requires PyTorch Export APIs and PyTorch >= 2.2.0.")
+@pytest.mark.skip(reason="Skipping for now due to migration of pt2e quant API to torchao, please use CoreMLQuantizer from ExecuTorch: https://github.com/pytorch/executorch/pull/16473")
 def test_weight_module_act_fusion(model_for_quant, is_qat, config):
     if _TORCH_VERSION >= "2.5.0" and config.global_config.activation_dtype == torch.quint8:
         pytest.xfail("TODO (rdar://141183574): Upgrade cto.torch for torch 2.5")

--- a/reqs/pytorch.pip
+++ b/reqs/pytorch.pip
@@ -13,4 +13,4 @@ torchsr==1.0.4; platform_machine == "arm64"
 # TODO (rdar://141476729) support a more recent timm
 timm==0.6.13; platform_machine == "arm64"
 
-torchao==0.10.0; platform_machine == "arm64" and python_version >= '3.10'
+torchao==0.15.0; platform_machine == "arm64" and python_version >= '3.10'


### PR DESCRIPTION
Summary:
We just removed pt2e quant from pytorch/pytorch in https://github.com/pytorch/pytorch/pull/169151 This PR updated the pt2e quantization callsites to torchao

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: