### PR TITLE
[Add] New LightGBM Converter

### DIFF
--- a/coremltools/_deps/__init__.py
+++ b/coremltools/_deps/__init__.py
@@ -102,6 +102,14 @@ except:
     _HAS_XGBOOST = False
 
 # ---------------------------------------------------------------------------------------
+_HAS_LIGHTGBM = True
+try:
+    import lightgbm
+except:
+    _HAS_LIGHTGBM = False
+MSG_LIGHTGBM_NOT_FOUND = "LightGBM not found."
+
+# ---------------------------------------------------------------------------------------
 _HAS_TF = True
 _HAS_TF_1 = False
 _HAS_TF_2 = False

--- a/coremltools/converters/__init__.py
+++ b/coremltools/converters/__init__.py
@@ -4,7 +4,7 @@
 # found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
 # expose directories as imports
-from . import libsvm, sklearn, xgboost
+from . import libsvm, lightgbm, sklearn, xgboost
 from ._converters_entry import convert
 from .mil import (
     ClassifierConfig,

--- a/coremltools/converters/lightgbm/__init__.py
+++ b/coremltools/converters/lightgbm/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2026, Apple Inc. All rights reserved.
+#
+# Use of this source code is governed by a BSD-3-clause license that can be
+# found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+
+from ._tree import convert

--- a/coremltools/converters/lightgbm/_tree.py
+++ b/coremltools/converters/lightgbm/_tree.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2026, Apple Inc. All rights reserved.
+#
+# Use of this source code is governed by a BSD-3-clause license that can be
+# found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+
+import coremltools as ct
+from coremltools import __version__ as ct_version
+
+from ._tree_ensemble import convert_tree_ensemble as _convert_tree_ensemble
+
+
+def convert(
+    model,
+    feature_names=None,
+    target="target",
+    force_32bit_float=True,
+    mode="classifier",
+    class_labels=None,
+    n_classes=None,
+):
+    """Convert a trained LightGBM model to Core ML format.
+
+    Parameters
+    ----------
+    model : lightgbm.Booster, lightgbm.LGBMClassifier, or lightgbm.LGBMRegressor
+        Trained LightGBM model.
+
+    feature_names : list of str or None
+        Names of input features exposed in the Core ML model interface.
+        When ``None``, feature names are taken from the model.
+
+    target : str
+        Name of the output feature exposed in the Core ML model.
+
+    force_32bit_float : bool
+        When ``True``, threshold and leaf values are cast to float32 to match
+        LightGBM's internal precision and enable the tree-ensemble compiler's
+        float32 optimisation path.
+
+    mode : str in ['regressor', 'classifier']
+        Conversion mode. Defaults to ``'classifier'``.
+
+    class_labels : list or None
+        Class labels for the classifier output. Defaults to ``range(n_classes)``.
+
+    n_classes : int or None
+        Number of output classes. Inferred from the model when not provided.
+
+    Returns
+    -------
+    model : coremltools.models.MLModel
+        Core ML model wrapping a ``TreeEnsembleClassifier`` or
+        ``TreeEnsembleRegressor`` spec.
+
+    Notes
+    -----
+    Models trained with categorical features (LightGBM ``"=="`` splits) are not
+    supported and raise ``NotImplementedError``. One-hot encode categorical
+    inputs before training to convert such models.
+
+    Examples
+    --------
+    .. sourcecode:: python
+
+        >>> import coremltools
+        >>> coreml_model = coremltools.converters.lightgbm.convert(
+        ...     lgbm_model,
+        ...     feature_names=feature_names,
+        ...     target="walkout_probability",
+        ... )
+        >>> coreml_model.save("model.mlpackage")
+    """
+    spec = _convert_tree_ensemble(
+        model,
+        feature_names,
+        target,
+        force_32bit_float=force_32bit_float,
+        mode=mode,
+        class_labels=class_labels,
+        n_classes=n_classes,
+    )
+    coreml_model = ct.models.MLModel(spec)
+
+    try:
+        from lightgbm import __version__ as lgbm_version
+        source_str = "lightgbm=={0}".format(lgbm_version)
+    except Exception:
+        source_str = "lightgbm"
+
+    coreml_model.user_defined_metadata[ct.models._METADATA_VERSION] = ct_version
+    coreml_model.user_defined_metadata[ct.models._METADATA_SOURCE] = source_str
+
+    return coreml_model

--- a/coremltools/converters/lightgbm/_tree_ensemble.py
+++ b/coremltools/converters/lightgbm/_tree_ensemble.py
@@ -1,0 +1,264 @@
+# Copyright (c) 2026, Apple Inc. All rights reserved.
+#
+# Use of this source code is governed by a BSD-3-clause license that can be
+# found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+
+import numpy as _np
+
+from ..._deps import _HAS_LIGHTGBM
+from ...models.tree_ensemble import TreeEnsembleClassifier
+from ...models.tree_ensemble import TreeEnsembleRegressor as _TreeEnsembleRegressor
+
+if _HAS_LIGHTGBM:
+    import lightgbm as _lightgbm
+
+
+def _recurse_node(
+    mlkit_tree,
+    lgb_node,
+    tree_id,
+    node_id,
+    force_32bit_float,
+    mode,
+    tree_index,
+    n_classes,
+    id_counter,
+    leaf_scale,
+):
+    """Recursively traverse a LightGBM tree node and append to the CoreML tree spec.
+
+    LightGBM uses a nested dict structure (left_child/right_child) rather than
+    XGBoost's flat nodeid references, so we assign node IDs ourselves via id_counter.
+    id_counter is a one-element list mutated in place to share state across recursive calls.
+
+    leaf_scale multiplies every leaf value before it is written. It is the binary
+    objective's ``sigmoid`` coefficient (1.0 otherwise): because
+    ``1 / (1 + exp(-s * sum(leaf))) == 1 / (1 + exp(-sum(s * leaf)))``, pre-scaling
+    the leaves lets the fixed Regression_Logistic transform reproduce LightGBM's
+    probabilities exactly.
+    """
+    relative_hit_rate = lgb_node.get("internal_weight") or lgb_node.get("leaf_weight")
+
+    if "split_feature" in lgb_node:
+        # Branch node
+        decision_type = lgb_node.get("decision_type", "<=")
+        if decision_type != "<=":
+            # LightGBM uses "==" for categorical splits, where the threshold is a
+            # "1||3"-style set of category values rather than a scalar. Core ML's
+            # tree ensemble cannot represent set membership in a single branch, so
+            # fail loudly instead of crashing on float(threshold) downstream.
+            raise NotImplementedError(
+                "LightGBM categorical splits (decision_type '%s') are not supported "
+                "by the Core ML converter. Train without categorical_feature, or "
+                "one-hot encode categorical inputs before training." % decision_type
+            )
+        feature_index = lgb_node["split_feature"]
+        feature_value = lgb_node["threshold"]
+        if force_32bit_float:
+            feature_value = float(_np.float32(feature_value))
+
+        # LightGBM decision_type is "<=" for numerical splits → BranchOnValueLessThanEqual
+        branch_mode = "BranchOnValueLessThanEqual"
+
+        # Assign child IDs now (we claim them from id_counter)
+        true_child_id = id_counter[0]
+        id_counter[0] += 1
+        false_child_id = id_counter[0]
+        id_counter[0] += 1
+
+        # default_left=True means missing values go to left child (the true branch)
+        missing_value_tracks_true_child = lgb_node.get("default_left", False)
+
+        mlkit_tree.add_branch_node(
+            tree_id,
+            node_id,
+            feature_index,
+            feature_value,
+            branch_mode,
+            true_child_id,
+            false_child_id,
+            relative_hit_rate=relative_hit_rate,
+            missing_value_tracks_true_child=missing_value_tracks_true_child,
+        )
+
+        # Recurse into children using the pre-assigned IDs
+        _recurse_node(
+            mlkit_tree,
+            lgb_node["left_child"],
+            tree_id,
+            true_child_id,
+            force_32bit_float,
+            mode,
+            tree_index,
+            n_classes,
+            id_counter,
+            leaf_scale,
+        )
+        _recurse_node(
+            mlkit_tree,
+            lgb_node["right_child"],
+            tree_id,
+            false_child_id,
+            force_32bit_float,
+            mode,
+            tree_index,
+            n_classes,
+            id_counter,
+            leaf_scale,
+        )
+    else:
+        # Leaf node
+        value = lgb_node["leaf_value"]
+        if leaf_scale != 1.0:
+            value = value * leaf_scale
+        if force_32bit_float:
+            value = float(_np.float32(value))
+
+        if mode == "classifier" and n_classes > 2:
+            value = {tree_index: value}
+
+        mlkit_tree.add_leaf_node(
+            tree_id, node_id, value, relative_hit_rate=relative_hit_rate
+        )
+
+
+def convert_tree_ensemble(
+    model,
+    feature_names,
+    target,
+    force_32bit_float,
+    mode="classifier",
+    class_labels=None,
+    n_classes=None,
+):
+    """Convert a LightGBM model to a CoreML protobuf tree ensemble spec.
+
+    Parameters
+    ----------
+    model : lightgbm.Booster or lightgbm.LGBMClassifier or lightgbm.LGBMRegressor
+        Trained LightGBM model.
+    feature_names : list of str or None
+        Names of input features. When None, taken from the model.
+    target : str
+        Name of the output feature in the CoreML model.
+    force_32bit_float : bool
+        Cast threshold/leaf values to float32 to match LightGBM's internal precision.
+    mode : str in ['regressor', 'classifier']
+        Conversion mode.
+    class_labels : list or None
+        Class label list for classifiers. Defaults to ``range(n_classes)``.
+    n_classes : int or None
+        Number of classes. Inferred from model when not provided.
+
+    Returns
+    -------
+    spec : Model_pb2.Model
+        Protobuf spec ready to wrap in ``coremltools.models.MLModel``.
+    """
+    if not _HAS_LIGHTGBM:
+        raise RuntimeError(
+            "LightGBM not found. LightGBM conversion API is disabled."
+        )
+    accepted_modes = ["regressor", "classifier"]
+    if mode not in accepted_modes:
+        raise ValueError("mode must be one of %s" % accepted_modes)
+
+    # ------------------------------------------------------------------ #
+    # Resolve model → Booster and feature_names                           #
+    # ------------------------------------------------------------------ #
+    if isinstance(model, (_lightgbm.LGBMClassifier, _lightgbm.LGBMRegressor)):
+        if isinstance(model, _lightgbm.LGBMClassifier) and mode == "regressor":
+            raise ValueError("mode is 'regressor' but a LGBMClassifier was provided.")
+        if isinstance(model, _lightgbm.LGBMRegressor) and mode == "classifier":
+            raise ValueError("mode is 'classifier' but a LGBMRegressor was provided.")
+
+        booster = model.booster_
+        if feature_names is None:
+            feature_names = booster.feature_name()
+
+        if isinstance(model, _lightgbm.LGBMClassifier) and n_classes is None:
+            n_classes = model.n_classes_
+
+    elif isinstance(model, _lightgbm.Booster):
+        booster = model
+        if feature_names is None:
+            feature_names = booster.feature_name()
+    else:
+        raise TypeError(
+            "Unexpected model type %s. "
+            "Expected lightgbm.Booster, LGBMClassifier, or LGBMRegressor." % type(model)
+        )
+
+    # ------------------------------------------------------------------ #
+    # Dump model to dict                                                   #
+    # ------------------------------------------------------------------ #
+    dump = booster.dump_model()
+
+    if n_classes is None:
+        # num_tree_per_iteration == 1 for binary; > 1 for multiclass
+        n_classes = max(dump.get("num_tree_per_iteration", 1), 1)
+        if n_classes == 1:
+            # binary classification or regression — treat as 2-class for classifier
+            if mode == "classifier":
+                n_classes = 2
+
+    # ------------------------------------------------------------------ #
+    # Build CoreML tree ensemble                                           #
+    # ------------------------------------------------------------------ #
+    if mode == "classifier":
+        if class_labels is None:
+            class_labels = list(range(n_classes))
+        if len(class_labels) != n_classes:
+            raise ValueError(
+                "Number of classes in model (%d) does not match "
+                "length of class_labels (%d)." % (n_classes, len(class_labels))
+            )
+
+        base_prediction = [0.0] if n_classes == 2 else [0.0] * n_classes
+        mlkit_tree = TreeEnsembleClassifier(feature_names, class_labels, target)
+        mlkit_tree.set_default_prediction_value(base_prediction)
+        if n_classes == 2:
+            mlkit_tree.set_post_evaluation_transform("Regression_Logistic")
+        else:
+            mlkit_tree.set_post_evaluation_transform("Classification_SoftMax")
+    else:
+        mlkit_tree = _TreeEnsembleRegressor(feature_names, target)
+        mlkit_tree.set_default_prediction_value(0.0)
+
+    num_tree_per_iter = dump.get("num_tree_per_iteration", 1)
+
+    # LightGBM's binary objective applies a sigmoid coefficient s:
+    # proba = 1 / (1 + exp(-s * raw_score)). The dump records it in the objective
+    # string, e.g. "binary sigmoid:2". Core ML's Regression_Logistic transform has
+    # no such coefficient, so we fold s into the leaf values (see _recurse_node).
+    # It only applies to the binary classifier path; multiclass uses softmax.
+    leaf_scale = 1.0
+    if mode == "classifier" and n_classes == 2:
+        objective = dump.get("objective", "") or ""
+        for token in objective.split():
+            if token.startswith("sigmoid:"):
+                try:
+                    leaf_scale = float(token.split(":", 1)[1])
+                except ValueError:
+                    leaf_scale = 1.0
+
+    for tree_id, tree_info in enumerate(dump["tree_info"]):
+        tree_index = tree_id % num_tree_per_iter  # class index for multiclass
+        root = tree_info["tree_structure"]
+        # id_counter[0] is the next free node ID within this tree.
+        # Root always gets 0; children are assigned in pre-order.
+        id_counter = [1]
+        _recurse_node(
+            mlkit_tree,
+            root,
+            tree_id,
+            node_id=0,
+            force_32bit_float=force_32bit_float,
+            mode=mode,
+            tree_index=tree_index,
+            n_classes=n_classes,
+            id_counter=id_counter,
+            leaf_scale=leaf_scale,
+        )
+
+    return mlkit_tree.spec

--- a/coremltools/test/api/test_api_visibilities.py
+++ b/coremltools/test/api/test_api_visibilities.py
@@ -176,6 +176,7 @@ class TestApiVisibilities:
             "TensorType",
             "convert",
             "libsvm",
+            "lightgbm",
             "mil",
             "sklearn",
             "xgboost",
@@ -211,6 +212,9 @@ class TestApiVisibilities:
 
     def test_converters_libsvm(self):
         _check_visible_modules(_get_visible_items(ct.converters.libsvm), ["convert"])
+
+    def test_converters_lightgbm(self):
+        _check_visible_modules(_get_visible_items(ct.converters.lightgbm), ["convert"])
 
     def test_converters_sklearn(self):
         _check_visible_modules(_get_visible_items(ct.converters.sklearn), ["convert"])

--- a/coremltools/test/lightgbm_tests/test_boosted_trees_classifier.py
+++ b/coremltools/test/lightgbm_tests/test_boosted_trees_classifier.py
@@ -1,0 +1,354 @@
+# Copyright (c) 2026, Apple Inc. All rights reserved.
+#
+# Use of this source code is governed by a BSD-3-clause license that can be
+# found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+
+import unittest
+
+import numpy as np
+
+from coremltools._deps import _HAS_LIGHTGBM, _HAS_SKLEARN, MSG_LIGHTGBM_NOT_FOUND
+
+if _HAS_LIGHTGBM:
+    import lightgbm as lgb
+    from coremltools.converters import lightgbm as lgb_converter
+
+if _HAS_SKLEARN:
+    from sklearn.datasets import make_classification
+
+
+def _sigmoid(x):
+    return 1.0 / (1.0 + np.exp(-x))
+
+
+def _eval_coreml_spec(spec, X):
+    """Manually traverse the CoreML TreeEnsemble spec to produce probabilities.
+
+    Used for numerical validation without needing the CoreML runtime.
+    """
+    ens = spec.treeEnsembleClassifier.treeEnsemble
+    node_map = {(n.treeId, n.nodeId): n for n in ens.nodes}
+    LEAF = 6  # LeafNode enum value
+
+    def eval_tree(tree_id, x):
+        n = node_map[(tree_id, 0)]
+        while n.nodeBehavior != LEAF:
+            fv = x[n.branchFeatureIndex]
+            go_true = (
+                n.missingValueTracksTrueChild
+                if np.isnan(fv)
+                else fv <= n.branchFeatureValue
+            )
+            n = node_map[
+                (tree_id, n.trueChildNodeId if go_true else n.falseChildNodeId)
+            ]
+        return n.evaluationInfo[0].evaluationValue
+
+    num_trees = max(t for t, _ in node_map) + 1
+    probs = []
+    for row in X:
+        total = sum(eval_tree(tid, row) for tid in range(num_trees))
+        probs.append(_sigmoid(total))
+    return np.array(probs)
+
+
+def _eval_coreml_regressor(spec, X):
+    """Manually traverse a CoreML TreeEnsembleRegressor spec to produce values."""
+    ens = spec.treeEnsembleRegressor.treeEnsemble
+    node_map = {(n.treeId, n.nodeId): n for n in ens.nodes}
+    base = list(ens.basePredictionValue)
+    LEAF = 6
+
+    def eval_tree(tree_id, x):
+        n = node_map[(tree_id, 0)]
+        while n.nodeBehavior != LEAF:
+            fv = x[n.branchFeatureIndex]
+            go_true = (
+                n.missingValueTracksTrueChild
+                if np.isnan(fv)
+                else fv <= n.branchFeatureValue
+            )
+            n = node_map[
+                (tree_id, n.trueChildNodeId if go_true else n.falseChildNodeId)
+            ]
+        return n.evaluationInfo[0].evaluationValue
+
+    num_trees = max(t for t, _ in node_map) + 1
+    out = []
+    for row in X:
+        total = sum(eval_tree(tid, row) for tid in range(num_trees))
+        total += base[0] if base else 0.0
+        out.append(total)
+    return np.array(out)
+
+
+def _eval_coreml_multiclass(spec, X, n_classes):
+    """Manually traverse a multiclass CoreML spec and apply softmax."""
+    ens = spec.treeEnsembleClassifier.treeEnsemble
+    node_map = {(n.treeId, n.nodeId): n for n in ens.nodes}
+    LEAF = 6
+
+    def eval_tree(tree_id, x):
+        n = node_map[(tree_id, 0)]
+        while n.nodeBehavior != LEAF:
+            fv = x[n.branchFeatureIndex]
+            go_true = (
+                n.missingValueTracksTrueChild
+                if np.isnan(fv)
+                else fv <= n.branchFeatureValue
+            )
+            n = node_map[
+                (tree_id, n.trueChildNodeId if go_true else n.falseChildNodeId)
+            ]
+        ev = n.evaluationInfo[0]
+        return ev.evaluationIndex, ev.evaluationValue
+
+    num_trees = max(t for t, _ in node_map) + 1
+    out = []
+    for row in X:
+        scores = np.zeros(n_classes)
+        for tid in range(num_trees):
+            cls, val = eval_tree(tid, row)
+            scores[cls] += val
+        e = np.exp(scores - scores.max())
+        out.append(e / e.sum())
+    return np.array(out)
+
+
+@unittest.skipIf(not _HAS_LIGHTGBM, MSG_LIGHTGBM_NOT_FOUND)
+@unittest.skipIf(not _HAS_SKLEARN, "scikit-learn not installed. Skipping tests.")
+class LightGBMBinaryClassifierTest(unittest.TestCase):
+    """Unit tests for the LightGBM → CoreML binary classifier converter."""
+
+    @classmethod
+    def setUpClass(cls):
+        X, y = make_classification(
+            n_samples=500,
+            n_features=20,
+            n_informative=10,
+            random_state=42,
+        )
+        cls.feature_names = [f"feat_{i}" for i in range(X.shape[1])]
+        clf = lgb.LGBMClassifier(n_estimators=50, num_leaves=8, random_state=42)
+        clf.fit(X, y, feature_name=cls.feature_names)
+        cls.model = clf
+        cls.X = X.astype(np.float32)
+        cls.y = y
+
+    def test_spec_type(self):
+        spec = lgb_converter.convert(
+            self.model,
+            feature_names=self.feature_names,
+            target="label",
+        ).get_spec()
+        self.assertIsNotNone(spec)
+        self.assertEqual(spec.WhichOneof("Type"), "treeEnsembleClassifier")
+
+    def test_class_labels(self):
+        spec = lgb_converter.convert(
+            self.model,
+            feature_names=self.feature_names,
+            target="label",
+            class_labels=[0, 1],
+        ).get_spec()
+        labels = list(spec.treeEnsembleClassifier.int64ClassLabels.vector)
+        self.assertEqual(labels, [0, 1])
+
+    def test_tree_count(self):
+        spec = lgb_converter.convert(
+            self.model,
+            feature_names=self.feature_names,
+            target="label",
+        ).get_spec()
+        ens = spec.treeEnsembleClassifier.treeEnsemble
+        tree_ids = {n.treeId for n in ens.nodes}
+        self.assertEqual(len(tree_ids), self.model.n_estimators)
+
+    def test_post_eval_transform(self):
+        """Binary classifier must use Regression_Logistic (value 2)."""
+        spec = lgb_converter.convert(
+            self.model,
+            feature_names=self.feature_names,
+            target="label",
+        ).get_spec()
+        # Regression_Logistic = 2 in the enum
+        self.assertEqual(
+            spec.treeEnsembleClassifier.postEvaluationTransform, 2
+        )
+
+    def test_numerical_accuracy(self):
+        """Converted spec must match LightGBM predictions within float32 tolerance."""
+        spec = lgb_converter.convert(
+            self.model,
+            feature_names=self.feature_names,
+            target="label",
+        ).get_spec()
+
+        lgb_probs = self.model.predict_proba(self.X[:20])[:, 1]
+        coreml_probs = _eval_coreml_spec(spec, self.X[:20])
+
+        max_err = np.max(np.abs(lgb_probs - coreml_probs))
+        self.assertLess(max_err, 1e-5, f"Max abs error {max_err} exceeds 1e-5")
+
+    def test_feature_names_from_model(self):
+        """When feature_names=None, names should be taken from the booster."""
+        spec = lgb_converter.convert(
+            self.model,
+            feature_names=None,
+            target="label",
+        ).get_spec()
+        input_names = [inp.name for inp in spec.description.input]
+        self.assertEqual(sorted(input_names), sorted(self.feature_names))
+
+    def test_metadata(self):
+        import coremltools as ct
+        model = lgb_converter.convert(
+            self.model,
+            feature_names=self.feature_names,
+            target="label",
+        )
+        self.assertIn(ct.models._METADATA_VERSION, model.user_defined_metadata)
+        src = model.user_defined_metadata[ct.models._METADATA_SOURCE]
+        self.assertIn("lightgbm", src)
+
+    def test_booster_input(self):
+        """Passing a raw Booster object should also work."""
+        booster = self.model.booster_
+        spec = lgb_converter.convert(
+            booster,
+            feature_names=self.feature_names,
+            target="label",
+            mode="classifier",
+            class_labels=[0, 1],
+        ).get_spec()
+        self.assertEqual(spec.WhichOneof("Type"), "treeEnsembleClassifier")
+
+    def test_invalid_mode_raises(self):
+        with self.assertRaises(ValueError):
+            lgb_converter.convert(
+                self.model,
+                feature_names=self.feature_names,
+                target="label",
+                mode="invalid_mode",
+            )
+
+    def test_nondefault_sigmoid(self):
+        """A binary model trained with sigmoid != 1.0 must still match.
+
+        LightGBM's binary proba is 1/(1+exp(-sigmoid*raw)); the converter folds
+        the sigmoid coefficient into the leaf values so Regression_Logistic
+        reproduces it exactly.
+        """
+        clf = lgb.LGBMClassifier(
+            n_estimators=20, num_leaves=8, sigmoid=2.0, random_state=42
+        )
+        clf.fit(self.X, self.y, feature_name=self.feature_names)
+        spec = lgb_converter.convert(
+            clf, feature_names=self.feature_names, target="label"
+        ).get_spec()
+
+        lgb_probs = clf.predict_proba(self.X[:20])[:, 1]
+        coreml_probs = _eval_coreml_spec(spec, self.X[:20])
+        max_err = np.max(np.abs(lgb_probs - coreml_probs))
+        self.assertLess(max_err, 1e-5, f"Max abs error {max_err} exceeds 1e-5")
+
+    def test_categorical_split_raises(self):
+        """Categorical ('==') splits are unsupported and must raise clearly."""
+        rng = np.random.RandomState(0)
+        cat = rng.randint(0, 5, size=600).astype(np.float64)
+        num = rng.randn(600)
+        X = np.column_stack([cat, num])
+        y = ((cat == 1) | (cat == 3)).astype(int)
+        clf = lgb.LGBMClassifier(n_estimators=15, num_leaves=8, random_state=0)
+        clf.fit(X, y, categorical_feature=[0])
+        with self.assertRaises(NotImplementedError):
+            lgb_converter.convert(clf, feature_names=["c", "x"], target="label")
+
+
+@unittest.skipIf(not _HAS_LIGHTGBM, MSG_LIGHTGBM_NOT_FOUND)
+@unittest.skipIf(not _HAS_SKLEARN, "scikit-learn not installed. Skipping tests.")
+class LightGBMRegressorTest(unittest.TestCase):
+    """Unit tests for the LightGBM → CoreML regressor converter."""
+
+    @classmethod
+    def setUpClass(cls):
+        from sklearn.datasets import make_regression
+
+        X, y = make_regression(n_samples=300, n_features=15, random_state=42)
+        cls.feature_names = [f"feat_{i}" for i in range(X.shape[1])]
+        reg = lgb.LGBMRegressor(n_estimators=30, num_leaves=8, random_state=42)
+        reg.fit(X, y, feature_name=cls.feature_names)
+        cls.model = reg
+        cls.X = X.astype(np.float32)
+
+    def test_spec_type(self):
+        spec = lgb_converter.convert(
+            self.model,
+            feature_names=self.feature_names,
+            target="value",
+            mode="regressor",
+        ).get_spec()
+        self.assertEqual(spec.WhichOneof("Type"), "treeEnsembleRegressor")
+
+    def test_numerical_accuracy(self):
+        """Converted regressor must match LightGBM predictions.
+
+        Guards against losing LightGBM's boost_from_average initial score, which
+        is baked into the leaf values rather than carried as a base prediction.
+        """
+        spec = lgb_converter.convert(
+            self.model,
+            feature_names=self.feature_names,
+            target="value",
+            mode="regressor",
+        ).get_spec()
+
+        lgb_pred = self.model.predict(self.X[:20])
+        coreml_pred = _eval_coreml_regressor(spec, self.X[:20])
+        max_err = np.max(np.abs(lgb_pred - coreml_pred))
+        self.assertLess(max_err, 1e-3, f"Max abs error {max_err} exceeds 1e-3")
+
+
+@unittest.skipIf(not _HAS_LIGHTGBM, MSG_LIGHTGBM_NOT_FOUND)
+@unittest.skipIf(not _HAS_SKLEARN, "scikit-learn not installed. Skipping tests.")
+class LightGBMMulticlassClassifierTest(unittest.TestCase):
+    """Unit tests for the LightGBM → CoreML multiclass classifier converter."""
+
+    @classmethod
+    def setUpClass(cls):
+        X, y = make_classification(
+            n_samples=600,
+            n_features=20,
+            n_informative=12,
+            n_classes=4,
+            random_state=1,
+        )
+        cls.n_classes = 4
+        cls.feature_names = [f"feat_{i}" for i in range(X.shape[1])]
+        clf = lgb.LGBMClassifier(n_estimators=25, num_leaves=8, random_state=1)
+        clf.fit(X, y, feature_name=cls.feature_names)
+        cls.model = clf
+        cls.X = X.astype(np.float32)
+
+    def test_post_eval_transform(self):
+        """Multiclass classifier must use Classification_SoftMax (value 1)."""
+        spec = lgb_converter.convert(
+            self.model, feature_names=self.feature_names, target="label"
+        ).get_spec()
+        # Classification_SoftMax = 1 in the enum
+        self.assertEqual(spec.treeEnsembleClassifier.postEvaluationTransform, 1)
+
+    def test_numerical_accuracy(self):
+        """Converted multiclass spec must match predict_proba within tolerance."""
+        spec = lgb_converter.convert(
+            self.model, feature_names=self.feature_names, target="label"
+        ).get_spec()
+
+        lgb_proba = self.model.predict_proba(self.X[:20])
+        coreml_proba = _eval_coreml_multiclass(spec, self.X[:20], self.n_classes)
+        max_err = np.max(np.abs(lgb_proba - coreml_proba))
+        self.assertLess(max_err, 1e-5, f"Max abs error {max_err} exceeds 1e-5")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/reqs/test.pip
+++ b/reqs/test.pip
@@ -13,6 +13,8 @@ scipy; platform_machine == "arm64"
 
 xgboost==1.4.2; platform_machine != "arm64"
 
+lightgbm==4.6.0
+
 # coremltools.optimize.torch
 filelock==3.6.0
 pytest-flake8==1.0.7


### PR DESCRIPTION
## Summary
coremltools can convert scikit-learn, XGBoost, and LibSVM models but has
no LightGBM support. This adds a LightGBM → Core ML converter.

`coremltools.converters.lightgbm.convert` supports `Booster`,
`LGBMClassifier`, and `LGBMRegressor` for binary/multiclass
classification and regression, mirroring the existing xgboost converter.
Implemented on top of the latest `main`.

- Add lightgbm converter in `coremltools/converters/lightgbm`
- Add lightgbm converter unit tests in `coremltools/test/lightgbm_tests`

Previous PR #254 can also be closed.

## Testing Plan
All unit tests pass.