### PR TITLE
Add OnesLike op to TF frontend

### DIFF
--- a/coremltools/converters/mil/frontend/tensorflow/ops.py
+++ b/coremltools/converters/mil/frontend/tensorflow/ops.py
@@ -3133,6 +3133,17 @@ def ZerosLike(context, node):
         x = mb.fill(shape=mb.shape(x=x), value=np_type(0), name=node.name)
     context.add(node.name, x)
 
+@register_tf_op
+def OnesLike(context, node):
+    x = context[node.inputs[0]]
+    if x.rank == 0:
+        np_type = types.nptype_from_builtin(x.sym_type)
+        x = mb.const(val=np_type(1), name=node.name)
+    else:
+        np_type = types.nptype_from_builtin(x.sym_type.get_primitive())
+        x = mb.fill(shape=mb.shape(x=x), value=np_type(1), name=node.name)
+    context.add(node.name, x)
+
 
 @register_tf_op
 def IsFinite(context, node):

--- a/coremltools/converters/mil/frontend/tensorflow/test/test_ops.py
+++ b/coremltools/converters/mil/frontend/tensorflow/test/test_ops.py
@@ -7422,6 +7422,49 @@ class TestZerosLike(TensorFlowBaseTest):
             compute_unit=compute_unit,
             backend=backend,
         )
+class TestOnesLike(TensorFlowBaseTest):
+    @pytest.mark.parametrize(
+        "compute_unit, backend, rank, dynamic",
+        itertools.product(
+            compute_units,
+            backends,
+            [rank for rank in range(5)],
+            [True, False],
+        ),
+    )
+    def test(self, compute_unit, backend, rank, dynamic):
+        if rank == 0:
+            pytest.skip('Rank 0 not supported by CoreML runtime')
+        input_shape = np.random.randint(low=2, high=4, size=rank)
+        input_value = random_gen(input_shape, rand_min=-1, rand_max=1)
+        if dynamic:
+            a, b = np.prod(input_shape[:2]), np.prod(input_shape[2:])
+            reshape_vals = np.array([a, b], dtype=np.int32)
+            reshape_input_shape = np.array([2], dtype=np.int32)
+
+            @make_tf_graph([input_shape, list(reshape_input_shape) + [tf.int32]])
+            def build_model(x, reshape):
+                x = tf.reshape(x, shape=reshape)
+                return tf.raw_ops.OnesLike(x=x)
+
+            model, inputs, outputs = build_model
+            input_values = [input_value, reshape_vals]
+        else:
+
+            @make_tf_graph([input_shape])
+            def build_model(x):
+                return tf.raw_ops.OnesLike(x=x)
+
+            model, inputs, outputs = build_model
+            input_values = [input_value]
+        input_dict = dict(zip(inputs, input_values))
+        TensorFlowBaseTest.run_compare_tf(
+            model,
+            input_dict,
+            outputs,
+            compute_unit=compute_unit,
+            backend=backend,
+        )
 
 
 class TestIsFinite(TensorFlowBaseTest):


### PR DESCRIPTION
## Summary
Adds `OnesLike` to the TensorFlow frontend op registry, mirroring the existing `ZerosLike` implementation.

## Motivation
`OnesLike` is missing from the TF frontend, causing conversion failures for models with dynamic sequence lengths.

## Changes
- Added `OnesLike` handler in `ops.py` alongside `ZerosLike`
- Added `TestOnesLike` test class in `test_ops.py` mirroring `TestZerosLike`