### PR TITLE
Add torch op coverage for LLM attention mask construction

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -5734,17 +5734,43 @@ def bitwise_not(context, node):
     context.add(x)
 
 
-@register_torch_op(torch_alias=["and"])
-def bitwise_and(context, node):
-    inputs = _get_inputs(context, node)
+def _bitwise_as_logical_if_boolean(context, node, op_name, logical_handler):
+    """Shared body for bitwise_and/or/xor.
 
+    Core ML has no true bitwise op on integers, so we lower to the logical
+    counterpart whenever at least one operand is bool — which covers the common
+    "combine boolean masks" pattern in attention/transformer code (where
+    torch.export may produce a mixed bool/float pair). Pure non-bool inputs are
+    still rejected so we don't silently change semantics for genuine integer
+    bitwise math.
+    """
+    inputs = _get_inputs(context, node)
     input_dtypes = [i.dtype for i in inputs]
-    if all(types.is_bool(input_dtype) for input_dtype in input_dtypes):
-        logical_and(context, node)
+    if any(types.is_bool(d) for d in input_dtypes):
+        logical_handler(context, node)
     else:
         raise NotImplementedError(
-            f"The `bitwise_and` op only supports boolean input, but get {input_dtypes}."
+            f"The `{op_name}` op only supports boolean input, but get {input_dtypes}."
         )
+
+
+@register_torch_op(torch_alias=["and"])
+def bitwise_and(context, node):
+    _bitwise_as_logical_if_boolean(context, node, "bitwise_and", logical_and)
+
+
+# "or" and "xor" cover the post-sanitize form of "aten::__or__" / "aten::__xor__"
+# which torch.export emits for `tensor | tensor` / `tensor ^ tensor`. These are
+# common when building boolean attention masks (e.g. Gemma combines a causal
+# mask with a padding mask via __or__).
+@register_torch_op(torch_alias=["or"])
+def bitwise_or(context, node):
+    _bitwise_as_logical_if_boolean(context, node, "bitwise_or", logical_or)
+
+
+@register_torch_op(torch_alias=["xor"])
+def bitwise_xor(context, node):
+    _bitwise_as_logical_if_boolean(context, node, "bitwise_xor", logical_xor)
 
 
 @register_torch_op
@@ -6664,6 +6690,16 @@ def new_zeros(context, node):
 
 
 @register_torch_op
+def new_ones(context, node):
+    # tensor.new_ones(size) — same shape semantics as new_zeros, value is 1.
+    # Use _make_fill_op so float-typed shape inputs (which torch.export sometimes
+    # produces) are coerced to int32 automatically.
+    inputs = _get_inputs(context, node)
+    result = _make_fill_op(inputs[1], 1.0, node.name)
+    context.add(result)
+
+
+@register_torch_op
 def scalar_tensor(context, node):
     x = _get_inputs(context, node, expected=[1, 5])[0]
     res = mb.identity(x=x, name=node.name)
@@ -7443,7 +7479,7 @@ def _nonzero_as_tuple(context, node, x):
     context.add(result, node.name)
 
 
-@register_torch_op(torch_alias=["where.self"])
+@register_torch_op(torch_alias=["where.self", "where.scalarother"])
 def where(context, node):
     inputs = _get_inputs(context, node)
 

--- a/coremltools/converters/mil/frontend/torch/test/test_internal_graph.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_internal_graph.py
@@ -21,6 +21,39 @@ from .. import ops
 from .. import utils
 from ..converter import TranscriptionContext
 from ..internal_graph import InternalTorchIRNode
+from ..utils import sanitize_op_kind
+
+
+class TestSanitizeOpKind:
+    """Unit tests for the op-name canonicalizer used by both TorchScript and EXIR
+    frontends. The trickiest case is op overloads whose canonical name only
+    contains a "__name__" wrapper after the namespace prefix is stripped — e.g.
+    aten::__or__.Tensor must canonicalize to "or" so it resolves against the
+    same registry entry as the legacy "__or__" form.
+    """
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            # Already-canonical names round-trip.
+            ("add", "add"),
+            ("logical_or", "logical_or"),
+            # Legacy double-underscore form (single token).
+            ("__add__", "add"),
+            ("__or__", "or"),
+            # ATen / overload-suffixed forms.
+            ("aten::add.Tensor", "add"),
+            ("aten::bmm.default", "bmm"),
+            ("aten::pow.Tensor_Scalar", "pow"),
+            # Dunder hidden behind a namespace + overload suffix — the case that
+            # used to slip through and produce e.g. "__or__" as the lookup key.
+            ("aten::__or__.Tensor", "or"),
+            ("aten::__and__.Tensor", "and"),
+            ("aten::__xor__.Tensor", "xor"),
+        ],
+    )
+    def test_sanitize_op_kind(self, raw, expected):
+        assert sanitize_op_kind(raw) == expected
 
 
 class TestTorchOps:

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -4501,6 +4501,34 @@ class TestNewZeros(TorchBaseTest):
         )
 
 
+class TestNewOnes(TorchBaseTest):
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend, shape",
+        itertools.product(
+            compute_units,
+            backends,
+            frontends,
+            [
+                (1,),
+                (2, 3),
+                (1, 1, 2, 5, 1),
+            ],
+        ),
+    )
+    def test_new_ones_static(self, compute_unit, backend, frontend, shape):
+        class OnesStaticModel(nn.Module):
+            def forward(self, x):
+                return x.new_ones(x.shape)
+
+        self.run_compare_torch(
+            shape,
+            OnesStaticModel().eval(),
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+        )
+
+
 class TestNewFull(TorchBaseTest):
     @pytest.mark.parametrize(
         "compute_unit, backend, frontend, rank",
@@ -13314,6 +13342,75 @@ class TestBitwiseAnd(TorchBaseTest):
                 compute_unit=compute_unit,
                 input_as_shape=False,
             )
+
+
+class TestBitwiseOr(TorchBaseTest):
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend",
+        itertools.product(compute_units, backends, frontends),
+    )
+    def test_bitwise_or(self, compute_unit, backend, frontend):
+        class TestModel(torch.nn.Module):
+            def forward(self, x, y):
+                return torch.bitwise_or(x, y)
+
+        input_shape = (2, 3)
+        input_data_x = torch.rand(*input_shape) > 0.2
+        input_data_y = torch.rand(*input_shape) < 0.8
+        self.run_compare_torch(
+            [input_data_x, input_data_y],
+            TestModel(),
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+            input_as_shape=False,
+        )
+
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend",
+        itertools.product(compute_units, backends, frontends),
+    )
+    def test_or_operator(self, compute_unit, backend, frontend):
+        # Exercises tensor.__or__ (i.e. `x | y`) which sanitizes to "or" and
+        # is the form torch.export emits when building boolean attention masks.
+        class TestModel(torch.nn.Module):
+            def forward(self, x, y):
+                return x | y
+
+        input_shape = (2, 3)
+        input_data_x = torch.rand(*input_shape) > 0.2
+        input_data_y = torch.rand(*input_shape) < 0.8
+        self.run_compare_torch(
+            [input_data_x, input_data_y],
+            TestModel(),
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+            input_as_shape=False,
+        )
+
+
+class TestBitwiseXor(TorchBaseTest):
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend",
+        itertools.product(compute_units, backends, frontends),
+    )
+    def test_bitwise_xor(self, compute_unit, backend, frontend):
+        class TestModel(torch.nn.Module):
+            def forward(self, x, y):
+                return torch.bitwise_xor(x, y)
+
+        input_shape = (2, 3)
+        input_data_x = torch.rand(*input_shape) > 0.2
+        input_data_y = torch.rand(*input_shape) < 0.8
+        self.run_compare_torch(
+            [input_data_x, input_data_y],
+            TestModel(),
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+            input_as_shape=False,
+        )
 
 
 class TestUnfold(TorchBaseTest):

--- a/coremltools/converters/mil/frontend/torch/utils.py
+++ b/coremltools/converters/mil/frontend/torch/utils.py
@@ -163,6 +163,12 @@ def sanitize_op_kind(op_kind: str) -> str:
     op_kind = skip_default_prefix_and_suffix_with_deliminator(op_kind, "::")
     op_kind = skip_default_prefix_and_suffix_with_deliminator(op_kind, ".")
 
+    # 4. Strip the "__name__" wrapper again. The dunder may only become visible
+    # after stripping the namespace and overload suffix above, e.g.
+    # "aten::__or__.Tensor" -> "__or__" -> "or".
+    if op_kind.startswith("__") and op_kind.endswith("__"):
+        op_kind = op_kind[2:-2]
+
     return op_kind
 
 


### PR DESCRIPTION
## Summary

Adds the small set of torch ops that HuggingFace attention-mask construction emits via `torch.export` but coremltools didn't yet handle. Discovered while converting `google/gemma-4-E2B-it`, but the same gaps affect any decoder LLM that builds masks the way HuggingFace's `eager` attention path does.

All five gaps are independent fixes for **existing asymmetries** in the registry (e.g. `bitwise_and` exists but `bitwise_or` did not; `new_zeros` exists but `new_ones` did not). None of them change behavior of any op that already worked.

## Reproduction (before this PR)

```python
import torch
from transformers import AutoModelForCausalLM, AutoTokenizer
import coremltools as ct

model = AutoModelForCausalLM.from_pretrained(
    "google/gemma-4-E2B-it",
    torch_dtype=torch.float32,
    attn_implementation="eager",
).eval()
tok = AutoTokenizer.from_pretrained("google/gemma-4-E2B-it")
enc = tok("hello", return_tensors="pt", padding="max_length", max_length=32)

class Wrapper(torch.nn.Module):
    def __init__(self, m):
        super().__init__()
        self.m = m
    def forward(self, ids, attn):
        return self.m(input_ids=ids, attention_mask=attn, use_cache=False).logits

with torch.no_grad():
    ep = torch.export.export(
        Wrapper(model),
        args=(enc["input_ids"], enc["attention_mask"]),
        strict=False,
    ).run_decompositions({})

ct.convert(ep, convert_to="mlprogram", minimum_deployment_target=ct.target.iOS18)
# NotImplementedError: Unsupported fx node or_1, kind __or__
```

After fixing `__or__` the converter then fails on `__and__`, then `new_ones`, then `where.scalarother`, then `bitwise_and` with mixed bool+float inputs. This PR addresses all of them in one place.

## Changes

1. **`sanitize_op_kind`** — strip the `__name__` wrapper after the namespace and overload suffix have been removed. Previously `aten::__or__.Tensor` sanitized to `__or__` instead of `or`, so the registry lookup missed even when an `or` handler existed. The original logic only stripped `__...__` if the *whole* op kind matched, which is only the case for the legacy TorchScript form.

2. **Register `bitwise_or` / `bitwise_xor`** with `or` / `xor` aliases for the post-sanitize form. Both reuse the `logical_*` MIL primitives, mirroring the existing `bitwise_and` registration. The asymmetry was clearly accidental.

3. **Relax `bitwise_and` / `bitwise_or` / `bitwise_xor`** to accept mixed-bool inputs. Previously they required *all* inputs to be bool; now if at least one input is bool we cast both to bool and lower to the corresponding `logical_*` op. Pure non-bool inputs are still rejected with the same error so genuine integer bitwise math is unchanged. This unblocks Gemma-style mask combination where a bool causal mask meets a float padding mask.

4. **Register `aten::new_ones`** mirroring the existing `new_zeros`, using `_make_fill_op` so float-typed shape inputs from `torch.export` are coerced to int32 (which is also a latent issue in `new_zeros` that this PR avoids by using the safer helper).

5. **Add `where.ScalarOther` as an alias** on the existing `where` handler, which already does dtype promotion and broadcasting. The `where.self` and `where.scalarself` overloads were already covered; `where.scalarother` was the missing third.

## Test plan

- New unit tests in `test_internal_graph.py` covering the dunder-after-namespace case for `sanitize_op_kind`:
  - `aten::__or__.Tensor` → `or`
  - `aten::__and__.Tensor` → `and`
  - `aten::__xor__.Tensor` → `xor`
  - Plus the existing legacy forms (`__add__` → `add`, `aten::add.Tensor` → `add`, etc.) to guard against regressions
- New op-level tests in `test_torch_ops.py`:
  - `TestNewOnes::test_new_ones_static`
  - `TestBitwiseOr::test_bitwise_or` and `test_or_operator` (the latter exercises the `tensor | tensor` form)
  - `TestBitwiseXor::test_bitwise_xor`
- Existing `TestBitwiseAnd` and all `TestLogical*` tests still pass (the relaxed bool check is a strict superset of the previous behavior)

End-to-end validation on `google/gemma-4-E2B-it` (`compute_precision=FLOAT32`):

```
ref last argmax: 7001 -> ' France'
cml last argmax: 7001 -> ' France'
top-5 overlap: 5/5
per-position argmax agreement: 100.0% (5/5)
max abs diff: 5.30e-02
VERDICT: Core ML model is functionally correct.
```

(`fp16` correctness for the same model is addressed by a separate PR: https://github.com/apple/coremltools/pull/2669 — no functional dependency between the two PRs, but both are needed to convert Gemma 4 cleanly.)