### PR TITLE
Fix incorrect axis value in ArgMax/ArgMin documentation examples

### DIFF
--- a/mlmodel/format/NeuralNetwork.proto
+++ b/mlmodel/format/NeuralNetwork.proto
@@ -5707,7 +5707,7 @@ message TopKLayerParams {
  * e.g.:
  *
  * input shape = (45, 34, 10, 5)
- * axis = -2
+ * axis = -3
  * output shape = (45, 1, 10, 5), if removeDim = False (default)
  * output shape = (45, 10, 5), if removeDim = True
  *
@@ -5734,7 +5734,7 @@ message ArgMaxLayerParams {
 * e.g.:
 *
 * input shape = (45, 34, 10, 5)
-* axis = -2
+* axis = -3
 * output shape = (45, 1, 10, 5), if removeDim = False (default)
 * output shape = (45, 10, 5), if removeDim = True
 *


### PR DESCRIPTION
 ## Summary

  - Fixes the axis value in `ArgMaxLayerParams` and `ArgMinLayerParams` documentation examples in `NeuralNetwork.proto`
  - Changed `axis = -2` to `axis = -3` to match the documented output shapes

  ## Problem

  The examples showed:
  - Input shape: `(45, 34, 10, 5)`
  - `axis = -2`
  - Output shape: `(45, 1, 10, 5)`

  This is mathematically inconsistent. For a 4D tensor:
  - `axis = -2` (index 2, size 10) would produce `(45, 34, 1, 5)`
  - `axis = -3` (index 1, size 34) correctly produces `(45, 1, 10, 5)`

  ## Test plan

  - [x] Verified the math: negative index `-3` maps to dimension 1 (size 34), which when reduced gives `(45, 1, 10, 5)`
  - Documentation-only change, no functional code affected

  Fixes #1189