### PR TITLE
Fix rename_feature skipping layer outputs when rename_inputs=False

### DIFF
--- a/coremltools/models/utils.py
+++ b/coremltools/models/utils.py
@@ -674,10 +674,10 @@ def rename_feature(
                 for index, name in enumerate(layer.input):
                     if name == current_name:
                         layer.input[index] = new_name
-                if rename_outputs:
-                    for index, name in enumerate(layer.output):
-                        if name == current_name:
-                            layer.output[index] = new_name
+            if rename_outputs:
+                for index, name in enumerate(layer.output):
+                    if name == current_name:
+                        layer.output[index] = new_name
 
         if rename_inputs:
             for preprocess_params in nn.preprocessing:

--- a/coremltools/test/neural_network/test_model.py
+++ b/coremltools/test/neural_network/test_model.py
@@ -186,6 +186,23 @@ class MLModelTest(unittest.TestCase):
         self.assertIsNotNone(preds)
         self.assertEqual(preds["output"], 3.1)
 
+    def test_rename_output_neural_network(self):
+        input_features = [("data", datatypes.Array(3))]
+        output_features = [("output", datatypes.Array(3))]
+        builder = NeuralNetworkBuilder(input_features, output_features)
+        builder.add_activation(
+            name="relu",
+            non_linearity="RELU",
+            input_name="data",
+            output_name="output",
+        )
+        spec = builder.spec
+        rename_feature(
+            spec, "output", "renamed_output", rename_inputs=False, rename_outputs=True
+        )
+        self.assertEqual(spec.description.output[0].name, "renamed_output")
+        self.assertEqual(spec.neuralNetwork.layers[0].output[0], "renamed_output")
+
     @unittest.skipUnless(
         _is_macos() and _macos_version() >= (10, 13), "Only supported on macOS 10.13+"
     )


### PR DESCRIPTION
`rename_feature(..., rename_inputs=False, rename_outputs=True)` on a `neuralNetwork` spec renames `description.output` but leaves the producing layer's `output` field unchanged. The model then fails to compile with "Interface specifies output X which is not produced by any layer in the neural network".

The `if rename_outputs:` branch sat inside `if rename_inputs:`, so the layer-output rename only ran when both flags were true. The fix moves the branch out one level so the two flags become independent.

Added `test_rename_output_neural_network`. `test_rename_output` next to it uses a `glmRegressor` spec, which never reaches the per-layer loop.

Fixes #2494
