### PR TITLE
Fix softplus and mish fp16 overflow on ANE via stable decomposition

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -1775,6 +1775,23 @@ def rrelu(context, node):
     context.add(res)
 
 
+def _stable_softplus_mil(x):
+    """Numerically stable softplus: max(x, 0) + log(1 + exp(-|x|)).
+
+    Since -|x| <= 0, exp(-|x|) is always in (0, 1], so no overflow occurs
+    in any precision.  This matches the formula used by coremltools' own
+    softplus MIL op ``value_inference``.
+
+    See issue #2687 for the original fp16 overflow report.
+    """
+    abs_x = mb.abs(x=x)
+    neg_abs_x = mb.mul(x=-1.0, y=abs_x)
+    exp_val = mb.exp(x=neg_abs_x)
+    log_val = mb.log(x=mb.add(x=1.0, y=exp_val))
+    max_val = mb.maximum(x=x, y=0.0)
+    return mb.add(x=max_val, y=log_val)
+
+
 @register_torch_op
 def softplus(context, node):
     def _parse_positional_args(context, node) -> Tuple[Var]:
@@ -1795,20 +1812,20 @@ def softplus(context, node):
     x, beta, threshold = _parse_positional_args(context, node)
 
     if beta == 1:
-        # this is the special case that Core ML softplus handles
-        res = mb.softplus(x=x, name=node.name)
+        sp = _stable_softplus_mil(x)
     else:
-        if x.rank == 4:
-            # can use Core ML softplus_parametric
-            C = x.shape[1]
-            alpha_br = np.repeat(1.0 / beta, C).astype("float32")
-            beta_br = np.repeat(beta, C).astype("float32")
-            res = mb.softplus_parametric(x=x, alpha=alpha_br, beta=beta_br, name=node.name)
-        else:
-            # have to generally decompose
-            beta_mul_x = mb.mul(x=beta, y=x)
-            softplus = mb.softplus(x=beta_mul_x)
-            res = mb.real_div(x=softplus, y=beta, name=node.name)
+        # For non-unit beta: softplus(x) = (1/beta) * softplus(beta * x)
+        beta_mul_x = mb.mul(x=beta, y=x)
+        sp = mb.real_div(x=_stable_softplus_mil(beta_mul_x), y=beta)
+
+    # Apply PyTorch's threshold: for beta * x > threshold, softplus(x) ≈ x,
+    # so return x directly.  This matches PyTorch's exact behavior.
+    if beta == 1:
+        cond = mb.greater(x=x, y=threshold)
+    else:
+        beta_x = mb.mul(x=beta, y=x)
+        cond = mb.greater(x=beta_x, y=threshold)
+    res = mb.select(cond=cond, a=x, b=sp, name=node.name)
     context.add(res)
 
 
@@ -1817,8 +1834,8 @@ def mish(context, node):
     inputs = _get_inputs(context, node, expected=1)
     x = inputs[0]
 
-    softplus = mb.softplus(x=x)
-    tanh = mb.tanh(x=softplus)
+    # Mish(x) = x * tanh(softplus(x))
+    tanh = mb.tanh(x=_stable_softplus_mil(x))
     res = mb.mul(x=x, y=tanh, name=node.name)
     context.add(res)
 

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -1813,18 +1813,15 @@ def softplus(context, node):
 
     if beta == 1:
         sp = _stable_softplus_mil(x)
+        cond = mb.greater(x=x, y=threshold)
     else:
         # For non-unit beta: softplus(x) = (1/beta) * softplus(beta * x)
-        beta_mul_x = mb.mul(x=beta, y=x)
-        sp = mb.real_div(x=_stable_softplus_mil(beta_mul_x), y=beta)
+        beta_x = mb.mul(x=beta, y=x)
+        sp = mb.real_div(x=_stable_softplus_mil(beta_x), y=beta)
+        cond = mb.greater(x=beta_x, y=threshold)
 
     # Apply PyTorch's threshold: for beta * x > threshold, softplus(x) ≈ x,
     # so return x directly.  This matches PyTorch's exact behavior.
-    if beta == 1:
-        cond = mb.greater(x=x, y=threshold)
-    else:
-        beta_x = mb.mul(x=beta, y=x)
-        cond = mb.greater(x=beta_x, y=threshold)
     res = mb.select(cond=cond, a=x, b=sp, name=node.name)
     context.add(res)
 

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -6721,17 +6721,9 @@ class TestActivation(TorchBaseTest):
             # executorch decomposes softplus to very basic log and exp
             target_op = "exp"
         else:
-            if beta is None or beta == 1:
-                # this is the special case that Core ML softplus handles
-                target_op = "softplus"
-            else:
-                if rank == 4:
-                    # can use Core ML softplus_parametric
-                    target_op = "softplus_parametric"
-                else:
-                    # have to generally decompose to
-                    # `x -> beta * x -> softplus(beta * x) -> softplus(beta * x) / beta`
-                    target_op = "softplus"
+            # The converter now wraps softplus in a select for fp16 threshold safety,
+            # so we skip the target_op check for non-executorch frontends.
+            target_op = None
 
         self.run_compare_torch(
             input_shape,
@@ -6741,6 +6733,46 @@ class TestActivation(TorchBaseTest):
             compute_unit=compute_unit,
             minimum_deployment_target=minimum_deployment_target,
             target_op=target_op,
+        )
+
+    @pytest.mark.parametrize(
+        "backend, frontend",
+        itertools.product(backends, frontends),
+    )
+    def test_softplus_fp16_stable_decomposition(self, backend, frontend):
+        """Regression test for issue #2687: the converter must decompose
+        softplus into numerically stable primitives instead of emitting
+        the native ``softplus`` MIL op, because the native op overflows
+        in fp16 on Apple Neural Engine at x ≈ 10.4.
+
+        This is a conversion-only test: it converts a small Softplus model
+        and asserts that no native ``softplus`` op remains in the MIL graph.
+        On ``main`` the graph contains the native op and the assertion
+        fails; with the fix the graph contains the stable decomposition
+        (exp, log, maximum) and it passes.
+        """
+        if frontend == TorchFrontend.EXECUTORCH:
+            pytest.skip("ExecuTorch decomposes softplus independently")
+
+        torch.manual_seed(0)
+        model = nn.Softplus().eval()
+        x = torch.randn(1, 10)
+
+        torch_model = export_torch_model_to_frontend(model, (x,), frontend)
+        inputs = [ct.TensorType(shape=x.shape)]
+        mlmodel = ct.convert(
+            torch_model,
+            inputs=inputs,
+            convert_to=backend[0],
+            compute_precision=ct.precision.FLOAT16 if len(backend) > 1 and backend[1] == "fp16" else ct.precision.FLOAT32,
+        )
+
+        prog = mlmodel._mil_program
+        softplus_ops = prog.find_ops(op_type="softplus")
+        assert len(softplus_ops) == 0, (
+            f"Expected no native 'softplus' ops in the MIL graph after stable "
+            f"decomposition, but found {len(softplus_ops)}. The converter should "
+            f"replace softplus with max(x,0)+log(1+exp(-|x|)) for fp16 safety."
         )
 
     @pytest.mark.parametrize(

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -6737,21 +6737,26 @@ class TestActivation(TorchBaseTest):
 
     @pytest.mark.parametrize("frontend", frontends)
     def test_softplus_fp16_stable_decomposition(self, frontend):
-        """Regression test for issue #2687: the converter must decompose
-        softplus into numerically stable primitives instead of emitting
-        the native ``softplus`` MIL op, because the native op overflows
-        in fp16 on Apple Neural Engine at x ≈ 10.4.
-
-        This is a conversion-only test: it converts a small Softplus model
-        to mlprogram with fp16 precision and asserts that no native
-        ``softplus`` op remains in the MIL graph.  On ``main`` the graph
-        contains the native op and the assertion fails; with the fix the
-        graph contains the stable decomposition (exp, log, maximum) and
-        it passes.
-        """
+        """Verify softplus is decomposed into overflow-safe ops for fp16 (#2687)."""
         if frontend == TorchFrontend.EXECUTORCH:
             pytest.skip("ExecuTorch decomposes softplus independently")
 
+        # Demonstrate that naive fp16 softplus (log(1+exp(x))) overflows for
+        # large x, while the stable form (max(x,0)+log(1+exp(-|x|))) does not.
+        x_val = np.float16(15.0)
+        naive = np.float16(np.log(np.float16(1.0) + np.exp(x_val)))
+        assert not np.isfinite(naive), (
+            f"Naive fp16 softplus should overflow at x=15, got {naive}"
+        )
+        stable = np.float16(
+            np.maximum(x_val, np.float16(0))
+            + np.log(np.float16(1.0) + np.exp(-np.abs(x_val)))
+        )
+        assert np.isfinite(stable) and abs(float(stable) - 15.0) < 0.5, (
+            f"Stable fp16 softplus should produce ~15.0, got {stable}"
+        )
+
+        # Verify the converter emits the stable decomposition, not the native op.
         torch.manual_seed(0)
         model = nn.Softplus().eval()
         x = torch.randn(1, 10)
@@ -6764,21 +6769,12 @@ class TestActivation(TorchBaseTest):
             compute_precision=ct.precision.FLOAT16,
         )
 
-        softplus_ops = mlmodel._mil_program.find_ops(op_type="softplus")
-        assert len(softplus_ops) == 0, (
-            f"Expected no native 'softplus' ops in the MIL graph after stable "
-            f"decomposition, but found {len(softplus_ops)}. The converter should "
-            f"replace softplus with max(x,0)+log(1+exp(-|x|)) for fp16 safety."
+        prog = mlmodel._mil_program
+        assert len(prog.find_ops(op_type="softplus")) == 0, (
+            "Native softplus op should be replaced by stable decomposition"
         )
-
-        # Positive assertion: the stable decomposition must emit at least one
-        # 'exp' op (from exp(-|x|)).  This guards against a vacuously passing
-        # test on an empty or broken graph.
-        exp_ops = mlmodel._mil_program.find_ops(op_type="exp")
-        assert len(exp_ops) >= 1, (
-            f"Expected at least one 'exp' op from the stable softplus "
-            f"decomposition, but found {len(exp_ops)}. The graph may be "
-            f"empty or the decomposition was not applied."
+        assert len(prog.find_ops(op_type="exp")) >= 1, (
+            "Stable decomposition should contain at least one exp op"
         )
 
     @pytest.mark.parametrize(

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -6771,6 +6771,16 @@ class TestActivation(TorchBaseTest):
             f"replace softplus with max(x,0)+log(1+exp(-|x|)) for fp16 safety."
         )
 
+        # Positive assertion: the stable decomposition must emit at least one
+        # 'exp' op (from exp(-|x|)).  This guards against a vacuously passing
+        # test on an empty or broken graph.
+        exp_ops = mlmodel._mil_program.find_ops(op_type="exp")
+        assert len(exp_ops) >= 1, (
+            f"Expected at least one 'exp' op from the stable softplus "
+            f"decomposition, but found {len(exp_ops)}. The graph may be "
+            f"empty or the decomposition was not applied."
+        )
+
     @pytest.mark.parametrize(
         "compute_unit, backend, frontend, shape",
         itertools.product(compute_units, backends, frontends, COMMON_SHAPES_ALL),

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -6735,21 +6735,19 @@ class TestActivation(TorchBaseTest):
             target_op=target_op,
         )
 
-    @pytest.mark.parametrize(
-        "backend, frontend",
-        itertools.product(backends, frontends),
-    )
-    def test_softplus_fp16_stable_decomposition(self, backend, frontend):
+    @pytest.mark.parametrize("frontend", frontends)
+    def test_softplus_fp16_stable_decomposition(self, frontend):
         """Regression test for issue #2687: the converter must decompose
         softplus into numerically stable primitives instead of emitting
         the native ``softplus`` MIL op, because the native op overflows
         in fp16 on Apple Neural Engine at x ≈ 10.4.
 
         This is a conversion-only test: it converts a small Softplus model
-        and asserts that no native ``softplus`` op remains in the MIL graph.
-        On ``main`` the graph contains the native op and the assertion
-        fails; with the fix the graph contains the stable decomposition
-        (exp, log, maximum) and it passes.
+        to mlprogram with fp16 precision and asserts that no native
+        ``softplus`` op remains in the MIL graph.  On ``main`` the graph
+        contains the native op and the assertion fails; with the fix the
+        graph contains the stable decomposition (exp, log, maximum) and
+        it passes.
         """
         if frontend == TorchFrontend.EXECUTORCH:
             pytest.skip("ExecuTorch decomposes softplus independently")
@@ -6759,16 +6757,14 @@ class TestActivation(TorchBaseTest):
         x = torch.randn(1, 10)
 
         torch_model = export_torch_model_to_frontend(model, (x,), frontend)
-        inputs = [ct.TensorType(shape=x.shape)]
         mlmodel = ct.convert(
             torch_model,
-            inputs=inputs,
-            convert_to=backend[0],
-            compute_precision=ct.precision.FLOAT16 if len(backend) > 1 and backend[1] == "fp16" else ct.precision.FLOAT32,
+            inputs=[ct.TensorType(shape=x.shape)],
+            convert_to="mlprogram",
+            compute_precision=ct.precision.FLOAT16,
         )
 
-        prog = mlmodel._mil_program
-        softplus_ops = prog.find_ops(op_type="softplus")
+        softplus_ops = mlmodel._mil_program.find_ops(op_type="softplus")
         assert len(softplus_ops) == 0, (
             f"Expected no native 'softplus' ops in the MIL graph after stable "
             f"decomposition, but found {len(softplus_ops)}. The converter should "


### PR DESCRIPTION
## Problem

The native softplus MIL op computes `log(1 + exp(x))`, where `exp(x)` overflows in fp16 for `x > ~10.4` on Apple Neural Engine, causing a hard, single-step output collapse to 0. This also affects `nn.Mish` (`x * tanh(softplus(x))`). CPU and GPU compute units are unaffected.

Additionally, PyTorch's threshold parameter (default 20) was being ignored by the converter.

Discovered while debugging fp16 precision in a KataGo-style network's Mish activations (see #2687).

## Solution

Replace the native softplus op with the numerically stable equivalent:

`
softplus(x) = max(x, 0) + log(1 + exp(-|x|))
`

Since `-|x| <= 0`, `exp(-|x|)` is always in `(0, 1]`, so no overflow can occur in any precision. This formula is already used by coremltools' own softplus MIL op `value_inference`.

Also apply PyTorch's threshold parameter: for `beta * x > threshold`, return `x` directly, matching PyTorch's exact semantics.

## Changes

**ops.py** — softplus converter:
- Extracted shared `_stable_softplus_mil(x)` helper (no `mb` parameter — uses module-level import)
- Replaced `mb.softplus()` with the stable decomposition
- For `beta == 1`: threshold compares `x > threshold` directly (no redundant `mul(1, x)`)
- For `beta != 1`: `beta_x = mb.mul(x=beta, y=x)` computed once and reused for both softplus and threshold condition
- Two blank lines before each `@register_torch_op` per file convention

**ops.py** — mish converter:
- Applied same stable softplus via `_stable_softplus_mil(x)`
- Mish becomes: `x * tanh(_stable_softplus_mil(x))`

**test_torch_ops.py**:
- Updated `test_softplus` to account for new graph structure (`select` op from threshold handling)
- Added `test_softplus_fp16_stable_decomposition`: **conversion-only** test that converts a small `nn.Softplus()` model to `mlprogram` with `fp16` precision and asserts zero native `softplus` ops remain in the MIL graph. On `main` the assertion fails (native op present); with the fix it passes (decomposed ops).

## Testing

- All existing `test_softplus` parametrized test cases pass (108 non-skipped variants)
- All 20 `test_mish` tests pass
- New `test_softplus_fp16_stable_decomposition` passes with the fix, fails without it (verified by @ChinChangYang)

Fixes #2687
Fixes #2359