### PR TITLE
Fix CI

### DIFF
--- a/reqs/test_executorch.pip
+++ b/reqs/test_executorch.pip
@@ -4,3 +4,4 @@
 # Warning: Starting from ExecuTorch 0.6.0, coremltools is added as a dependency
 # so we need to re-install built-from-source coremltools after pip install ExecuTorch
 executorch>=0.6.0; platform_machine == "arm64" and python_version >= '3.10' and python_version < '3.13'
+setuptools<81


### PR DESCRIPTION
Recently `setuptools` pushed a new version which removed their `pkg_resources`. This breaks the version of `executorch` that we depend on.

CI: https://gitlab.com/coremltools1/coremltools/-/pipelines/2349677850