### PR TITLE
Accumulate activation calibration ranges

### DIFF
--- a/coremltools/optimize/_utils.py
+++ b/coremltools/optimize/_utils.py
@@ -867,8 +867,6 @@ def _update_tensor_range(
     """
     tensor_min = np.min(np.array(tensor_value).flatten())
     tensor_max = np.max(np.array(tensor_value).flatten())
-    activation_stats_dict[tensor_name]["rmin"] = tensor_min
-    activation_stats_dict[tensor_name]["rmax"] = tensor_max
     if tensor_name in activation_stats_dict:
         activation_stats_dict[tensor_name]["rmin"] = min(
             tensor_min, activation_stats_dict[tensor_name]["rmin"]
@@ -877,8 +875,7 @@ def _update_tensor_range(
             tensor_max, activation_stats_dict[tensor_name]["rmax"]
         )
     else:
-        activation_stats_dict[tensor_name]["rmin"] = tensor_min
-        activation_stats_dict[tensor_name]["rmax"] = tensor_max
+        activation_stats_dict[tensor_name] = {"rmin": tensor_min, "rmax": tensor_max}
 
 
 def _combine_lists_with_common_elements(data: List[List[str]]) -> List[List[str]]:

--- a/coremltools/optimize/coreml/experimental/_model_debugger.py
+++ b/coremltools/optimize/coreml/experimental/_model_debugger.py
@@ -268,8 +268,6 @@ class ModelDebugger:
     def record_intermediate_output(output_value, output_name, activation_stats_dict):
         tensor_min = np.min(output_value.flatten())
         tensor_max = np.max(output_value.flatten())
-        activation_stats_dict[output_name]["rmin"] = tensor_min
-        activation_stats_dict[output_name]["rmax"] = tensor_max
         if output_name in activation_stats_dict:
             activation_stats_dict[output_name]["rmin"] = min(
                 tensor_min, activation_stats_dict[output_name]["rmin"]
@@ -278,8 +276,7 @@ class ModelDebugger:
                 tensor_max, activation_stats_dict[output_name]["rmax"]
             )
         else:
-            activation_stats_dict[output_name]["rmin"] = tensor_min
-            activation_stats_dict[output_name]["rmax"] = tensor_max
+            activation_stats_dict[output_name] = {"rmin": tensor_min, "rmax": tensor_max}
 
     def step(
         self,

--- a/coremltools/optimize/coreml/experimental/_post_training_quantization.py
+++ b/coremltools/optimize/coreml/experimental/_post_training_quantization.py
@@ -101,8 +101,6 @@ def _update_tensor_range(
 ) -> None:
     tensor_min = np.min(np.array(tensor_value).flatten())
     tensor_max = np.max(np.array(tensor_value).flatten())
-    activation_stats_dict[tensor_name]["rmin"] = tensor_min
-    activation_stats_dict[tensor_name]["rmax"] = tensor_max
     if tensor_name in activation_stats_dict:
         activation_stats_dict[tensor_name]["rmin"] = min(
             tensor_min, activation_stats_dict[tensor_name]["rmin"]
@@ -111,8 +109,7 @@ def _update_tensor_range(
             tensor_max, activation_stats_dict[tensor_name]["rmax"]
         )
     else:
-        activation_stats_dict[tensor_name]["rmin"] = tensor_min
-        activation_stats_dict[tensor_name]["rmax"] = tensor_max
+        activation_stats_dict[tensor_name] = {"rmin": tensor_min, "rmax": tensor_max}
 
 
 def _combine_lists_with_common_elements(data: List[List[str]]) -> List[List[str]]:

--- a/coremltools/optimize/coreml/experimental/test_post_training_quantization.py
+++ b/coremltools/optimize/coreml/experimental/test_post_training_quantization.py
@@ -11,7 +11,9 @@ import sys
 import coremltools as ct
 from coremltools.optimize.coreml.experimental._post_training_quantization import (
     _get_activation_calibration_stats,
+    _update_tensor_range,
 )
+from coremltools.optimize.coreml.experimental._model_debugger import ModelDebugger
 from coremltools.test.optimize.coreml.test_passes import TestCompressionPasses
 import coremltools.optimize as cto
 
@@ -76,6 +78,25 @@ class TestActivationQuantization:
 
 
 class TestGetActivationStats(TestActivationQuantization):
+    def test_update_tensor_range_accumulates_running_min_max(self):
+        stats = {}
+
+        _update_tensor_range("my_tensor", np.array([0.0, 5.0, 10.0]), stats)
+        _update_tensor_range("my_tensor", np.array([2.0, 3.0, 5.0]), stats)
+        _update_tensor_range("my_tensor", np.array([-1.0, 7.0, 15.0]), stats)
+
+        assert stats["my_tensor"]["rmin"] == -1.0
+        assert stats["my_tensor"]["rmax"] == 15.0
+
+    def test_record_intermediate_output_accumulates_running_min_max(self):
+        stats = {}
+
+        ModelDebugger.record_intermediate_output(np.array([0.0, 5.0, 10.0]), "my_tensor", stats)
+        ModelDebugger.record_intermediate_output(np.array([2.0, 3.0, 5.0]), "my_tensor", stats)
+        ModelDebugger.record_intermediate_output(np.array([-1.0, 7.0, 15.0]), "my_tensor", stats)
+
+        assert stats["my_tensor"]["rmin"] == -1.0
+        assert stats["my_tensor"]["rmax"] == 15.0
 
     def test_activation_quantization(self):
         """

--- a/coremltools/optimize/coreml/experimental/test_post_training_quantization.py
+++ b/coremltools/optimize/coreml/experimental/test_post_training_quantization.py
@@ -82,7 +82,13 @@ class TestGetActivationStats(TestActivationQuantization):
         stats = {}
 
         _update_tensor_range("my_tensor", np.array([0.0, 5.0, 10.0]), stats)
+        assert stats["my_tensor"]["rmin"] == 0.0
+        assert stats["my_tensor"]["rmax"] == 10.0
+
         _update_tensor_range("my_tensor", np.array([2.0, 3.0, 5.0]), stats)
+        assert stats["my_tensor"]["rmin"] == 0.0
+        assert stats["my_tensor"]["rmax"] == 10.0
+
         _update_tensor_range("my_tensor", np.array([-1.0, 7.0, 15.0]), stats)
 
         assert stats["my_tensor"]["rmin"] == -1.0
@@ -92,7 +98,13 @@ class TestGetActivationStats(TestActivationQuantization):
         stats = {}
 
         ModelDebugger.record_intermediate_output(np.array([0.0, 5.0, 10.0]), "my_tensor", stats)
+        assert stats["my_tensor"]["rmin"] == 0.0
+        assert stats["my_tensor"]["rmax"] == 10.0
+
         ModelDebugger.record_intermediate_output(np.array([2.0, 3.0, 5.0]), "my_tensor", stats)
+        assert stats["my_tensor"]["rmin"] == 0.0
+        assert stats["my_tensor"]["rmax"] == 10.0
+
         ModelDebugger.record_intermediate_output(np.array([-1.0, 7.0, 15.0]), "my_tensor", stats)
 
         assert stats["my_tensor"]["rmin"] == -1.0

--- a/coremltools/test/optimize/test_utils.py
+++ b/coremltools/test/optimize/test_utils.py
@@ -13,6 +13,23 @@ from coremltools.converters.mil.mil.ops.defs.iOS18.compression import constexpr_
 from coremltools.optimize import _utils as optimize_utils
 
 
+class TestUpdateTensorRange:
+    @pytest.mark.parametrize(
+        "stats",
+        [
+            {},
+            {"my_tensor": {"rmin": float("inf"), "rmax": float("-inf")}},
+        ],
+    )
+    def test_accumulates_running_min_max(self, stats):
+        optimize_utils._update_tensor_range("my_tensor", np.array([0.0, 5.0, 10.0]), stats)
+        optimize_utils._update_tensor_range("my_tensor", np.array([2.0, 3.0, 5.0]), stats)
+        optimize_utils._update_tensor_range("my_tensor", np.array([-1.0, 7.0, 15.0]), stats)
+
+        assert stats["my_tensor"]["rmin"] == -1.0
+        assert stats["my_tensor"]["rmax"] == 15.0
+
+
 class TestComputeQuantizationParams:
     @pytest.mark.parametrize(
         "quant_mode, rank, block_size",

--- a/coremltools/test/optimize/test_utils.py
+++ b/coremltools/test/optimize/test_utils.py
@@ -23,7 +23,13 @@ class TestUpdateTensorRange:
     )
     def test_accumulates_running_min_max(self, stats):
         optimize_utils._update_tensor_range("my_tensor", np.array([0.0, 5.0, 10.0]), stats)
+        assert stats["my_tensor"]["rmin"] == 0.0
+        assert stats["my_tensor"]["rmax"] == 10.0
+
         optimize_utils._update_tensor_range("my_tensor", np.array([2.0, 3.0, 5.0]), stats)
+        assert stats["my_tensor"]["rmin"] == 0.0
+        assert stats["my_tensor"]["rmax"] == 10.0
+
         optimize_utils._update_tensor_range("my_tensor", np.array([-1.0, 7.0, 15.0]), stats)
 
         assert stats["my_tensor"]["rmin"] == -1.0


### PR DESCRIPTION
Fixes #2704.

Activation calibration was overwriting each tensor's stored `rmin`/`rmax` before comparing the current batch against the previous range. That made the collected range depend on sample order, and a later narrower batch could replace an earlier wider range.

This initializes stats only when a tensor is first seen, then accumulates the running min and max for later batches. The same fix is applied to the experimental calibration/debugger paths that record activation ranges.

Tested:
- `python -m pytest coremltools/test/optimize/test_utils.py::TestUpdateTensorRange coremltools/optimize/coreml/experimental/test_post_training_quantization.py::TestGetActivationStats::test_update_tensor_range_accumulates_running_min_max coremltools/optimize/coreml/experimental/test_post_training_quantization.py::TestGetActivationStats::test_record_intermediate_output_accumulates_running_min_max -q`
- `python -m compileall -q coremltools/optimize/_utils.py coremltools/optimize/coreml/experimental/_post_training_quantization.py coremltools/optimize/coreml/experimental/_model_debugger.py coremltools/test/optimize/test_utils.py coremltools/optimize/coreml/experimental/test_post_training_quantization.py`
- `git diff --check`