### PR TITLE
Fix _EfficientKMeans cluster reduction to use intra-cluster errors (fixes #2698)

### DIFF
--- a/coremltools/optimize/torch/palettization/_efficient_kmeans.py
+++ b/coremltools/optimize/torch/palettization/_efficient_kmeans.py
@@ -259,7 +259,7 @@ class _EfficientKMeans:
                     reduce_min_error, reduce_labels_ = _EfficientKMeans.x_c_dist(
                         X, reduce_cluster_centers_
                     ).min(dim=-1)
-                    reduce_inertia = reduce_cluster_centers_.sum()
+                    reduce_inertia = reduce_min_error.sum()
                     rmse_error = _torch.sqrt(reduce_inertia / N)
 
                     if rmse_error < self.error_bnd:

--- a/coremltools/test/optimize/torch/palettization/test_efficient_kmeans.py
+++ b/coremltools/test/optimize/torch/palettization/test_efficient_kmeans.py
@@ -1,0 +1,38 @@
+#  Copyright (c) 2026, Apple Inc. All rights reserved.
+#
+#  Use of this source code is governed by a BSD-3-clause license that can be
+#  found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+
+import torch
+
+from coremltools.optimize.torch.palettization._efficient_kmeans import _EfficientKMeans
+
+
+def test_efficient_kmeans_reduces_cluster_when_error_bnd_satisfied():
+    # Regression test for issue #2698.
+    #
+    # On all-negative data, the previous implementation computed `reduce_inertia`
+    # from the sum of the *cluster centers* (which can be negative), making the
+    # subsequent sqrt produce NaN and the `rmse_error < error_bnd` check fail
+    # silently. With the fix, `reduce_inertia` is the sum of per-point min
+    # distance errors, so the comparison behaves as documented and the cluster
+    # count is reduced from 3 to 2.
+    X = torch.tensor(
+        [[-1.0], [-1.1], [-0.9], [-10.0], [-10.1], [-9.9]], dtype=torch.float32
+    )
+    init_centers = torch.tensor(
+        [[-1.0], [-10.0], [-50.0]], dtype=torch.float32
+    )
+    labels = torch.tensor([0, 0, 0, 1, 1, 1], dtype=torch.int64)
+
+    kmeans = _EfficientKMeans(
+        n_clusters=3,
+        init=init_centers,
+        labels=labels,
+        max_iter=5,
+        tol=1e-4,
+        error_bnd=2.0,
+    )
+    kmeans.fit(X)
+
+    assert kmeans.n_clusters == 2


### PR DESCRIPTION
### Summary

`_EfficientKMeans.fit` reduces `n_clusters` when removing the smallest-population centroid still keeps the per-point RMSE under `error_bnd`. The candidate `reduce_inertia` was being computed from `reduce_cluster_centers_.sum()` (the sum of the remaining centroid coordinates), which is the wrong quantity:

- The comparison `reduce_inertia / N` is meant to be a mean squared error, but summing centroid coordinates produces a value with no consistent sign or magnitude relative to `error_bnd`.
- When the data pushes the centroid sum negative, `_torch.sqrt(negative / N)` silently produces `NaN`. `NaN < self.error_bnd` evaluates to `False`, so cluster reduction is skipped even when it should fire.

### Fix

Sum the per-point min distance errors instead, mirroring the pattern already used a few lines above for `cur_inertia`:

```python
cur_inertia    = min_error.sum()         # line 247 (unchanged)
reduce_inertia = reduce_min_error.sum()  # line 262 (this change)
```

This is the fix suggested by the reporter in #2698.

### Verification

Added `coremltools/test/optimize/torch/palettization/test_efficient_kmeans.py` covering the all-negative-data case from the issue. Without the patch the test fails with `assert 3 == 2`; with the patch it passes:

```
coremltools/test/optimize/torch/palettization/test_efficient_kmeans.py . [100%]
============================== 1 passed in 0.01s ===============================
```

### Issue

Fixes #2698