### PR TITLE
Fix torch.acosh and torch.asinh lowering to MIL

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -7074,8 +7074,16 @@ def acos(context, node):
 
 @register_torch_op
 def acosh(context, node):
+    # MIL has no native acosh op, so decompose as:
+    #     acosh(x) = log(x + sqrt(x^2 - 1))
+    # which matches torch.acosh for the valid domain x >= 1.
     inputs = _get_inputs(context, node, expected=1)
-    context.add(mb.acosh(x=inputs[0], name=node.name))
+    x = inputs[0]
+    x_squared = mb.mul(x=x, y=x)
+    inner = mb.sub(x=x_squared, y=1.0)
+    sqrt_val = mb.sqrt(x=inner)
+    sum_val = mb.add(x=x, y=sqrt_val)
+    context.add(mb.log(x=sum_val, name=node.name))
 
 
 @register_torch_op
@@ -7357,8 +7365,16 @@ def sinh(context, node):
 
 @register_torch_op
 def asinh(context, node):
+    # MIL has no native asinh op, so decompose as:
+    #     asinh(x) = log(x + sqrt(x^2 + 1))
+    # which matches torch.asinh over all reals.
     inputs = _get_inputs(context, node, expected=1)
-    context.add(mb.asinh(x=inputs[0], name=node.name))
+    x = inputs[0]
+    x_squared = mb.mul(x=x, y=x)
+    inner = mb.add(x=x_squared, y=1.0)
+    sqrt_val = mb.sqrt(x=inner)
+    sum_val = mb.add(x=x, y=sqrt_val)
+    context.add(mb.log(x=sum_val, name=node.name))
 
 
 @register_torch_op

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -6686,6 +6686,7 @@ class TestElementWiseUnary(TorchBaseTest):
                 "abs",
                 "acos",
                 "asin",
+                "asinh",
                 "atan",
                 "ceil",
                 "cos",
@@ -6714,6 +6715,29 @@ class TestElementWiseUnary(TorchBaseTest):
         model = ModuleWrapper(function=op_func)
         self.run_compare_torch(
             shape, model, compute_unit=compute_unit, backend=backend, frontend=frontend
+        )
+
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend, shape",
+        itertools.product(
+            compute_units,
+            backends,
+            frontends,
+            [(1, 3, 5, 8)],
+        ),
+    )
+    def test_acosh(self, compute_unit, backend, frontend, shape):
+        # torch.acosh is only defined on x >= 1, so we need to pass inputs in
+        # that range instead of the default rand_range=(-1.0, 1.0) which would
+        # produce NaN values and break numeric comparison.
+        model = ModuleWrapper(function=torch.acosh)
+        self.run_compare_torch(
+            shape,
+            model,
+            compute_unit=compute_unit,
+            backend=backend,
+            frontend=frontend,
+            rand_range=(1.1, 5.0),
         )
 
     @pytest.mark.parametrize(
@@ -9219,6 +9243,7 @@ class TestTorchTensor(TorchBaseTest):
                 "abs",
                 "acos",
                 "asin",
+                "asinh",
                 "atan",
                 "atanh",
                 "ceil",


### PR DESCRIPTION
## Summary

Fixes #2569.

The torch converter functions for `acosh` and `asinh` in `coremltools/converters/mil/frontend/torch/ops.py` called `mb.acosh` and `mb.asinh`, but those ops do not exist in MIL. Every attempt to convert a model containing `torch.acosh` or `torch.asinh` therefore failed with:

```
AttributeError: type object 'Builder' has no attribute 'acosh'. Did you mean: 'acos'?
```

This PR replaces both calls with decompositions that use only existing MIL primitives (`mul`, `sub` / `add`, `sqrt`, `log`):

- `acosh(x) = log(x + sqrt(x^2 - 1))`   (valid on `x >= 1`)
- `asinh(x) = log(x + sqrt(x^2 + 1))`   (valid on all reals)

This follows the same in-place decomposition style already used for other compound ops in `ops.py` (e.g. `mish`, `atan2`).

## Tests

- `asinh` added to the existing parametrized lists in `TestElementWiseUnary.test_elementwise_no_params` and `TestTorchTensor.test_torch_rank0_tensor`; the default `rand_range=(-1.0, 1.0)` is safely inside `asinh`'s domain.
- New dedicated `TestElementWiseUnary.test_acosh` that passes inputs via `rand_range=(1.1, 5.0)`, since the default range would produce NaN inputs for `acosh` (domain `x >= 1`) and break the numeric comparison in `np.allclose`.

## Test plan

Because the Core ML runtime (`libcoremlpython`/`libmilstoragepython`) is macOS-only, I verified end-to-end on Linux for the code paths that work there:

- [x] `ct.convert` on tiny `torch.acosh` / `torch.asinh` models now runs all 96 default and 12 backend MIL passes without error (previously died in the torch frontend with the `AttributeError` above).
- [x] MIL programs produced match the intended decomposition exactly (`mul, sub, sqrt, add, log` for `acosh`; `mul, add, sqrt, add, log` for `asinh`).
- [x] Numerical accuracy of the decomposition vs PyTorch on random inputs: `acosh` bit-exact, `asinh` max abs error ~1.2e-7 (float32 round-off, well inside the test suite's default `atol=1e-4`).
- [x] `pytest -k "test_acosh or (test_elementwise_no_params and asinh) or (test_torch_rank0_tensor and asinh)"` on `neuralnetwork/fp32`: 3/3 pass.
- [x] Full `test_elementwise_no_params` parametrized class on `neuralnetwork/fp32`: 19/19 pass, no regressions from adding `"asinh"` to the list.
- [ ] `mlprogram/fp16` paths need to be exercised by upstream macOS CI (they fail locally on Linux with `RuntimeError: BlobWriter not loaded` for every `mlprogram` test, not just these — `libmilstoragepython.so` isn't built outside macOS).
