### PR TITLE
Fix view operation to handle single-element variable shapes

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -2339,10 +2339,17 @@ def view(context, node):
         shape = mb.list_gather(ls=shape, indices=indices)
 
     if isinstance(shape, list) and all(
-        [isinstance(dim, Var) and len(dim.shape) == 0 for dim in shape]
+        [
+            isinstance(dim, Var)
+            and (len(dim.shape) == 0 or (len(dim.shape) == 1 and dim.shape[0] == 1))
+            for dim in shape
+        ]
     ):
         int_shape = []
         for size in shape:
+            if len(size.shape) == 1 and size.shape[0] == 1:
+                size = mb.squeeze(x=size)
+
             if size.dtype == types.int32:
                 int_size = size
             else:

--- a/coremltools/converters/mil/frontend/torch/test/test_internal_graph.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_internal_graph.py
@@ -904,6 +904,19 @@ class TestTorchOps:
         expected_result = test_input.view(shape)
         assert np.allclose(expected_result, ssa.val)
 
+    def test_view_shape_list_with_single_element_var(self, context):
+        graph_inputs = {"input": mb.placeholder(shape=(2, 3), dtype=types.float)}
+        view_node = InternalTorchIRNode(kind="view", inputs=["input", "shape"], outputs=["output"])
+
+        with Function(inputs=graph_inputs) as ssa_func:
+            context.add(ssa_func.inputs["input"])
+            dim0 = mb.const(val=np.array([2], dtype=np.int64))
+            dim1 = mb.const(val=np.array(3, dtype=np.int64))
+            context.add([dim0, dim1], torch_name="shape")
+            ops.view(context, view_node)
+
+        assert context["output"].shape == (2, 3)
+
     @pytest.mark.parametrize(
         "input_shape, output_shape",
         itertools.product(


### PR DESCRIPTION
## Summary

Fix the PyTorch frontend `view` / `reshape` converter when the target shape is represented as a list of MIL Vars and one of the dimensions is a rank-1 single-element Var.

This came up in RFDETR vision to coreml export [HERE](https://github.com/landchenxuan/rf-detr-to-coreml/blob/c6831da8c83a6b11ca2ca3010e221d333c3ebb72/rfdetr_coreml/coreml_fixes.py#L58)

## Details

The converter already handled shape lists when every dimension Var was scalar. Some PyTorch graphs can carry scalar-like shape dimensions as tensors with shape `(1,)`. In that case, the converter skipped the list-to-shape-tensor path and later tried to cast the Python list of Vars directly, producing a conversion error.

This change treats rank-1 single-element dimension Vars as scalar-like by squeezing them before casting and concatenating the shape list.

## Test

Added a regression test covering a `view` node whose shape list contains a rank-1 single-element dimension Var.
