### PR TITLE
Fix meshgrid converter to handle non-1D inputs

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -6457,15 +6457,30 @@ def meshgrid(context, node):
         assert isinstance(tensor_inputs, (list, tuple))
         if len(tensor_inputs) < 2:
             raise ValueError("Requires >= 2 tensor inputs.")
-        if any(tensor_input.rank > 1 for tensor_input in tensor_inputs):
-            raise ValueError("meshgrid received non-1d tensor.")
 
         if indexing not in ("ij", "xy"):
             raise ValueError(f"indexing mode {indexing} not supported")
 
+    def _flatten_inputs(tensor_inputs):
+        """Flatten non-1D inputs to 1D.
+
+        PyTorch JIT tracing can produce tensors with shape (N, 1) instead of (N,)
+        for ops like torch.linspace. Since meshgrid expects 1D inputs, we reshape
+        them here.
+        """
+        flattened = []
+        for i, t in enumerate(tensor_inputs):
+            if t.rank > 1:
+                t = mb.reshape(
+                    x=t, shape=[-1], name=node.name + "_flatten_" + str(i)
+                )
+            flattened.append(t)
+        return flattened
+
     tensor_inputs, indexing = _parse_positional_args(context, node)
     indexing = _parse_keyword_args(context, node, indexing)
     _check_args(tensor_inputs, indexing)
+    tensor_inputs = _flatten_inputs(tensor_inputs)
 
     result_symbolic_shape = [tensor_input.shape[0] for tensor_input in tensor_inputs]
     result_shape = _utils.maybe_replace_symbols_with_source_tensor_shape_variables(

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -11312,6 +11312,54 @@ class TestMeshgrid(TorchBaseTest):
             compute_unit=compute_unit,
         )
 
+    @pytest.mark.parametrize(
+        "compute_unit, backend, indexing",
+        itertools.product(
+            compute_units,
+            backends,
+            ["ij", "xy"],
+        ),
+    )
+    def test_meshgrid_non_1d_inputs(self, compute_unit, backend, indexing):
+        """Test meshgrid where inputs become non-1D during conversion.
+
+        When a 1D tensor is divided by a 0D scalar (e.g. from a dynamic shape),
+        the MIL converter may produce a higher-rank result. The meshgrid converter
+        should flatten these to 1D before processing rather than raising an error.
+
+        This pattern occurs in deformable attention (DINO/Deformable-DETR/RF-DETR)
+        where coordinate grids are created via:
+            grid_y = torch.linspace(..., steps=h) / h
+            grid_x = torch.linspace(..., steps=w) / w
+            grid_y, grid_x = torch.meshgrid(grid_y, grid_x, indexing='ij')
+        """
+
+        class TestModel(nn.Module):
+            def forward(self, feat):
+                h, w = feat.shape[2], feat.shape[3]
+                grid_y = torch.linspace(
+                    0.5, h - 0.5, steps=h, dtype=feat.dtype, device=feat.device
+                ) / h
+                grid_x = torch.linspace(
+                    0.5, w - 0.5, steps=w, dtype=feat.dtype, device=feat.device
+                ) / w
+                grid_y, grid_x = torch.meshgrid(grid_y, grid_x, indexing=indexing)
+                return torch.stack([grid_x, grid_y], dim=-1)
+
+        inputs = (torch.randn(1, 64, 4, 6),)
+        model = TestModel().eval()
+        expected_results = model(*inputs)
+
+        self.run_compare_torch(
+            inputs,
+            model,
+            expected_results,
+            input_as_shape=False,
+            frontend=TorchFrontend.TORCHSCRIPT,
+            backend=backend,
+            compute_unit=compute_unit,
+        )
+
 
 class TestAddmm(TorchBaseTest):
     @pytest.mark.parametrize(


### PR DESCRIPTION
I am trying to use https://github.com/roboflow/rf-detr and convert the model to CoreML for use on iPad computer vision app. I'm using some of the fixes from https://github.com/landchenxuan/rf-detr-to-coreml and after upgrading to latest PyTorch 2.11 am getting good performance! :-)

There's one issue with `torch.meshgrid` that needs a small fix. For now I have a helper function to monkey-patch `coremltools` with this fix as workaround.

See description and code/test in this PR - done by coding agent.

Would be great if you could include it. 

---

## Summary

The `meshgrid` op converter raises `ValueError("meshgrid received non-1d tensor.")` when
inputs have rank > 1. This happens in practice when converting models that use
`torch.linspace(...) / scalar` before `torch.meshgrid()`, because the MIL `real_div` op
can broadcast the 1D linspace result with a 0D scalar divisor to produce a higher-rank
tensor.

This pattern is common in deformable attention modules (DINO, Deformable-DETR, RF-DETR)
where coordinate grids are created:

```python
grid_y = torch.linspace(0.5, h - 0.5, steps=h) / h
grid_x = torch.linspace(0.5, w - 0.5, steps=w) / w
grid_y, grid_x = torch.meshgrid(grid_y, grid_x, indexing="ij")
```

The PyTorch JIT trace shows 1D tensors flowing into `meshgrid`, but during MIL conversion
the division by a 0D shape-derived scalar produces a result with rank > 1 in the MIL IR,
causing the meshgrid converter to reject it.

## Changes

**`coremltools/converters/mil/frontend/torch/ops.py`**
- Removed the hard rejection of non-1D inputs (`raise ValueError("meshgrid received non-1d tensor.")`)
- Added `_flatten_inputs()` helper that reshapes any non-1D inputs to 1D via `mb.reshape(shape=[-1])` before meshgrid processing
- This is safe because `meshgrid` semantically requires 1D-like inputs, and the flatten simply recovers the intended shape

**`coremltools/converters/mil/frontend/torch/test/test_torch_ops.py`**
- Added `test_meshgrid_non_1d_inputs` to `TestMeshgrid` class
- Tests the deformable attention pattern (`linspace / scalar → meshgrid`) with both `ij` and `xy` indexing modes
- Parametrized across compute units and backends, consistent with existing test style

## Testing

Red/green verified:
- **RED**: Without the fix, the new test fails with `ValueError: meshgrid received non-1d tensor.`
- **GREEN**: With the fix, all meshgrid tests pass (both existing and new)

```
4 passed (2 existing + 2 new) — no regressions
```

## Related Issues

- Partially addresses [#1674](https://github.com/apple/coremltools/issues/1674) (meshgrid conversion failures)
- Related to [#1268](https://github.com/apple/coremltools/pull/1268) (previous meshgrid input fix)
- https://github.com/apple/coremltools/issues/2615