### PR TITLE
Fix `ImageType` handling in `_gen_random_feature_value`

### DIFF
--- a/coremltools/models/ml_program/experimental/perf_utils.py
+++ b/coremltools/models/ml_program/experimental/perf_utils.py
@@ -119,7 +119,7 @@ def _gen_random_feature_value(
     elif feature_type == "multiArrayType":
         return _gen_random_multiarray_value(type=type.multiArrayType)
 
-    elif type == "imageType":
+    elif feature_type == "imageType":
         return _gen_random_image_value(type=type.imageType)
 
     else:


### PR DESCRIPTION
Fixes #2678

Fixes a bug in `MLModelBenchmarker` where models with `ImageType` inputs fail during benchmarking due to incorrect feature type detection.