### PR TITLE
Raise NotImplementedError for unsupported TF symmetric pad mode

### DIFF
--- a/coremltools/converters/mil/frontend/tensorflow/ops.py
+++ b/coremltools/converters/mil/frontend/tensorflow/ops.py
@@ -1894,7 +1894,15 @@ def MirrorPad(context, node):
 
     mode = node.attr.get("mode", "reflect").lower()
     if mode == "symmetric":
-        mode = "reflect"
+        # MIL pad supports only `constant`, `reflect`, and `replicate`. TF's
+        # `symmetric` mode reflects including the edge values, which differs
+        # from `reflect` (excludes the edge). Mapping it to `reflect` would
+        # silently produce wrong outputs, so error out instead.
+        raise NotImplementedError(
+            "Padding mode 'symmetric' (SYMMETRIC) in the MirrorPad op is not "
+            "supported by Core ML. Only 'reflect' (REFLECT) is supported for "
+            "mirror padding."
+        )
     in_rank = len(x.sym_type.get_shape())
 
     if in_rank > 5 or in_rank < 2:
@@ -1950,7 +1958,15 @@ def Pad(context, node):
 
     mode = node.attr.get("mode", "constant").lower()
     if mode == "symmetric":
-        mode = "reflect"
+        # MIL pad supports only `constant`, `reflect`, and `replicate`. TF's
+        # `symmetric` mode reflects including the edge values, which differs
+        # from `reflect` (excludes the edge). Mapping it to `reflect` would
+        # silently produce wrong outputs, so error out instead.
+        raise NotImplementedError(
+            "Padding mode 'symmetric' (SYMMETRIC) in the Pad op is not "
+            "supported by Core ML. Only 'constant' (CONSTANT) and 'reflect' "
+            "(REFLECT) are supported."
+        )
     constant_val = node.attr.get("constant_val", 0.0)
     constant_val = mb.const(val=constant_val)
     in_rank = len(x.sym_type.get_shape())

--- a/coremltools/converters/mil/frontend/tensorflow/test/test_ops.py
+++ b/coremltools/converters/mil/frontend/tensorflow/test/test_ops.py
@@ -5402,6 +5402,29 @@ class TestPad(TensorFlowBaseTest):
             backend=backend
         )
 
+    @pytest.mark.parametrize(
+        "backend",
+        backends,
+    )
+    def test_symmetric_unsupported(self, backend):
+        # MIL has no `symmetric` pad mode. TF `symmetric` reflects including the
+        # edge value, unlike MIL `reflect`, so it must error out rather than
+        # being silently mapped to `reflect`. See issue #2280.
+        input_shape = (1, 4)
+
+        @make_tf_graph([input_shape])
+        def build_model(x):
+            return tf.pad(x, paddings=[[0, 0], [2, 2]], mode="SYMMETRIC")
+
+        model, inputs, outputs = build_model
+
+        with pytest.raises(NotImplementedError, match="symmetric"):
+            ct.convert(
+                model,
+                source="tensorflow",
+                convert_to="milinternal",
+            )
+
 
 class TestPadV2(TensorFlowBaseTest):
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Issue

Fixes #2280.

When converting a TensorFlow model, both the `Pad` and `MirrorPad` op handlers in `coremltools/converters/mil/frontend/tensorflow/ops.py` silently rewrite TF's `symmetric` padding mode to MIL's `reflect`:

```python
mode = node.attr.get("mode", "constant").lower()
if mode == "symmetric":
    mode = "reflect"
```

The two modes are not equivalent. TF `symmetric` reflects *including* the edge value, while `reflect` excludes it. For input `[1, 2, 3, 4]` padded by 2 on each side:

- symmetric: `[2, 1, | 1, 2, 3, 4 | 4, 3]`
- reflect:   `[3, 2, | 1, 2, 3, 4 | 3, 2]`

So a `tf.pad(..., mode='SYMMETRIC')` currently converts without any warning and the resulting Core ML model computes different, wrong values. This is a silent miscompilation.

## Fix

MIL `pad` supports only `constant`, `reflect`, and `replicate` (see `mil/ops/defs/iOS15/tensor_operation.py`), so `symmetric` cannot be expressed directly. As the reporter suggested, the right behavior is to raise a clear error rather than emit a wrong result. Both handlers now raise `NotImplementedError` naming the op and the unsupported mode. The `reflect` and `constant` paths are unchanged.

## Testing

Added `TestPad::test_symmetric_unsupported`, which asserts that converting a `tf.pad(mode='SYMMETRIC')` graph raises `NotImplementedError`. Verified locally with TensorFlow 2.19:

- before the fix, the TF -> MIL conversion emits `pad(..., mode="reflect")` for a SYMMETRIC input (silent wrong mapping confirmed)
- after the fix, SYMMETRIC raises `NotImplementedError` through both the `MirrorPad` path (`tf.pad` lowers SYMMETRIC to `MirrorPad`) and the `Pad` handler branch
- `REFLECT` and `CONSTANT` still convert correctly and emit `mode="reflect"` / `mode="constant"`

The new test passes for both backends. End-to-end runtime comparison was not run here because this environment lacks the compiled Core ML runtime, but the change is confined to the frontend mode mapping.