### PR TITLE
Add Alias

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -6455,6 +6455,7 @@ def meshgrid(context, node):
         "_assert_scalar",
         "_assert_tensor_metadata",
         "_local_scalar_dense",
+        "alias",
         "alias_copy",
         "clone",
         "contiguous",


### PR DESCRIPTION
## Motivation
Models such as T5 has `alias` op

## Solution
From [PyTorch alias definition](https://github.com/pytorch/pytorch/blob/v2.10.0/aten/src/ATen/native/native_functions.yaml#L10625-L10630) it seems to be a noop

## Testing:
✅ https://gitlab.com/coremltools1/coremltools/-/pipelines/2369567878