### PR TITLE
Fix int32 torch.mm runtime by lowering to matmul

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -1035,13 +1035,26 @@ def pixel_unshuffle(context, node):
     context.add(perm)
 
 
+def _construct_matmul(x: Var, y: Var, name: Optional[str] = None) -> Var:
+    if (
+        x.dtype != types.int32
+        and y.dtype != types.int32
+        and (len(y.shape) == 2 and len(x.shape) <= 3)
+        and (_is_const(y) or y.is_descendant_of_const)
+    ):
+        linear_x, weight = x, y
+        transposed_weight = mb.transpose(x=weight, perm=(1, 0))
+        res = mb.linear(x=linear_x, weight=transposed_weight, name=name)
+    else:
+        x, y = promote_input_dtypes([x, y])
+        res = mb.matmul(x=x, y=y, name=name)
+    return res
+
+
 @register_torch_op(torch_alias=["bmm", "mm"])
 def matmul(context, node):
     x, y = _get_inputs(context, node, expected=2)
-    x, y = promote_input_dtypes([x, y])
-    # Keep mm/bmm on the matmul path even when the RHS is constant. Lowering
-    # constant int32 weights to linear produces incorrect/runtime behavior.
-    res = mb.matmul(x=x, y=y, name=node.name)
+    res = _construct_matmul(x, y, node.name)
     context.add(res)
 
 

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -1035,21 +1035,13 @@ def pixel_unshuffle(context, node):
     context.add(perm)
 
 
-def _construct_matmul(x: Var, y: Var, name: Optional[str] = None) -> Var:
-    if (len(y.shape) == 2 and len(x.shape) <= 3) and (_is_const(y) or y.is_descendant_of_const):
-        linear_x, weight = x, y
-        transposed_weight = mb.transpose(x=weight, perm=(1, 0))
-        res = mb.linear(x=linear_x, weight=transposed_weight, name=name)
-    else:
-        x, y = promote_input_dtypes([x, y])
-        res = mb.matmul(x=x, y=y, name=name)
-    return res
-
-
 @register_torch_op(torch_alias=["bmm", "mm"])
 def matmul(context, node):
     x, y = _get_inputs(context, node, expected=2)
-    res = _construct_matmul(x, y, node.name)
+    x, y = promote_input_dtypes([x, y])
+    # Keep mm/bmm on the matmul path even when the RHS is constant. Lowering
+    # constant int32 weights to linear produces incorrect/runtime behavior.
+    res = mb.matmul(x=x, y=y, name=node.name)
     context.add(res)
 
 

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -19,6 +19,7 @@ import torch.nn as nn
 import coremltools as ct
 from coremltools import RangeDim, Shape, TensorType
 from coremltools._deps import _HAS_TORCH_AUDIO, _HAS_TORCH_VISION, version_lt
+from coremltools.converters.mil.backend.mil.load import BlobWriter
 from coremltools.converters.mil import testing_reqs
 from coremltools.converters.mil.frontend.torch.utils import (
     NUM_TO_TORCH_DTYPE,
@@ -41,6 +42,7 @@ from .testing_utils import (
     ModuleWrapper,
     TorchBaseTest,
     contains_op,
+    convert_to_mlmodel,
     export_torch_model_to_frontend,
     frontends,
     generate_input_data,
@@ -7085,6 +7087,52 @@ class TestMatMul(TorchBaseTest):
         self.run_compare_torch(
             [shape_x, shape_y], model, compute_unit=compute_unit, backend=backend, frontend=frontend
         )
+
+    @pytest.mark.parametrize("frontend", frontends)
+    @pytest.mark.parametrize(
+        "convert_to, minimum_deployment_target",
+        [("neuralnetwork", None), ("mlprogram", ct.target.iOS15)],
+    )
+    def test_mm_with_int32_constant_weight(
+        self, frontend, convert_to, minimum_deployment_target
+    ):
+        class TestModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer(
+                    "weight", torch.randint(low=-9, high=9, size=(4, 4), dtype=torch.int32)
+                )
+
+            def forward(self, x):
+                return torch.mm(x, self.weight)
+
+        model = TestModel().eval()
+        input_data = torch.randint(low=-9, high=9, size=(4, 4), dtype=torch.int32)
+        model_spec = export_torch_model_to_frontend(model, input_data, frontend)
+
+        if convert_to == "mlprogram" and BlobWriter is None:
+            pytest.skip("BlobWriter not loaded")
+
+        mlmodel = convert_to_mlmodel(
+            model_spec,
+            [input_data],
+            backend=(convert_to, "fp32"),
+            converter_input_type=[
+                ct.TensorType(name="x", shape=input_data.shape, dtype=np.int32)
+            ],
+            compute_unit=ct.ComputeUnit.CPU_ONLY,
+            minimum_deployment_target=minimum_deployment_target,
+        )
+
+        ops = get_op_types_in_program(mlmodel._mil_program)
+        assert "matmul" in ops
+        assert "linear" not in ops
+
+        if ct.utils._is_macos() and ct.models.model._MLModelProxy is not None:
+            output_name = mlmodel._spec.description.output[0].name
+            expected = model(input_data).numpy()
+            prediction = mlmodel.predict({"x": input_data.numpy()})[output_name]
+            np.testing.assert_array_equal(prediction.astype(np.int32), expected)
 
     @pytest.mark.parametrize(
         "compute_unit, backend, frontend",


### PR DESCRIPTION
Fixes #2575

## Summary
- lower torch.mm/torch.bmm through mb.matmul instead of the constant-weight mb.linear path
- keep the int32 constant-weight runtime path off the buggy linear lowering
- add a regression test that checks the converted graph uses matmul rather than linear for int32 torch.mm

## Testing
- /opt/miniconda3/envs/adamed/bin/python -m py_compile coremltools/converters/mil/frontend/torch/ops.py coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
- /opt/miniconda3/envs/adamed/bin/python -m pytest coremltools/converters/mil/frontend/torch/test/test_torch_ops.py -k "mm_with_int32_constant_weight" -q
  - local result: 1 passed, 1 skipped
  - the mlprogram case is skipped in this source checkout when BlobWriter is not available locally