### PR TITLE
Add regression test for length-1 tensor int casts

### DIFF
--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -7277,6 +7277,25 @@ class TestTo(TorchBaseTest):
             compute_unit=compute_unit,
         )
 
+    def test_cast_length_1_constant_tensor(self):
+        class TestModel(torch.nn.Module):
+            def forward(self, x):
+                b, c, h, w = x.shape
+                return x.reshape(b, c, int(h * w))
+
+        x = torch.rand(1, 2, 4, 4)
+        torch_model = export_torch_model_to_frontend(
+            TestModel().eval(),
+            (x,),
+            TorchFrontend.TORCHSCRIPT,
+        )
+        ct.convert(
+            torch_model,
+            inputs=[ct.TensorType(shape=x.shape)],
+            convert_to="neuralnetwork",
+            minimum_deployment_target=ct.target.iOS14,
+        )
+
     @pytest.mark.parametrize(
         "compute_unit, backend, frontend",
         itertools.product(compute_units, backends, frontends),


### PR DESCRIPTION
## Summary
- add a Torch frontend regression test for `int()` on a foldable length-1 tensor
- cover the minimal shape pattern that previously failed in `coremltools 9.0`
- keep the test conversion-only so it exercises the frontend bug without requiring CoreML runtime prediction

## Context
The released `9.0` converter fails on traced Torch graphs that contain `aten::Int` over a foldable length-1 tensor, for example a model that reshapes with `int(h * w)` after unpacking `x.shape`. Current `main` already handles this correctly in `_cast`; this test locks that behavior in.

Minimal repro shape pattern:
```python
b, c, h, w = x.shape
return x.reshape(b, c, int(h * w))
```

I verified locally that:
- `coremltools 9.0` fails on this pattern with `TypeError: only 0-dimensional arrays can be converted to Python scalars`
- current `main` converts it successfully
