### PR TITLE
Add normalize_affine_dequantize_int8 pass to fix GPU inference for pregenerated linear_symmetric models

### DIFF
--- a/coremltools/converters/mil/mil/passes/defs/optimize_quantization.py
+++ b/coremltools/converters/mil/mil/passes/defs/optimize_quantization.py
@@ -1243,3 +1243,76 @@ class canonicalize_quantized_lut_pattern(AbstractGraphPass):
             force_replace=True,  # Need to force replace because it involves replacing constexpr op.
         )
         block.remove_ops([old_op1, old_op2])
+
+
+@register_pass(namespace="common")
+class normalize_affine_dequantize_int8(AbstractGraphPass):
+    """
+    Converts ``constexpr_affine_dequantize`` ops that use signed int8 quantized_data
+    with zero_point=0 (symmetric int8 quantization) to an equivalent uint8 encoding
+    with zero_point=127.  The two encodings are mathematically identical for the
+    symmetric range [-127, 127]:
+
+    .. sourcecode:: python
+
+        (int8_val - 0) * scale == (uint8_val - 127) * scale
+        where uint8_val = int8_val + 127
+
+    The CoreML GPU/ANE runtime mishandles signed int8 in ``constexpr_affine_dequantize``
+    (rdar://121298675, rdar://158618073), producing incorrect inference results when GPU or Neural Engine
+    compute units are used.  Re-encoding as uint8+127 avoids the issue.  This pass was added to fix
+    pregenerated models that already contain the int8+zp=0 encoding (rdar://158618073).
+
+    Only applies when:
+    - ``quantized_data`` dtype is int8
+    - ``zero_point`` is a broadcast-zero tensor (scalar or vector of all zeros)
+    - data values are in [-127, 127] (symmetric range; value -128 cannot be losslessly
+      converted and causes the pass to skip that op)
+    """
+
+    def apply(self, prog):
+        for f in prog.functions.values():
+            self._apply_block(f)
+
+    @block_context_manager
+    def _apply_block(self, block: Block):
+        for op in list(block.operations):
+            if op.enclosing_block is None:
+                continue
+            for b in op.blocks:
+                self._apply_block(b)
+            self._try_transform(op, block)
+
+    @staticmethod
+    def _try_transform(op: Operation, block: Block) -> bool:
+        if op.op_type != "constexpr_affine_dequantize":
+            return False
+        if op.quantized_data.dtype != types.int8:
+            return False
+        zp = op.zero_point.val
+        if not np.all(zp == 0):
+            return False
+        int8_data = op.quantized_data.val
+        # Value -128 cannot be losslessly re-encoded as uint8+127 (-128+127 = -1, wraps
+        # to 255).  True symmetric int8 quantization clips to [-127, 127] and never
+        # produces -128, so bail out if it is present to stay conservative.
+        if np.any(int8_data == np.int8(-128)):
+            return False
+        uint8_data = (int8_data.astype(np.int32) + 127).astype(np.uint8)
+        new_zp = np.full(zp.shape, 127, dtype=np.uint8)
+        new_var = mb.constexpr_affine_dequantize(
+            quantized_data=uint8_data,
+            zero_point=new_zp,
+            scale=op.scale,
+            axis=op.axis,
+            name=op.outputs[0].name,
+            before_op=op,
+        )
+        block.replace_uses_of_var_after_op(
+            anchor_op=op,
+            old_var=op.outputs[0],
+            new_var=new_var,
+            force_replace=True,
+        )
+        block.remove_ops([op])
+        return True

--- a/coremltools/converters/mil/mil/passes/pass_pipeline.py
+++ b/coremltools/converters/mil/mil/passes/pass_pipeline.py
@@ -30,6 +30,7 @@ _COMMON_PASSES: List[Text] = [
     # always start quantization passes with canonicalizations
     "common::int_op_canonicalization",  # ops that support int do not need dequantize -> op -> quantize sandwich
     "common::nullify_redundant_quantization_zero_point",  # canonicalize zero point
+    "common::normalize_affine_dequantize_int8",  # re-encode int8+zp=0 as uint8+zp=127 for GPU correctness (rdar://121298675, rdar://158618073)
     # quantization pass 2: remove redundancy
     # remove redundancy after canonicalization but before anything else
     "common::dequantize_quantize_pair_elimination",
@@ -191,6 +192,7 @@ _FRONTEND_TF2_PASSES: List[Text] = [
 ]
 
 _BACKEND_MIL_PASSES: List[Text] = [
+    "common::normalize_affine_dequantize_int8",  # re-encode int8+zp=0 as uint8+zp=127 before any other backend pass; also in _COMMON_PASSES to catch ops from new conversions
     "common::const_elimination",
     "mil_backend::adjust_io_to_supported_types",
     "mil_backend::insert_image_preprocessing_ops",

--- a/coremltools/converters/mil/mil/passes/tests/test_quantization_passes.py
+++ b/coremltools/converters/mil/mil/passes/tests/test_quantization_passes.py
@@ -3104,3 +3104,106 @@ class TestInt32CastToInt16:
                 assert cast_op.dtype.val == "int16"
                 assert cast_op.outputs[0] == prog["main"].find_ops(op_type="gather")[0].indices
         assert get_op_types_in_program(prog) == expected_ops
+
+
+class TestNormalizeAffineDequantizeInt8:
+    """Tests for common::normalize_affine_dequantize_int8 pass."""
+
+    def _make_prog_int8_zp0(self, quantized_data, scale, zero_point, axis=0):
+        @mb.program(input_specs=[], opset_version=ct.target.iOS16)
+        def prog():
+            return mb.constexpr_affine_dequantize(
+                quantized_data=quantized_data,
+                zero_point=zero_point,
+                scale=scale,
+                axis=np.int32(axis),
+            )
+
+        return prog
+
+    def test_int8_zp0_transforms_to_uint8_zp127(self):
+        """int8 quantized_data with zero_point=0 is re-encoded as uint8+127."""
+        quantized_data = np.array([-127, -64, 0, 64, 127], dtype=np.int8)
+        scale = np.float16(0.5)
+        zero_point = np.int8(0)
+
+        prog = self._make_prog_int8_zp0(quantized_data, scale, zero_point)
+        apply_pass_and_basic_check(prog, "common::normalize_affine_dequantize_int8")
+
+        assert get_op_types_in_program(prog) == ["constexpr_affine_dequantize"]
+        op = prog.find_ops(op_type="constexpr_affine_dequantize", exactly_one=True)[0]
+
+        assert op.quantized_data.dtype == types.uint8
+        expected_uint8 = (quantized_data.astype(np.int32) + 127).astype(np.uint8)
+        np.testing.assert_array_equal(op.quantized_data.val, expected_uint8)
+
+        assert op.zero_point.dtype == types.uint8
+        np.testing.assert_array_equal(op.zero_point.val, np.full(zero_point.shape, 127, dtype=np.uint8))
+
+        # Output values must be numerically identical before and after
+        original_output = quantized_data.astype(np.float32) * float(scale)
+        new_output = (op.quantized_data.val.astype(np.int32) - int(op.zero_point.val)) * float(scale)
+        np.testing.assert_allclose(original_output, new_output, rtol=1e-5)
+
+    def test_channel_wise_int8_zp0_transforms(self):
+        """Channel-wise int8+zp=0 is also re-encoded."""
+        SHAPE = (4, 8)
+        quantized_data = np.random.randint(-127, 128, SHAPE, dtype=np.int8)
+        scale = np.random.rand(SHAPE[0]).astype(np.float16)
+        zero_point = np.zeros(SHAPE[0], dtype=np.int8)
+
+        prog = self._make_prog_int8_zp0(quantized_data, scale, zero_point, axis=0)
+        apply_pass_and_basic_check(prog, "common::normalize_affine_dequantize_int8")
+
+        op = prog.find_ops(op_type="constexpr_affine_dequantize", exactly_one=True)[0]
+        assert op.quantized_data.dtype == types.uint8
+        assert op.zero_point.dtype == types.uint8
+        np.testing.assert_array_equal(op.zero_point.val, np.full(zero_point.shape, 127, dtype=np.uint8))
+
+    def test_nonzero_zp_not_transformed(self):
+        """int8 with non-zero zero_point is left unchanged."""
+        quantized_data = np.array([-64, 0, 64], dtype=np.int8)
+        scale = np.float16(1.0)
+        zero_point = np.int8(5)  # non-zero
+
+        prog = self._make_prog_int8_zp0(quantized_data, scale, zero_point)
+        apply_pass_and_basic_check(prog, "common::normalize_affine_dequantize_int8")
+
+        op = prog.find_ops(op_type="constexpr_affine_dequantize", exactly_one=True)[0]
+        assert op.quantized_data.dtype == types.int8
+        assert op.zero_point.dtype == types.int8
+        assert int(op.zero_point.val) == 5
+
+    def test_uint8_not_transformed(self):
+        """uint8 quantized_data is left unchanged (already correct encoding)."""
+        quantized_data = np.array([0, 64, 127, 200, 254], dtype=np.uint8)
+        scale = np.float16(0.5)
+        zero_point = np.uint8(127)
+
+        @mb.program(input_specs=[], opset_version=ct.target.iOS16)
+        def prog():
+            return mb.constexpr_affine_dequantize(
+                quantized_data=quantized_data,
+                zero_point=zero_point,
+                scale=scale,
+                axis=np.int32(0),
+            )
+
+        apply_pass_and_basic_check(prog, "common::normalize_affine_dequantize_int8")
+        op = prog.find_ops(op_type="constexpr_affine_dequantize", exactly_one=True)[0]
+        assert op.quantized_data.dtype == types.uint8
+        np.testing.assert_array_equal(op.quantized_data.val, quantized_data)
+
+    def test_int8_with_minus128_not_transformed(self):
+        """int8 data containing -128 is skipped (cannot re-encode losslessly)."""
+        quantized_data = np.array([-128, -64, 0, 64, 127], dtype=np.int8)
+        scale = np.float16(0.5)
+        zero_point = np.int8(0)
+
+        prog = self._make_prog_int8_zp0(quantized_data, scale, zero_point)
+        apply_pass_and_basic_check(prog, "common::normalize_affine_dequantize_int8")
+
+        op = prog.find_ops(op_type="constexpr_affine_dequantize", exactly_one=True)[0]
+        # Transformation skipped: dtype and zero_point must remain unchanged
+        assert op.quantized_data.dtype == types.int8
+        assert int(op.zero_point.val) == 0


### PR DESCRIPTION
  # Add normalize_affine_dequantize_int8 pass to fix GPU inference for pregenerated linear_symmetric models

  Pregenerated mlpackages quantized with `linear_quantize_weights(mode="linear_symmetric")` contain
  `constexpr_affine_dequantize(int8, zero_point=0)` ops. The CoreML GPU/ANE runtime mishandles
  signed int8 in this op, producing incorrect inference results on
  CPU_AND_GPU/CPU_AND_NE compute units. Another PR addressed model *creation* via
  `ios18_quant_params_to_ios16`; this PR addresses *pregenerated* models that already contain the
  int8+zp=0 encoding.

  The new pass `normalize_affine_dequantize_int8` converts:
  - `constexpr_affine_dequantize(int8_data, zero_point=0)` → `constexpr_affine_dequantize(uint8_data, zero_point=127)`

  where `uint8_data = int8_data + 127`. The two encodings are mathematically identical for the
  symmetric range [-127, 127]: `(int8 - 0) * scale == (uint8 - 127) * scale`. The pass skips
  any op containing value -128 (cannot re-encode losslessly; true symmetric quantization never
  produces -128).

  The pass is added to both `_COMMON_PASSES` (for new conversions) and `_BACKEND_MIL_PASSES`
  (so it applies when users call any `ct.optimize.coreml` function on pregenerated models via
  `_apply_graph_pass`).

  ## Testing

  Testing: Added `TestNormalizeAffineDequantizeInt8` with 5 tests:
  - `test_int8_zp0_transforms_to_uint8_zp127` — verifies conversion and numerical equivalence
  - `test_channel_wise_int8_zp0_transforms` — verifies channel-wise case
  - `test_nonzero_zp_not_transformed` — guards against false positives
  - `test_uint8_not_transformed` — uint8 encoding left unchanged
  - `test_int8_with_minus128_not_transformed` — -128 safety guard

  ## Co-Authored-By

  Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>