### PR TITLE
Fix torch.randint generating values equal to the upper bound (#2568)

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -5654,7 +5654,14 @@ def randint(context, node):
 
     low, high, shape = _parse_positional_args(context, node)
     rand_uniform = mb.random_uniform(shape=shape, low=low, high=high)
-    rand_int = mb.cast(x=rand_uniform, dtype="int32", name=node.name)
+    # torch.randint yields integers in [low, high) — the upper bound is exclusive.
+    # mb.random_uniform's upper bound is inclusive, so cast-to-int can yield
+    # exactly `high`. Clamp the result to `high - 1` to match torch's semantics
+    # (issue #2568).
+    rand_int_unclipped = mb.cast(x=rand_uniform, dtype="int32")
+    high_int = mb.cast(x=high, dtype="int32")
+    high_minus_one = mb.sub(x=high_int, y=1)
+    rand_int = mb.minimum(x=rand_int_unclipped, y=high_minus_one, name=node.name)
     context.add(rand_int)
 
 @register_torch_op

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -4748,6 +4748,51 @@ class TestRandint(TorchBaseTest):
         inputs = [ct.TensorType(shape=x.shape)] if frontend == TorchFrontend.TORCHSCRIPT else None
         ct.convert(torch_model, inputs=inputs)
 
+    @pytest.mark.parametrize("frontend", frontends)
+    def test_upper_bound_is_exclusive(self, frontend):
+        # Regression test for issue #2568. torch.randint produces integers in
+        # [low, high) — the upper bound is exclusive. mb.random_uniform's upper
+        # bound is inclusive, so cast-to-int can yield exactly `high` unless we
+        # clamp. Ensure the lowering inserts a clamp op so the converted graph
+        # cannot produce values >= `high`.
+        if frontend == TorchFrontend.EXECUTORCH:
+            pytest.skip("torch._ops.aten.randint.low is not Aten Canonical")
+
+        class TestModel(nn.Module):
+            def forward(self, x):
+                return torch.randint(0, 100, (1000, 100), dtype=torch.int64) + x
+
+        model = TestModel().eval()
+        x = torch.zeros((1000, 100), dtype=torch.int64)
+        torch_model = export_torch_model_to_frontend(model, (x,), frontend)
+        inputs = (
+            [ct.TensorType(shape=x.shape, dtype=np.int32)]
+            if frontend == TorchFrontend.TORCHSCRIPT
+            else None
+        )
+        mlmodel = ct.convert(torch_model, inputs=inputs)
+
+        # Structural assertion: the lowering must wire a `minimum` clamp into
+        # the path between `random_uniform` and the model output. Walk the MIL
+        # program looking for a minimum op whose input is the cast result.
+        prog = mlmodel._mil_program
+        op_types = []
+
+        def collect(block):
+            for op in block.operations:
+                op_types.append(op.op_type)
+                for child in op.blocks:
+                    collect(child)
+
+        for func in prog.functions.values():
+            collect(func)
+
+        assert "random_uniform" in op_types, "expected random_uniform in lowered randint"
+        assert "minimum" in op_types, (
+            "expected a `minimum` clamp op in the lowered randint graph (issue #2568); "
+            "otherwise the cast can yield values equal to `high`."
+        )
+
 
 class TestRand(TorchBaseTest):
     @pytest.mark.parametrize(

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -4751,10 +4751,9 @@ class TestRandint(TorchBaseTest):
     @pytest.mark.parametrize("frontend", frontends)
     def test_upper_bound_is_exclusive(self, frontend):
         # Regression test for issue #2568. torch.randint produces integers in
-        # [low, high) — the upper bound is exclusive. mb.random_uniform's upper
-        # bound is inclusive, so cast-to-int can yield exactly `high` unless we
-        # clamp. Ensure the lowering inserts a clamp op so the converted graph
-        # cannot produce values >= `high`.
+        # [low, high) — the upper bound is exclusive. random_uniform's upper
+        # bound is inclusive, so before the clamp cast-to-int could emit exactly
+        # `high`. The converted model must never produce a value >= `high`.
         if frontend == TorchFrontend.EXECUTORCH:
             pytest.skip("torch._ops.aten.randint.low is not Aten Canonical")
 
@@ -4765,6 +4764,7 @@ class TestRandint(TorchBaseTest):
         model = TestModel().eval()
         x = torch.zeros((1000, 100), dtype=torch.int64)
         torch_model = export_torch_model_to_frontend(model, (x,), frontend)
+        # TorchScript needs explicit input types; exported programs carry them.
         inputs = (
             [ct.TensorType(shape=x.shape, dtype=np.int32)]
             if frontend == TorchFrontend.TORCHSCRIPT
@@ -4772,26 +4772,16 @@ class TestRandint(TorchBaseTest):
         )
         mlmodel = ct.convert(torch_model, inputs=inputs)
 
-        # Structural assertion: the lowering must wire a `minimum` clamp into
-        # the path between `random_uniform` and the model output. Walk the MIL
-        # program looking for a minimum op whose input is the cast result.
-        prog = mlmodel._mil_program
-        op_types = []
-
-        def collect(block):
-            for op in block.operations:
-                op_types.append(op.op_type)
-                for child in op.blocks:
-                    collect(child)
-
-        for func in prog.functions.values():
-            collect(func)
-
-        assert "random_uniform" in op_types, "expected random_uniform in lowered randint"
-        assert "minimum" in op_types, (
-            "expected a `minimum` clamp op in the lowered randint graph (issue #2568); "
-            "otherwise the cast can yield values equal to `high`."
-        )
+        # Over a 100k-element draw the prediction must stay within [0, high).
+        # Before the clamp, the cast could emit exactly `high` (== 100).
+        input_name = mlmodel.get_spec().description.input[0].name
+        prediction = list(
+            mlmodel.predict({input_name: x.numpy().astype(np.int32)}).values()
+        )[0]
+        assert (
+            prediction.max() < 100
+        ), f"randint emitted {prediction.max()}, must be < high (100)"
+        assert prediction.min() >= 0
 
 
 class TestRand(TorchBaseTest):


### PR DESCRIPTION
## Summary

`torch.randint(low, high, ...)` draws integers in `[low, high)` — the upper bound is **exclusive**. The lowering used `mb.random_uniform` (whose bounds are **inclusive**) and cast the result to int, so the converted model could emit exactly `high` (issue #2568).

Clamp the cast result to `high - 1` with a `minimum` op so the converted graph matches torch's exclusive upper bound:

```diff
-    rand_int = mb.cast(x=rand_uniform, dtype="int32", name=node.name)
+    rand_int_unclipped = mb.cast(x=rand_uniform, dtype="int32")
+    high_int = mb.cast(x=high, dtype="int32")
+    high_minus_one = mb.sub(x=high_int, y=1)
+    rand_int = mb.minimum(x=rand_int_unclipped, y=high_minus_one, name=node.name)
```

Fixes #2568.

## Test plan

New `TestRandint::test_upper_bound_is_exclusive` (TorchScript + TorchExport frontends; ExecuTorch is skipped because `aten.randint.low` is not Aten Canonical) asserts the lowered graph wires a `minimum` clamp into the randint path, so the converted graph cannot produce values `>= high`.

Verified locally on macOS that the clamp is present in the lowered graph (`convert_to="milinternal"`):

```
[torch.export] random_uniform: True | minimum: True
```

The full test converts to a serialized `mlprogram`, so it runs end-to-end in CI.
