### PR TITLE
Lower multi-dimensional reflect/replicate pad at op conversion time

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -2378,6 +2378,63 @@ def view(context, node):
     context.add(view)
 
 
+def _lower_pad(x: Var, pad, mode: str, value: float, name: str) -> Var:
+    """
+    Build the ``mb.pad`` op(s) implementing a torch pad, decomposing when needed.
+
+    Core ML accepts ``reflect`` / ``replicate`` padding only when every non-zero pad
+    lies in the last two dimensions, while torch has no such restriction, e.g.
+    ``torch.nn.ReflectionPad3d`` / ``torch.nn.ReplicationPad3d`` pad three dimensions.
+    Both modes map each output index to an input index per axis independently, so
+    padding several axes at once is equivalent to padding them one after another. That
+    lets an unsupported pad be lowered as a sequence of supported ones, each moving the
+    axis it pads to the end. Without this, conversion succeeds but the resulting model
+    fails to load with
+    "Padding for more than two dimensions only supports `constant` mode".
+    """
+
+    def _pad(x: Var, pad, is_last: bool) -> Var:
+        kwargs = {"name": name} if is_last else {}
+        return mb.pad(x=x, pad=pad, mode=mode, constant_val=value, **kwargs)
+
+    if mode not in ("reflect", "replicate") or not isinstance(pad, list):
+        return _pad(x, pad, True)
+
+    # ``pad`` describes the last ``len(pad) // 2`` dimensions of ``x``
+    offset = x.rank - len(pad) // 2
+
+    def _pad_of(axis: int) -> List[int]:
+        return pad[2 * (axis - offset) : 2 * (axis - offset) + 2]
+
+    padded_axes = [axis for axis in range(offset, x.rank) if any(_pad_of(axis))]
+    leading_axes = [axis for axis in padded_axes if axis < x.rank - 2]
+    if not leading_axes:
+        return _pad(x, pad, True)
+
+    # Pad the last two dimensions in one op, then each remaining axis on its own,
+    # transposed to the end so that Core ML sees a last-dimension-only pad.
+    steps = []
+    if any(axis >= x.rank - 2 for axis in padded_axes):
+        trailing_pad = [0] * len(pad)
+        trailing_pad[-4:] = pad[-4:]
+        steps.append((None, trailing_pad))
+    for axis in leading_axes:
+        steps.append(([i for i in range(x.rank) if i != axis] + [axis], _pad_of(axis)))
+
+    res = x
+    for step_index, (perm, step_pad) in enumerate(steps):
+        is_last = step_index == len(steps) - 1
+        if perm is None:
+            res = _pad(res, step_pad, is_last)
+        else:
+            inverse_perm = [perm.index(axis) for axis in range(x.rank)]
+            res = mb.transpose(x=res, perm=perm)
+            res = _pad(res, step_pad, False)
+            kwargs = {"name": name} if is_last else {}
+            res = mb.transpose(x=res, perm=inverse_perm, **kwargs)
+    return res
+
+
 @register_torch_op(torch_alias=["constant_pad_nd"])
 def pad(context, node):
     def _parse_positional_args(context, node) -> Tuple[Var]:
@@ -2493,13 +2550,13 @@ def pad(context, node):
 
     if types.is_complex(x.dtype):
         real, imag = (
-            mb.pad(x=x, pad=pad, mode=mode, constant_val=value, name=node.name)
+            _lower_pad(x, pad, mode, value, node.name)
             for x in (mb.complex_real(data=x), mb.complex_imag(data=x))
         )
         res = mb.complex(real_data=real, imag_data=imag, name=node.name)
     else:
         x, value = promote_input_dtypes([x, value])
-        res = mb.pad(x=x, pad=pad, mode=mode, constant_val=value, name=node.name)
+        res = _lower_pad(x, pad, mode, value, node.name)
     context.add(res)
 
 

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -11432,7 +11432,7 @@ class TestPad(TorchBaseTest):
     @pytest.mark.parametrize(
         "compute_unit, backend, frontend, rank, mode",
         itertools.product(
-            compute_units, backends, frontends, range(3, 5), ["reflect", "replicate"]
+            compute_units, backends, frontends, range(3, 6), ["reflect", "replicate"]
         ),
     )
     def test_pad_reflect_replicate(self, compute_unit, backend, frontend, rank: int, mode: str):
@@ -11448,13 +11448,55 @@ class TestPad(TorchBaseTest):
         elif rank == 4:
             pad_len = 4
             input_shape = (10, 5, 5, 10)
+        elif rank == 5:
+            pad_len = 6
+            input_shape = (2, 3, 5, 5, 10)
         else:
             raise NotImplementedError(
-                "Only 3D, 4D padding with non-constant padding are supported for now"
+                "Only 3D, 4D, 5D padding with non-constant padding are supported for now"
             )
         max_pad = min(input_shape[-1], input_shape[-2])
         pad = list(np.random.randint(low=0, high=max_pad, size=pad_len))
         model = ModuleWrapper(function=torch.nn.functional.pad, kwargs={"pad": pad, "mode": mode})
+        self.run_compare_torch(
+            input_shape, model, backend=backend, compute_unit=compute_unit, frontend=frontend
+        )
+
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend, torch_module, padding",
+        itertools.product(
+            compute_units,
+            backends,
+            frontends,
+            [torch.nn.ReflectionPad3d, torch.nn.ReplicationPad3d],
+            [2, (1, 2, 1, 2, 1, 2)],
+        ),
+    )
+    def test_pad_reflect_replicate_3d(
+        self, compute_unit, backend, frontend, torch_module, padding
+    ):
+        # Regression test for issues #2571 and #2576: these pad three dimensions, which
+        # Core ML supports only in "constant" mode, so the converted model used to fail
+        # to load with "Padding for more than two dimensions only supports `constant`
+        # mode".
+        input_shape = (1, 3, 5, 6, 7)
+        model = torch_module(padding).eval()
+        self.run_compare_torch(
+            input_shape, model, backend=backend, compute_unit=compute_unit, frontend=frontend
+        )
+
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend, mode",
+        itertools.product(compute_units, backends, frontends, ["reflect", "replicate"]),
+    )
+    def test_pad_reflect_replicate_leading_dims(self, compute_unit, backend, frontend, mode):
+        # Two padded dimensions, but neither of them is one of the last two: Core ML
+        # requires all non-zero non-constant padding to be in the last two dimensions.
+        input_shape = (3, 4, 5, 6)
+        model = ModuleWrapper(
+            function=torch.nn.functional.pad,
+            kwargs={"pad": [0, 0, 1, 2, 2, 1], "mode": mode},
+        )
         self.run_compare_torch(
             input_shape, model, backend=backend, compute_unit=compute_unit, frontend=frontend
         )


### PR DESCRIPTION
### Problem

`reflect` and `replicate` padding fail to convert when padding is applied outside the last two dimensions. The Core ML runtime rejects the resulting op:

```
Error: Unable to parse ML Program: in operation op_11_cast_fp16:
Padding for more than two dimensions only supports `constant` mode
```

The restriction is often described as "at most two padded dimensions", but that is not what the runtime enforces. Enumerated against a rank-5 input (identical for `reflect` and `replicate`):

| pad | padded axes | result |
|---|---|---|
| `[0,0, 0,0, 0,0, 0,0, 1,1]` | 4 | OK |
| `[0,0, 0,0, 0,0, 1,1, 1,1]` | 3, 4 | OK |
| `[0,0, 0,0, 1,1, 0,0, 0,0]` | 2 | rejected |
| `[0,0, 0,0, 1,1, 1,1, 0,0]` | 2, 3 | rejected |
| `[0,0, 1,1, 0,0, 0,0, 0,0]` | 1 | rejected |

The actual rule is **all non-zero non-constant padding must be in the last two dimensions**. So a rank-4 `F.pad(x, (0,0,1,2,2,1), mode="replicate")` pads only two axes and is still rejected.

### Fix

Lowered at op conversion time in the torch `pad` converter, per @TobyRoseman's question on #2697.

`reflect` and `replicate` map each output index to an input index one axis at a time, so a multi-axis pad is exactly a sequence of single-axis pads. The converter pads the last two dimensions first, then each remaining axis individually with that axis transposed to the end — so Core ML only ever sees non-constant padding on the final dimension.

No new pass and no pipeline ordering to reason about, and nothing merges the chain back because the emitted pads are never adjacent. Constant mode, dynamic pad values, and already-legal pads emit byte-identical output.

### Testing

Same tests against `main` and against this branch, both backends, both frontends:

```
main        : 28 failed, 8 passed, 12 skipped
this branch : 36 passed, 12 skipped
full TestPad: 58 passed, 22 skipped
MIL pass tests (-k pad): 215 passed
```

Coverage added: `test_pad_reflect_replicate` extended to rank 5 (no `neuralnetwork` skip needed), `test_pad_reflect_replicate_3d` for `ReflectionPad3d`/`ReplicationPad3d` symmetric and asymmetric, and `test_pad_reflect_replicate_leading_dims` for the two-leading-axes case.

Numerics verified against eager PyTorch on `mlprogram` fp32 and `neuralnetwork`.