### PR TITLE
Fix tf.random ops being folded into constants during conversion

### DIFF
--- a/coremltools/converters/mil/frontend/tensorflow/basic_graph_ops.py
+++ b/coremltools/converters/mil/frontend/tensorflow/basic_graph_ops.py
@@ -242,6 +242,11 @@ def check_connections(gd):
             assert k in control_inputs
 
 
+# Random ops are nondeterministic even when their shape input is constant, so they
+# must not be folded. Exact names (not substring) leave RandomUniformInt etc. alone. #2204
+_TF_NONDETERMINISTIC_OPS = ["RandomUniform", "RandomStandardNormal", "Multinomial"]
+
+
 def const_determined_nodes(gd, assume_variable_nodes=None):
     """
     Given a graph, extract all nodes that only depends on const nodes.
@@ -273,6 +278,8 @@ def const_determined_nodes(gd, assume_variable_nodes=None):
         elif "global" in node.op:
             vis[node.name] = False
         elif "FakeQuant" in node.op:
+            vis[node.name] = False
+        elif node.op in _TF_NONDETERMINISTIC_OPS:
             vis[node.name] = False
         elif node.name in assume_variable_nodes:
             vis[node.name] = False

--- a/coremltools/converters/mil/frontend/tensorflow/test/test_ops.py
+++ b/coremltools/converters/mil/frontend/tensorflow/test/test_ops.py
@@ -3695,6 +3695,41 @@ class TestRandom(TensorFlowBaseTest):
         )
 
     @pytest.mark.parametrize(
+        "compute_unit, backend, tf_op",
+        itertools.product(compute_units, backends, ["uniform", "normal", "categorical"]),
+    )
+    def test_random_op_not_folded(self, compute_unit, backend, tf_op):
+        # A random op with a constant shape must stay in the converted model, not be
+        # folded to a const (#2204). ct.convert directly because run_compare_tf would
+        # compare TF and CoreML outputs, which differ for a nondeterministic op.
+        if tf_op == "uniform":
+            op = lambda x: x + tf.random.uniform((1, 4), minval=0.0, maxval=1.0)
+            mil_op, nn_layer = "random_uniform", "randomUniformStatic"
+        elif tf_op == "normal":
+            op = lambda x: x + tf.random.normal((1, 4), mean=0.0, stddev=1.0)
+            mil_op, nn_layer = "random_normal", "randomNormalStatic"
+        else:
+            op = lambda x: x + tf.cast(tf.random.categorical(tf.ones((1, 4)), 4), tf.float32)
+            mil_op, nn_layer = "random_categorical", "categoricalDistribution"
+
+        @make_tf_graph([[1, 4]])
+        def build_model(x):
+            return op(x)
+
+        model, _, _ = build_model
+        mlmodel = ct.convert(
+            model,
+            source="tensorflow",
+            convert_to=backend[0],
+            compute_units=compute_unit,
+            minimum_deployment_target=ct.target.iOS15 if backend[0] == "mlprogram" else None,
+        )
+        if backend[0] == "mlprogram":
+            assert TestRandom._op_count_in_mil_program(mlmodel, mil_op) == 1
+        else:
+            assert layer_counts(mlmodel._spec, nn_layer) == 1
+
+    @pytest.mark.parametrize(
         "compute_unit, backend, low, high, rank, constant",
         itertools.product(
             compute_units,


### PR DESCRIPTION
`const_determined_nodes` treats a TF random op as constant when its only input is the shape, which is itself constant. `constant_propagation` then evaluates the op once and `delete_unnecessary_constant_nodes` turns it into a `Const`, so the exported model returns the same draw on every prediction. These passes run before MIL conversion, so both `neuralnetwork` and `mlprogram` are affected.

`RandomUniform`, `RandomStandardNormal` and `Multinomial` now join the nodes that are never folded, next to the existing `Variable`/`Placeholder`/`FakeQuant` cases. All three already have MIL handlers, so they convert to real `random_uniform`/`random_normal`/`random_categorical` ops. The match is exact, so random ops without a converter (`RandomUniformInt`, `TruncatedNormal`, the `Stateless*` ops) keep folding as they do today rather than becoming a hard conversion error. They can be added later once they have MIL handlers.

`test_random_op_not_folded` covers all three ops on both backends and fails on main without the fix.

Fixes #2204.
