### PR TITLE
Fix build.sh num-procs help text

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -33,7 +33,7 @@ print_help() {
   echo
   echo "Usage: build.sh"
   echo
-  echo "  --num_procs=n (default 1)       Specify the number of processes to run in parallel."
+  echo "  --num-procs=n (default 1)       Specify the number of processes to run in parallel."
   echo "  --python=*                      Python to use for configuration."
   echo "  --protobuf                      Rebuild & overwrite the protocol buffers in MLModel."
   echo "  --debug                         Build without optimizations and stripping symbols."


### PR DESCRIPTION
## Summary

`scripts/build.sh --help` documents the option as `--num_procs`, but the argument parser only accepts `--num-procs` (see [`scripts/build.sh:53`](https://github.com/apple/coremltools/blob/main/scripts/build.sh#L53)). A user copy-pasting from `--help` hits the `unknown_option` branch and the script exits.

This corrects the documented spelling to match the accepted spelling. One-character change.

Refs [#2376](https://github.com/apple/coremltools/issues/2376) (build-script item 1).

## Test plan

- [x] `bash -n scripts/build.sh` — syntax OK
- [x] `bash scripts/build.sh --help` — now prints `--num-procs=n (default 1)`
- [x] `grep "num_procs\|num-procs" scripts/build.sh` — both lines now use `--num-procs`

## Scope

Intentionally narrow. This PR does not modernize CMake, change NumPy pins, refactor Python detection, or touch any other item from #2376 — those need separate discussion.