### PR TITLE
Cast int input to fp32 in torch reciprocal converter

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -7323,7 +7323,14 @@ def floor(context, node):
 @register_torch_op
 def reciprocal(context, node):
     inputs = _get_inputs(context, node, expected=1)
-    context.add(mb.inverse(x=inputs[0], name=node.name))
+    x = inputs[0]
+    # PyTorch's reciprocal promotes int inputs to float; mb.inverse only
+    # accepts fp16/fp32. Without this cast, common patterns like
+    # `1 / x.shape[0]` (which TorchScript traces as
+    # reciprocal(prim::NumToTensor(int))) fail to convert.
+    if types.is_int(x.dtype):
+        x = mb.cast(x=x, dtype="fp32")
+    context.add(mb.inverse(x=x, name=node.name))
 
 
 @register_torch_op

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -6676,6 +6676,35 @@ class TestActivation(TorchBaseTest):
         )
 
 
+class TestReciprocal(TorchBaseTest):
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend",
+        itertools.product(compute_units, backends, frontends),
+    )
+    def test_reciprocal_int_shape(self, compute_unit, backend, frontend):
+        # Regression test for #2579: TorchScript traces `16 / x.shape[0]`
+        # as reciprocal(int) -> mul(16), and reciprocal previously rejected
+        # the int input because mb.inverse only accepts fp16/fp32.
+        if frontend in TORCH_EXPORT_BASED_FRONTENDS:
+            pytest.skip("torch.export folds shape-derived constants")
+
+        class TestModel(nn.Module):
+            def forward(self, x):
+                return 16 / x.shape[0] * x
+
+        # mb.inverse uses hardware reciprocal with limited precision; loosen
+        # tolerance to accommodate fp16 backends.
+        self.run_compare_torch(
+            (2, 16, 11),
+            TestModel(),
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+            atol=1e-2,
+            rtol=1e-2,
+        )
+
+
 class TestElementWiseUnary(TorchBaseTest):
     @pytest.mark.parametrize(
         "compute_unit, backend, frontend, shape, op_string",


### PR DESCRIPTION
## Summary
- `torch.reciprocal` returns a float for int inputs in PyTorch, but `mb.inverse` only accepts fp16/fp32. Common patterns like `1 / x.shape[0]` (which TorchScript traces as `reciprocal(prim::NumToTensor(int))`) failed to convert with:

  > Op (op_type: inverse) Input x expects tensor or scalar of dtype from type domain ['fp16', 'fp32'] but got tensor[1, int32]

- Insert a fp32 cast before `mb.inverse` when the input dtype is integer, mirroring the pattern already used by `log`, `sqrt`, and other unary ops that share the same MIL constraint.

## Test plan
- [x] `pytest test_torch_ops.py::TestReciprocal::test_reciprocal_int_shape` — TorchScript path; the torch.export path folds the shape-derived constant and is skipped.
- [x] End-to-end mlpackage.predict on the issue repro produces 8.0 (within fp16 reciprocal precision). The same fix unblocks RoPE-style `1 / theta**(2i/d)` expressions, verified separately.

Fixes #2579.