### PR TITLE
Re-encode linear_symmetric int8 weights as uint8 in constexpr_affine_dequantize

### DIFF
--- a/coremltools/optimize/_utils.py
+++ b/coremltools/optimize/_utils.py
@@ -738,9 +738,20 @@ def ios18_quant_params_to_ios16(quant_params: QuantParams) -> QuantParamsIos16:
 
     scale = quant_params.scale
     zero_point = quant_params.offset
-    if zero_point is None:
+    quantized_data = quant_params.data
+
+    if zero_point is None and quantized_data.dtype == np.int8:
+        # Symmetric signed-int quantization (offset=None) stores weights in [-127, 127] with
+        # zero_point=0.  The CoreML GPU/ANE runtime on some OS versions mishandles signed int8
+        # in constexpr_affine_dequantize.  Re-encode as unsigned uint8 [0, 254] with
+        # zero_point=127, which is mathematically identical:
+        #   (uint8 - 127) * scale  ==  int8 * scale
+        # This is safe because symmetric quantization clips to [-127, 127], never -128.
+        quantized_data = (quantized_data.astype(np.int32) + 127).astype(np.uint8)
+        zero_point = np.full(scale.shape, 127, dtype=np.uint8)
+    elif zero_point is None:
         # The constexpr_affine_dequantize op requires zero_point.
-        zero_point = np.zeros_like(scale).astype(quant_params.data.dtype)
+        zero_point = np.zeros_like(scale).astype(quantized_data.dtype)
 
     # The constexpr_affine_dequantize op requires scale and zero_point to have rank 0 or 1.
     if isinstance(scale, (np.ndarray, np.generic)):
@@ -749,7 +760,7 @@ def ios18_quant_params_to_ios16(quant_params: QuantParams) -> QuantParamsIos16:
         zero_point = np.squeeze(zero_point)
 
     return QuantParamsIos16(
-        quantized_data=quant_params.data, zero_point=zero_point, scale=scale, axis=np.int32(axis)
+        quantized_data=quantized_data, zero_point=zero_point, scale=scale, axis=np.int32(axis)
     )
 
 

--- a/coremltools/test/optimize/coreml/test_post_training_quantization.py
+++ b/coremltools/test/optimize/coreml/test_post_training_quantization.py
@@ -293,7 +293,9 @@ class TestLinearQuantizeWeights:
         assert get_op_types_in_program(prog) == expected_ops
         assert prog.find_ops(op_type="conv")[1].weight.op.op_type == "const"
 
-        expected_dtype = [np.int8, np.uint8, np.uint8, np.uint8, np.uint8]
+        # linear_symmetric int8 is re-encoded as uint8 (zero_point=127) for GPU/ANE compatibility
+        # (rdar://121298675); all remaining ops use uint8 natively.
+        expected_dtype = [np.uint8, np.uint8, np.uint8, np.uint8, np.uint8]
         affine_ops = prog.find_ops(op_type="constexpr_affine_dequantize")
         for dtype, op in zip(expected_dtype, affine_ops):
             assert op.quantized_data.val.dtype == dtype
@@ -318,6 +320,36 @@ class TestLinearQuantizeWeights:
 
         quanitze_op = mlmodel_quantized._mil_program.functions["main"].find_ops(op_type="constexpr_affine_dequantize")[0]
         assert model.weight.detach().numpy().shape == quanitze_op.quantized_data.shape
+
+        verify_model_outputs(mlmodel, mlmodel_quantized, coreml_input_values)
+
+    def test_linear_symmetric_int8_uses_uint8_encoding(self):
+        """
+        Verify that linear_symmetric with int8 dtype re-encodes to uint8 with zero_point=127
+        (rdar://121298675). The CoreML GPU/ANE backend may mishandle signed int8 in
+        constexpr_affine_dequantize. uint8[0,254]+zp=127 is mathematically identical to int8[-127,127]+zp=0.
+        """
+        model, inputs, torch_input_values, coreml_input_values = get_test_model_and_data()
+        torchmodel = torch.jit.trace(model, torch_input_values)
+        mlmodel = ct.convert(torchmodel, inputs=inputs, convert_to="mlprogram")
+
+        mlmodel_quantized = linear_quantize_weights(mlmodel, mode="linear_symmetric", dtype=np.int8)
+
+        quant_op = mlmodel_quantized._mil_program.functions["main"].find_ops(
+            op_type="constexpr_affine_dequantize"
+        )[0]
+
+        # Quantized data must be uint8 (not int8) after the re-encoding
+        assert quant_op.quantized_data.val.dtype == np.uint8, (
+            "linear_symmetric int8 must be re-encoded as uint8 for GPU/ANE compatibility"
+        )
+        # zero_point must be 127 (the uint8 symmetric midpoint)
+        assert np.all(quant_op.zero_point.val == 127), (
+            "zero_point must be 127 for the re-encoded uint8 symmetric quantization"
+        )
+        # All quantized values must be in the valid uint8 symmetric range [0, 254]
+        assert np.all(quant_op.quantized_data.val >= 0)
+        assert np.all(quant_op.quantized_data.val <= 254)
 
         verify_model_outputs(mlmodel, mlmodel_quantized, coreml_input_values)
 


### PR DESCRIPTION
  # Re-encode linear_symmetric int8 weights as uint8 in constexpr_affine_dequantize

  ## Summary

  `linear_quantize_weights(mode="linear_symmetric")` with default `int8` dtype produces a `constexpr_affine_dequantize` op with signed
  int8 quantized data and `zero_point=0`. The CoreML GPU/ANE runtime may mishandle signed int8 in this op, causing wrong inference
  results when `compute_units=CPU_AND_GPU` or `CPU_AND_NE`.

  Re-encode symmetric int8 (`offset=None`) as uint8 with `zero_point=127` in `ios18_quant_params_to_ios16`. This is mathematically
  identical — `(uint8-127)*scale == int8*scale` — but uses unsigned representation that the GPU/ANE runtime handles correctly.

  The re-encoding is safe because symmetric quantization clips to `[-127, 127]`, never `-128`, so `int8 + 127` always fits in `[0,
  254]`.

  ## Testing

  Added `test_linear_symmetric_int8_uses_uint8_encoding`: verifies that `constexpr_affine_dequantize` ops produced by
  `linear_quantize_weights(mode="linear_symmetric", dtype=np.int8)` use `uint8` quantized data with `zero_point=127`, and that the model
   output is numerically correct.

  Updated `test_linear_quantization` expected dtype from `np.int8` to `np.uint8` for the `linear_symmetric` conv op.

  Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>