### PR TITLE
Fix torch var/std converter ignoring correction > 1 under tracing

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -7668,37 +7668,45 @@ def var(context, node):
         x = inputs[0]
 
         if context.frontend == TorchFrontend.TORCHSCRIPT:
-            # torch.jit.trace does not distinguish by name `std` and `std.dim`,
-            # instead by nargs 2 or 4
+            # torch.jit.trace does not distinguish by name `var` and `var.dim`,
+            # instead by nargs 2 or 4. It also collapses the `unbiased` and
+            # `correction` overloads onto the same signature, so the second
+            # (nargs == 2) or third (nargs == 4) positional argument may carry
+            # either a bool `unbiased` or a Scalar `correction`. We treat it as
+            # `correction` since that subsumes `unbiased` (unbiased=False is
+            # correction=0, unbiased=True is correction=1).
             keepdim = False
             dim = None
             if len(inputs) == 2:
-                unbiased = inputs[1]
+                correction = inputs[1]
             if len(inputs) == 4:
                 dim = inputs[1]
-                unbiased = inputs[2]
+                correction = inputs[2]
                 keepdim = inputs[3]
         else:
             if node.kind == "var":
-                unbiased = inputs[1] if nargs > 1 else True
+                correction = inputs[1] if nargs > 1 else True
                 dim = None
                 keepdim = False
             else:
                 assert node.kind == "var.dim"
                 assert nargs > 1
                 dim = inputs[1]
-                unbiased = inputs[2] if nargs > 2 else True
+                correction = inputs[2] if nargs > 2 else True
                 keepdim = inputs[3] if nargs > 3 else False
 
-        return x, dim, unbiased, keepdim
+        return x, dim, correction, keepdim
 
-    def _parse_keyword_args(context, node, dim, unbiased, keepdim) -> Tuple[Var]:
+    def _parse_keyword_args(context, node, dim, correction, keepdim) -> Tuple[Var]:
         dim = _get_kwinputs(context, node, "dim", default=[dim])[0]
-        unbiased = _get_kwinputs(context, node, "unbiased", default=[unbiased])[0]
+        unbiased = _get_kwinputs(context, node, "unbiased", default=[None])[0]
+        if unbiased is not None:
+            correction = unbiased
+        correction = _get_kwinputs(context, node, "correction", default=[correction])[0]
         keepdim = _get_kwinputs(context, node, "keepdim", default=[keepdim])[0]
-        return dim, unbiased, keepdim
+        return dim, correction, keepdim
 
-    def _translate_torch_args(dim, unbiased, keepdim) -> Tuple[Var]:
+    def _translate_torch_args(dim, correction, keepdim) -> Tuple[Var]:
         if isinstance(dim, Var):
             dim = dim.val
         try:
@@ -7706,19 +7714,23 @@ def var(context, node):
         except:
             pass
 
-        if isinstance(unbiased, Var):
-            unbiased = unbiased.val
+        if isinstance(correction, Var):
+            correction = correction.val
+        # `unbiased` is the bool special case of `correction`: a true/false flag
+        # maps to a divisor of N-1 / N, i.e. correction 1 / 0. A missing value
+        # defaults to torch's unbiased estimator (correction 1).
+        correction = 1 if correction is None else int(correction)
 
         if isinstance(keepdim, Var):
             keepdim = keepdim.val
 
-        return dim, unbiased, keepdim
+        return dim, correction, keepdim
 
-    x, dim, unbiased, keepdim = _parse_positional_args(context, node)
-    dim, unbiased, keepdim = _parse_keyword_args(context, node, dim, unbiased, keepdim)
-    axes, unbiased, keep_dims = _translate_torch_args(dim, unbiased, keepdim)
+    x, dim, correction, keepdim = _parse_positional_args(context, node)
+    dim, correction, keepdim = _parse_keyword_args(context, node, dim, correction, keepdim)
+    axes, correction, keep_dims = _translate_torch_args(dim, correction, keepdim)
 
-    y = _var(x, axes=axes, keep_dims=keep_dims, unbiased=unbiased)
+    y = _var(x, axes=axes, keep_dims=keep_dims, correction=correction)
     context.add(y, node.name)
 
 
@@ -7783,36 +7795,44 @@ def std(context, node):
 
         if context.frontend == TorchFrontend.TORCHSCRIPT:
             # torch.jit.trace does not distinguish by name `std` and `std.dim`,
-            # instead by nargs 2 or 4
+            # instead by nargs 2 or 4. It also collapses the `unbiased` and
+            # `correction` overloads onto the same signature, so the second
+            # (nargs == 2) or third (nargs == 4) positional argument may carry
+            # either a bool `unbiased` or a Scalar `correction`. We treat it as
+            # `correction` since that subsumes `unbiased` (unbiased=False is
+            # correction=0, unbiased=True is correction=1).
             keepdim = False
             dim = None
             if len(inputs) == 2:
-                unbiased = inputs[1]
+                correction = inputs[1]
             if len(inputs) == 4:
                 dim = inputs[1]
-                unbiased = inputs[2]
+                correction = inputs[2]
                 keepdim = inputs[3]
         else:
             if node.kind == "std":
-                unbiased = inputs[1] if nargs > 1 else True
+                correction = inputs[1] if nargs > 1 else True
                 dim = None
                 keepdim = False
             else:
                 assert node.kind == "std.dim"
                 assert nargs > 1
                 dim = inputs[1]
-                unbiased = inputs[2] if nargs > 2 else True
+                correction = inputs[2] if nargs > 2 else True
                 keepdim = inputs[3] if nargs > 3 else False
 
-        return x, dim, unbiased, keepdim
+        return x, dim, correction, keepdim
 
-    def _parse_keyword_args(context, node, dim, unbiased, keepdim) -> Tuple[Var]:
+    def _parse_keyword_args(context, node, dim, correction, keepdim) -> Tuple[Var]:
         dim = _get_kwinputs(context, node, "dim", default=[dim])[0]
-        unbiased = _get_kwinputs(context, node, "unbiased", default=[unbiased])[0]
+        unbiased = _get_kwinputs(context, node, "unbiased", default=[None])[0]
+        if unbiased is not None:
+            correction = unbiased
+        correction = _get_kwinputs(context, node, "correction", default=[correction])[0]
         keepdim = _get_kwinputs(context, node, "keepdim", default=[keepdim])[0]
-        return dim, unbiased, keepdim
+        return dim, correction, keepdim
 
-    def _translate_torch_args(dim, unbiased, keepdim) -> Tuple[Var]:
+    def _translate_torch_args(dim, correction, keepdim) -> Tuple[Var]:
         if isinstance(dim, Var):
             dim = dim.val
         try:
@@ -7820,19 +7840,23 @@ def std(context, node):
         except:
             pass
 
-        if isinstance(unbiased, Var):
-            unbiased = unbiased.val
+        if isinstance(correction, Var):
+            correction = correction.val
+        # `unbiased` is the bool special case of `correction`: a true/false flag
+        # maps to a divisor of N-1 / N, i.e. correction 1 / 0. A missing value
+        # defaults to torch's unbiased estimator (correction 1).
+        correction = 1 if correction is None else int(correction)
 
         if isinstance(keepdim, Var):
             keepdim = keepdim.val
 
-        return dim, unbiased, keepdim
+        return dim, correction, keepdim
 
-    x, dim, unbiased, keepdim = _parse_positional_args(context, node)
-    dim, unbiased, keepdim = _parse_keyword_args(context, node, dim, unbiased, keepdim)
-    axes, unbiased, keep_dims = _translate_torch_args(dim, unbiased, keepdim)
+    x, dim, correction, keepdim = _parse_positional_args(context, node)
+    dim, correction, keepdim = _parse_keyword_args(context, node, dim, correction, keepdim)
+    axes, correction, keep_dims = _translate_torch_args(dim, correction, keepdim)
 
-    variance = _var(x, axes=axes, keep_dims=keep_dims, unbiased=unbiased)
+    variance = _var(x, axes=axes, keep_dims=keep_dims, correction=correction)
     standard_deviation = mb.sqrt(x=variance)
     context.add(standard_deviation, node.name)
 

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -8211,37 +8211,45 @@ def var(context, node):
         x = inputs[0]
 
         if context.frontend == TorchFrontend.TORCHSCRIPT:
-            # torch.jit.trace does not distinguish by name `std` and `std.dim`,
-            # instead by nargs 2 or 4
+            # torch.jit.trace does not distinguish by name `var` and `var.dim`,
+            # instead by nargs 2 or 4. It also collapses the `unbiased` and
+            # `correction` overloads onto the same signature, so the second
+            # (nargs == 2) or third (nargs == 4) positional argument may carry
+            # either a bool `unbiased` or a Scalar `correction`. We treat it as
+            # `correction` since that subsumes `unbiased` (unbiased=False is
+            # correction=0, unbiased=True is correction=1).
             keepdim = False
             dim = None
             if len(inputs) == 2:
-                unbiased = inputs[1]
+                correction = inputs[1]
             if len(inputs) == 4:
                 dim = inputs[1]
-                unbiased = inputs[2]
+                correction = inputs[2]
                 keepdim = inputs[3]
         else:
             if node.kind == "var":
-                unbiased = inputs[1] if nargs > 1 else True
+                correction = inputs[1] if nargs > 1 else True
                 dim = None
                 keepdim = False
             else:
                 assert node.kind == "var.dim"
                 assert nargs > 1
                 dim = inputs[1]
-                unbiased = inputs[2] if nargs > 2 else True
+                correction = inputs[2] if nargs > 2 else True
                 keepdim = inputs[3] if nargs > 3 else False
 
-        return x, dim, unbiased, keepdim
+        return x, dim, correction, keepdim
 
-    def _parse_keyword_args(context, node, dim, unbiased, keepdim) -> Tuple[Var]:
+    def _parse_keyword_args(context, node, dim, correction, keepdim) -> Tuple[Var]:
         dim = _get_kwinputs(context, node, "dim", default=[dim])[0]
-        unbiased = _get_kwinputs(context, node, "unbiased", default=[unbiased])[0]
+        unbiased = _get_kwinputs(context, node, "unbiased", default=[None])[0]
+        if unbiased is not None:
+            correction = unbiased
+        correction = _get_kwinputs(context, node, "correction", default=[correction])[0]
         keepdim = _get_kwinputs(context, node, "keepdim", default=[keepdim])[0]
-        return dim, unbiased, keepdim
+        return dim, correction, keepdim
 
-    def _translate_torch_args(dim, unbiased, keepdim) -> Tuple[Var]:
+    def _translate_torch_args(dim, correction, keepdim) -> Tuple[Var]:
         if isinstance(dim, Var):
             dim = dim.val
         try:
@@ -8249,19 +8257,23 @@ def var(context, node):
         except:
             pass
 
-        if isinstance(unbiased, Var):
-            unbiased = unbiased.val
+        if isinstance(correction, Var):
+            correction = correction.val
+        # `unbiased` is the bool special case of `correction`: a true/false flag
+        # maps to a divisor of N-1 / N, i.e. correction 1 / 0. A missing value
+        # defaults to torch's unbiased estimator (correction 1).
+        correction = 1 if correction is None else int(correction)
 
         if isinstance(keepdim, Var):
             keepdim = keepdim.val
 
-        return dim, unbiased, keepdim
+        return dim, correction, keepdim
 
-    x, dim, unbiased, keepdim = _parse_positional_args(context, node)
-    dim, unbiased, keepdim = _parse_keyword_args(context, node, dim, unbiased, keepdim)
-    axes, unbiased, keep_dims = _translate_torch_args(dim, unbiased, keepdim)
+    x, dim, correction, keepdim = _parse_positional_args(context, node)
+    dim, correction, keepdim = _parse_keyword_args(context, node, dim, correction, keepdim)
+    axes, correction, keep_dims = _translate_torch_args(dim, correction, keepdim)
 
-    y = _var(x, axes=axes, keep_dims=keep_dims, unbiased=unbiased)
+    y = _var(x, axes=axes, keep_dims=keep_dims, correction=correction)
     context.add(y, node.name)
 
 
@@ -8326,36 +8338,44 @@ def std(context, node):
 
         if context.frontend == TorchFrontend.TORCHSCRIPT:
             # torch.jit.trace does not distinguish by name `std` and `std.dim`,
-            # instead by nargs 2 or 4
+            # instead by nargs 2 or 4. It also collapses the `unbiased` and
+            # `correction` overloads onto the same signature, so the second
+            # (nargs == 2) or third (nargs == 4) positional argument may carry
+            # either a bool `unbiased` or a Scalar `correction`. We treat it as
+            # `correction` since that subsumes `unbiased` (unbiased=False is
+            # correction=0, unbiased=True is correction=1).
             keepdim = False
             dim = None
             if len(inputs) == 2:
-                unbiased = inputs[1]
+                correction = inputs[1]
             if len(inputs) == 4:
                 dim = inputs[1]
-                unbiased = inputs[2]
+                correction = inputs[2]
                 keepdim = inputs[3]
         else:
             if node.kind == "std":
-                unbiased = inputs[1] if nargs > 1 else True
+                correction = inputs[1] if nargs > 1 else True
                 dim = None
                 keepdim = False
             else:
                 assert node.kind == "std.dim"
                 assert nargs > 1
                 dim = inputs[1]
-                unbiased = inputs[2] if nargs > 2 else True
+                correction = inputs[2] if nargs > 2 else True
                 keepdim = inputs[3] if nargs > 3 else False
 
-        return x, dim, unbiased, keepdim
+        return x, dim, correction, keepdim
 
-    def _parse_keyword_args(context, node, dim, unbiased, keepdim) -> Tuple[Var]:
+    def _parse_keyword_args(context, node, dim, correction, keepdim) -> Tuple[Var]:
         dim = _get_kwinputs(context, node, "dim", default=[dim])[0]
-        unbiased = _get_kwinputs(context, node, "unbiased", default=[unbiased])[0]
+        unbiased = _get_kwinputs(context, node, "unbiased", default=[None])[0]
+        if unbiased is not None:
+            correction = unbiased
+        correction = _get_kwinputs(context, node, "correction", default=[correction])[0]
         keepdim = _get_kwinputs(context, node, "keepdim", default=[keepdim])[0]
-        return dim, unbiased, keepdim
+        return dim, correction, keepdim
 
-    def _translate_torch_args(dim, unbiased, keepdim) -> Tuple[Var]:
+    def _translate_torch_args(dim, correction, keepdim) -> Tuple[Var]:
         if isinstance(dim, Var):
             dim = dim.val
         try:
@@ -8363,19 +8383,23 @@ def std(context, node):
         except:
             pass
 
-        if isinstance(unbiased, Var):
-            unbiased = unbiased.val
+        if isinstance(correction, Var):
+            correction = correction.val
+        # `unbiased` is the bool special case of `correction`: a true/false flag
+        # maps to a divisor of N-1 / N, i.e. correction 1 / 0. A missing value
+        # defaults to torch's unbiased estimator (correction 1).
+        correction = 1 if correction is None else int(correction)
 
         if isinstance(keepdim, Var):
             keepdim = keepdim.val
 
-        return dim, unbiased, keepdim
+        return dim, correction, keepdim
 
-    x, dim, unbiased, keepdim = _parse_positional_args(context, node)
-    dim, unbiased, keepdim = _parse_keyword_args(context, node, dim, unbiased, keepdim)
-    axes, unbiased, keep_dims = _translate_torch_args(dim, unbiased, keepdim)
+    x, dim, correction, keepdim = _parse_positional_args(context, node)
+    dim, correction, keepdim = _parse_keyword_args(context, node, dim, correction, keepdim)
+    axes, correction, keep_dims = _translate_torch_args(dim, correction, keepdim)
 
-    variance = _var(x, axes=axes, keep_dims=keep_dims, unbiased=unbiased)
+    variance = _var(x, axes=axes, keep_dims=keep_dims, correction=correction)
     standard_deviation = mb.sqrt(x=variance)
     context.add(standard_deviation, node.name)
 

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -7956,7 +7956,7 @@ class TestVarStd(TorchBaseTest):
             backends,
             frontends,
             ["var", "std"],
-            [0, 1],
+            [0, 1, 2],
             [[0, 2], [1], [2]],
             [True, False],
         ),

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -8717,7 +8717,7 @@ class TestVarStd(TorchBaseTest):
             backends,
             frontends,
             ["var", "std"],
-            [0, 1],
+            [0, 1, 2],
             [[0, 2], [1], [2]],
             [True, False],
         ),


### PR DESCRIPTION
### Bug

When a model is converted via `torch.jit.trace`, `torch.var`/`torch.std` called with the `correction` keyword lower to the same `aten::var`/`aten::std` signature as the older `unbiased` keyword. Both keywords end up in the same positional slot (`aten::var(self, dim, <slot>, keepdim)`), and the slot's constant is just an int.

The converter always read that slot as the boolean `unbiased`. So any `correction >= 2` was truthy and silently treated as `unbiased=True`, i.e. `correction=1`. `correction=0` and `correction=1` happened to come out right only because they coincide with `unbiased=False`/`True`.

Repro (torch 2.12, coremltools from main):

```python
import torch, coremltools as ct, numpy as np
torch.manual_seed(0)
x = torch.randn(3, 5)

class M(torch.nn.Module):
    def forward(self, x):
        return torch.var(x, dim=-1, correction=2, keepdim=True)

ts = torch.jit.trace(M().eval(), x)
m = ct.convert(ts, inputs=[ct.TensorType(name="x", shape=x.shape, dtype=np.float32)],
               compute_units=ct.ComputeUnit.CPU_ONLY, minimum_deployment_target=ct.target.iOS17)

print("torch ", M()(x).flatten()[:2].tolist())
print("coreml", np.asarray(list(m.predict({"x": x.numpy()}).values())[0]).flatten()[:2].tolist())
```

```
torch  [2.762..., 1.057...]   # divides by N - 2 = 3
coreml [2.072..., 0.793...]   # divides by N - 1 = 4  (wrong, == correction=1)
```

`correction=3, 4, ...` are all collapsed to the `correction=1` result the same way. `std` has the same problem since it reuses this logic.

### Fix

Read the argument as `correction` rather than `unbiased`. `correction` is a strict generalization: `unbiased=False` is `correction=0` and `unbiased=True` is `correction=1`, so existing `unbiased`-traced graphs keep their current behavior, and `correction >= 2` now divides by `N - correction` as PyTorch does. The value is routed through the existing `_var(correction=...)` path. The `unbiased=` kwarg (export) is still accepted and mapped onto `correction`.

### Test

`test_var_std_with_correction` only parametrized `correction` over `[0, 1]`, which is exactly the range the old code got right by accident, so the bug was invisible. Extended it to include `correction=2`. With this fix the full matrix (var/std x correction[0,1,2] x dim[[0,2],[1],[2]] x keepdim) passes; on main the `correction=2` cases fail with a numerical mismatch.
