### PR TITLE
Raise a clear error when a no-input model targets below iOS18

### DIFF
--- a/coremltools/converters/mil/converter.py
+++ b/coremltools/converters/mil/converter.py
@@ -8,6 +8,7 @@ import warnings as _warnings
 from typing import Optional, Text, Tuple
 
 import coremltools as ct
+from coremltools import _SPECIFICATION_VERSION_IOS_18, _logger as logger
 from coremltools.converters._profile_utils import _profile
 from coremltools.converters.mil import input_types
 from coremltools.converters.mil.mil import Builder as mb
@@ -302,6 +303,29 @@ def mil_convert_to_proto(
     PassPipelineManager.apply_pipeline(prog, backend_pipeline)
 
     prog._check_early_error_out_for_invalid_program()
+
+    # Models with no inputs require specification version >= iOS18; otherwise
+    # the resulting mlpackage fails to compile with
+    #   "Empty input is only valid in specification version >= 9".
+    # When the spec version was inferred from the default (i.e. user did not
+    # request an older target), bump it transparently. If the user explicitly
+    # requested a lower target, the existing `check_deployment_compatibility`
+    # at the entry point will surface the conflict.
+    spec_version = kwargs.get("specification_version")
+    if (
+        convert_to == "mlprogram"
+        and spec_version is not None
+        and spec_version < _SPECIFICATION_VERSION_IOS_18
+    ):
+        main_func = prog.functions.get(prog.default_function_name)
+        if main_func is not None and len(main_func.inputs) == 0:
+            logger.warning(
+                "Model has no inputs, which requires specification version "
+                ">= iOS18. Bumping specification version from %d to %d.",
+                spec_version,
+                _SPECIFICATION_VERSION_IOS_18,
+            )
+            kwargs["specification_version"] = _SPECIFICATION_VERSION_IOS_18
 
     backend_converter_type = converter_registry.backends.get(convert_to.lower())
     if not backend_converter_type:

--- a/coremltools/converters/mil/converter.py
+++ b/coremltools/converters/mil/converter.py
@@ -8,7 +8,7 @@ import warnings as _warnings
 from typing import Optional, Text, Tuple
 
 import coremltools as ct
-from coremltools import _SPECIFICATION_VERSION_IOS_18, _logger as logger
+from coremltools import _SPECIFICATION_VERSION_IOS_18
 from coremltools.converters._profile_utils import _profile
 from coremltools.converters.mil import input_types
 from coremltools.converters.mil.mil import Builder as mb
@@ -305,12 +305,10 @@ def mil_convert_to_proto(
     prog._check_early_error_out_for_invalid_program()
 
     # Models with no inputs require specification version >= iOS18; otherwise
-    # the resulting mlpackage fails to compile with
+    # the resulting mlpackage fails to compile downstream with
     #   "Empty input is only valid in specification version >= 9".
-    # When the spec version was inferred from the default (i.e. user did not
-    # request an older target), bump it transparently. If the user explicitly
-    # requested a lower target, the existing `check_deployment_compatibility`
-    # at the entry point will surface the conflict.
+    # Surface that as an explicit error here rather than letting the user
+    # discover it at compile time.
     spec_version = kwargs.get("specification_version")
     if (
         convert_to == "mlprogram"
@@ -319,13 +317,14 @@ def mil_convert_to_proto(
     ):
         main_func = prog.functions.get(prog.default_function_name)
         if main_func is not None and len(main_func.inputs) == 0:
-            logger.warning(
-                "Model has no inputs, which requires specification version "
-                ">= iOS18. Bumping specification version from %d to %d.",
-                spec_version,
-                _SPECIFICATION_VERSION_IOS_18,
+            raise ValueError(
+                "Model has no inputs, which requires a deployment target of "
+                "iOS18 / macOS15 or later (specification version "
+                f"{_SPECIFICATION_VERSION_IOS_18}); the requested target maps "
+                f"to specification version {spec_version}. Re-run "
+                "`ct.convert(...)` with "
+                "`minimum_deployment_target=ct.target.iOS18` (or a later target)."
             )
-            kwargs["specification_version"] = _SPECIFICATION_VERSION_IOS_18
 
     backend_converter_type = converter_registry.backends.get(convert_to.lower())
     if not backend_converter_type:

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_export_conversion_api.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_export_conversion_api.py
@@ -333,6 +333,25 @@ class TestTorchExportConversionAPI(TorchBaseTest):
         )
         assert mlmodel.user_defined_metadata[_METADATA_SOURCE_DIALECT] == dialect_name
 
+    @pytest.mark.parametrize("frontend", frontends)
+    def test_no_input_model_bumps_spec_version(self, frontend):
+        # Regression test for #2578: a model with no inputs requires
+        # specification version >= iOS18, so the converter should auto-bump
+        # the default target instead of producing an iOS15 mlpackage that
+        # fails to compile with "Empty input is only valid in specification
+        # version >= 9".
+        class Model(torch.nn.Module):
+            def forward(self):
+                return torch.ones(5, 5)
+
+        exported_model = export_torch_model_to_frontend(Model().eval(), (), frontend)
+
+        mlmodel = ct.convert(exported_model)
+        spec = mlmodel.get_spec()
+        assert len(spec.description.input) == 0
+        assert spec.specificationVersion >= ct.target.iOS18.value
+        verify_prediction(mlmodel)
+
 
 @pytest.mark.skipif((version_info.major, version_info.minor) == (3, 13), reason="rdar://158079341")
 class TestExecuTorchExamples(TorchBaseTest):

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_export_conversion_api.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_export_conversion_api.py
@@ -334,19 +334,25 @@ class TestTorchExportConversionAPI(TorchBaseTest):
         assert mlmodel.user_defined_metadata[_METADATA_SOURCE_DIALECT] == dialect_name
 
     @pytest.mark.parametrize("frontend", frontends)
-    def test_no_input_model_bumps_spec_version(self, frontend):
+    def test_no_input_model_requires_ios18(self, frontend):
         # Regression test for #2578: a model with no inputs requires
-        # specification version >= iOS18, so the converter should auto-bump
-        # the default target instead of producing an iOS15 mlpackage that
+        # specification version >= iOS18, otherwise the produced mlpackage
         # fails to compile with "Empty input is only valid in specification
-        # version >= 9".
+        # version >= 9". Verify both the happy path (iOS18 succeeds) and the
+        # error path (lower target raises a clear ValueError pointing the
+        # user at minimum_deployment_target).
         class Model(torch.nn.Module):
             def forward(self):
                 return torch.ones(5, 5)
 
         exported_model = export_torch_model_to_frontend(Model().eval(), (), frontend)
 
-        mlmodel = ct.convert(exported_model)
+        # Default target (iOS15) must fail with an actionable error message.
+        with pytest.raises(ValueError, match=r"minimum_deployment_target=ct\.target\.iOS18"):
+            ct.convert(exported_model)
+
+        # Explicit iOS18 target must succeed and produce a runnable mlpackage.
+        mlmodel = ct.convert(exported_model, minimum_deployment_target=ct.target.iOS18)
         spec = mlmodel.get_spec()
         assert len(spec.description.input) == 0
         assert spec.specificationVersion >= ct.target.iOS18.value


### PR DESCRIPTION
## Summary

A model with no inputs requires Core ML specification version ≥ 9 (iOS18 / macOS15). Below that, the produced mlpackage fails to compile at predict time with:

> validator error: Empty input is only valid in specification version >= 9. This model has version 6.

Per review feedback, rather than silently bumping the user's requested deployment target, surface the requirement at conversion time: when an `mlprogram` has no inputs and the requested target maps to a spec version below iOS18, raise a `ValueError` that names the requirement and points the user at `minimum_deployment_target=ct.target.iOS18`.

## Test plan
- [x] New test `TestTorchExportConversionAPI::test_no_input_model_requires_ios18` covers both paths: the default (iOS15) target raises the actionable `ValueError`, and an explicit `iOS18` target converts and predicts successfully.

Fixes #2578.
