### PR TITLE
Support real-valued input in torch.fft.irfft converter

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -8749,6 +8749,12 @@ def fft_ifftn(context, node):
 def fft_irfft(context, node):
     """Lowers torch.fft.irfft by the dialect op `complex_irfft` from complex_dialect_ops.py."""
     input_data, n, dim, norm = _get_inputs(context, node, expected=[4])
+    # torch.fft.irfft accepts a real input and treats it as a complex tensor with a zero
+    # imaginary part. The complex_irfft dialect op only takes complex64, so promote a real
+    # input to complex here before lowering.
+    if not types.is_complex(input_data.dtype):
+        imag_data = mb.fill(shape=mb.shape(x=input_data), value=0.0)
+        input_data = mb.complex(real_data=input_data, imag_data=imag_data)
     irfft_res = mb.complex_irfft(data=input_data, n=n, dim=dim, norm=norm)
     context.add(irfft_res, node.name)
 

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -12974,6 +12974,27 @@ class TestFft(TorchBaseTest):
         )
 
     @pytest.mark.parametrize(
+        "compute_unit, backend, n, dim, norm",
+        itertools.product(
+            compute_units,
+            backends,
+            [None, 1, 5],
+            [0, 1, -1],
+            [None, "forward", "backward", "ortho"],
+        ),
+    )
+    def test_fft_irfft_real_input(self, compute_unit: ct.ComputeUnit, backend, n, dim, norm):
+        # torch.fft.irfft accepts a real input (treated as complex with a zero imaginary part).
+        # The input is not wrapped with torch.complex here, unlike test_fft_basic. See GH #2130.
+        class FftModel(torch.nn.Module):
+            def forward(self, x):
+                return torch.fft.irfft(x, n=n, dim=dim, norm=norm)
+
+        TorchBaseTest.run_compare_torch(
+            (2, 3, 4), FftModel(), backend=backend, compute_unit=compute_unit
+        )
+
+    @pytest.mark.parametrize(
         "compute_unit, backend",
         itertools.product(
             compute_units,


### PR DESCRIPTION
## Summary

Converting a model that calls `torch.fft.irfft` on a real-valued tensor fails:

```
Op "complex_irfft_0" (op_type: complex_irfft) Input data="k_f" expects
tensor or scalar of dtype from type domain ['complex64'] but got tensor[3,fp32]
```

`torch.fft.irfft` accepts a real-valued input and treats it as a complex tensor with a zero imaginary part (a one-sided Hermitian spectrum is real at DC). The `fft_irfft` handler passed the traced input straight to the `complex_irfft` dialect op, which only accepts `complex64`, so any real input is rejected at conversion time. The underlying IRFFT lowering already exists and works; only the real-to-complex promotion was missing.

Fixes #2130.

## Changes

`coremltools/converters/mil/frontend/torch/ops.py`
- In `fft_irfft`, if the input is not already complex, build a zero imaginary part with `mb.fill` and wrap it into a complex value via `mb.complex` before calling `complex_irfft`. This mirrors what the `complex_fft` / `complex_fftn` lowering already does for real inputs and matches PyTorch semantics. Complex inputs are passed through unchanged.

`coremltools/converters/mil/frontend/torch/test/test_torch_ops.py`
- Added `test_fft_irfft_real_input` to `TestFft`, parametrized over `n`, `dim`, and `norm`. Unlike the existing `test_fft_basic`, the input is not wrapped with `torch.complex`, so it covers the real-input path from the issue.

## Testing

Red/green verified end to end (`ct.convert` then `predict` on `ComputeUnit.CPU_ONLY`, compared against `torch.fft.irfft`):

- RED: without the fix the new test fails with the `complex_irfft` dtype error above.
- GREEN: with the fix, `test_fft_irfft_real_input` passes (36/36 cases), and the existing `TestFft` tests are unaffected.

Numeric agreement against PyTorch across default args, explicit `n` (pad and trim), every `norm` mode, and 1D/2D/3D inputs:
- FLOAT32 compute precision: max abs diff ~1e-7.
- FLOAT16 compute precision: max abs diff ~1e-3, in line with the existing complex-input irfft path (same DFT-by-matmul lowering).

The original issue snippet now converts and produces `[0.15625, 0.78125, 0.78125, 0.78125]`, matching PyTorch exactly.

Implemented with the help of a coding agent.