### PR TITLE
Add Python 3.14 support to pip wheels

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,6 +39,11 @@ build_wheel_macos_py310:
   variables:
     PYTHON: "3.10"
 
+build_wheel_macos_py314:
+  <<: *build_macos
+  variables:
+    PYTHON: "3.14"
+
 
 #########################################################################
 ##
@@ -60,6 +65,16 @@ test_py310_coremltools_test:
     WHEEL_PATH: build/dist/*cp310*11*
     TEST_PACKAGE: coremltools.test
     PYTHON: "3.10"
+    REQUIREMENTS: reqs/test.pip
+
+test_py314_coremltools_test:
+  <<: *test_macos_pkg
+  dependencies:
+    - build_wheel_macos_py314
+  variables:
+    WHEEL_PATH: build/dist/*cp314*11*
+    TEST_PACKAGE: coremltools.test
+    PYTHON: "3.14"
     REQUIREMENTS: reqs/test.pip
 
 test_py310_pytorch_script:

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -19,7 +19,7 @@ Follow these steps:
 1. Fork and clone the GitHub [coremltools repository](https://github.com/apple/coremltools).
 
 2. Run the [build.sh](scripts/build.sh) script to build `coremltools`.
-	* By default this script uses Python 3.7, but you can include `--python=3.8` (or `3.9`, `3.10`, `3.11`, `3.12`, `3.13`) as a argument to change the Python version.
+	* By default this script uses Python 3.7, but you can include `--python=3.8` (or `3.9`, `3.10`, `3.11`, `3.12`, `3.13`, `3.14`) as a argument to change the Python version.
 	* The script creates a new `build` folder with the coremltools distribution, and a `dist` folder with Python wheel files.
 
 3. Run the [test.sh](scripts/test.sh) script to test the build.
@@ -45,7 +45,7 @@ The following build targets help you configure the development environment. If y
 * `test_slow` | Run all non-fast tests.
 * `wheel` | Build wheels in release mode.
 
-The script uses Python 3.7, but you can include `--python=3.8` (or `3.9`, `3.10`, `3.11`, `3.12`, `3.13`) as a argument to change the Python version.
+The script uses Python 3.7, but you can include `--python=3.8` (or `3.9`, `3.10`, `3.11`, `3.12`, `3.13`, `3.14`) as a argument to change the Python version.
 
 ## Resources
 

--- a/docs-guides/source/installing-coremltools.md
+++ b/docs-guides/source/installing-coremltools.md
@@ -4,7 +4,7 @@ This page describes how to install the [`coremltools`](https://github.com/apple/
 
 ```{admonition} Supported Python and MacOS Versions
 
-The current version of coremltools ([version 9.0b1](https://github.com/apple/coremltools)) includes wheels for Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13. The last stable release of coremltools to support Python 2 is version 4.0.
+The current version of coremltools ([version 9.0b1](https://github.com/apple/coremltools)) includes wheels for Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14. The last stable release of coremltools to support Python 2 is version 4.0.
 
 The supported MacOS versions are as follows:
 

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,7 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Topic :: Scientific/Engineering",
         "Topic :: Software Development",
     ],


### PR DESCRIPTION
 This PR enables Python 3.14 support by adding it to the build matrix and package metadata.
  
 As reported in #2695, the existing C++/Objective-C code is already compatible with 3.14, but the lack of a `cp314` wheel causes
`pip` to install a "pure Python" version missing critical native extensions.

Changes:
    - CI: Added build and test jobs for Python 3.14 to `.gitlab-ci.yml`.
    - Metadata: Added Python 3.14 classifier to `setup.py`.
    - Docs: Updated `BUILDING.md` and installation guides to include 3.14.
    
   Closes #2695