### PR TITLE
Preserve integer dtype in torch div() with rounding_mode (fixes #2733)

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -1985,8 +1985,8 @@ def div(context, node):
         inputs = _get_inputs(context, node, expected=[2, 3])
         nargs = len(inputs)
 
-        x = mb.cast(x=inputs[0], dtype="fp32")
-        y = mb.cast(x=inputs[1], dtype="fp32")
+        x = inputs[0]
+        y = inputs[1]
         if nargs < 3:
             rounding_mode = None
         else:
@@ -2005,13 +2005,25 @@ def div(context, node):
     x, y, rounding_mode = _parse_positional_args(context, node)
     rounding_mode = _parse_keyword_args(context, node, rounding_mode)
 
+    # With a rounding mode, torch.div preserves the integer dtype when both operands
+    # are integers, e.g. torch.div(7, 2, rounding_mode="floor") -> 3 (not 3.0).
+    # Without a rounding mode torch.div always performs true division and returns a
+    # float. The arithmetic below is carried out in fp32, so the integer result must
+    # be cast back to int to match torch instead of leaking an fp32 output.
+    is_integer_output = (
+        rounding_mode is not None and types.is_int(x.dtype) and types.is_int(y.dtype)
+    )
+
+    x = mb.cast(x=x, dtype="fp32")
+    y = mb.cast(x=y, dtype="fp32")
+
     if rounding_mode is not None:
         if rounding_mode == "floor":
             # round towards negative infinity
             # e.g.:
             # values before floor: [2.6, -3.4, -3.6]
             # values after floor: [2, -4, -4]
-            res = mb.floor_div(x=x, y=y, name=node.name)
+            res = mb.floor_div(x=x, y=y)
         elif rounding_mode == "trunc":
             # round towards 0
             # e.g.:
@@ -2021,11 +2033,12 @@ def div(context, node):
             s = mb.sign(x=z)
             all_positive = mb.mul(x=z, y=s)
             all_positive_floor = mb.floor(x=all_positive)
-            res = mb.mul(x=all_positive_floor, y=s, name=node.name)
+            res = mb.mul(x=all_positive_floor, y=s)
         else:
             raise NotImplementedError(
                 'rounding mode "{}" not supported in the "div" op'.format(rounding_mode)
             )
+        res = mb.cast(x=res, dtype="int32" if is_integer_output else "fp32", name=node.name)
     else:
         res = mb.real_div(x=x, y=y, name=node.name)
 

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -2005,11 +2005,7 @@ def div(context, node):
     x, y, rounding_mode = _parse_positional_args(context, node)
     rounding_mode = _parse_keyword_args(context, node, rounding_mode)
 
-    # With a rounding mode, torch.div preserves the integer dtype when both operands
-    # are integers, e.g. torch.div(7, 2, rounding_mode="floor") -> 3 (not 3.0).
-    # Without a rounding mode torch.div always performs true division and returns a
-    # float. The arithmetic below is carried out in fp32, so the integer result must
-    # be cast back to int to match torch instead of leaking an fp32 output.
+    # torch.div preserves int dtype with a rounding_mode; cast back after fp32 arithmetic
     is_integer_output = (
         rounding_mode is not None and types.is_int(x.dtype) and types.is_int(y.dtype)
     )

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -6803,11 +6803,7 @@ class TestActivation(TorchBaseTest):
         itertools.product(compute_units, backends, frontends, ["floor", "trunc"]),
     )
     def test_div_integer_dtype(self, compute_unit, backend, frontend, rounding_mode):
-        # When a rounding mode is given, torch.div preserves the integer dtype if
-        # both operands are integers, e.g. div(7, 2, rounding_mode="floor") -> 3
-        # (not 3.0). The converter used to always cast the operands to fp32, so an
-        # all-integer division leaked an fp32 result. Use negative operands as well
-        # to cover the floor (towards -inf) vs trunc (towards 0) distinction.
+        # negative operands distinguish floor (towards -inf) from trunc (towards zero)
         model = ModuleWrapper(function=torch.div, kwargs={"rounding_mode": rounding_mode})
         x1 = torch.from_numpy(np.array([10, -10, 7, -7], dtype=np.int32))
         x2 = torch.from_numpy(np.array([3, 3, 2, 2], dtype=np.int32))
@@ -6821,11 +6817,7 @@ class TestActivation(TorchBaseTest):
             input_as_shape=False,
             expected_results=out,
         )
-        # The numerical check above passes even without the fix, since the integer
-        # quotient is exactly representable as a float too. The fix is about dtype:
-        # an all-integer division must come back as integers on the ML Program
-        # backend (it was fp32 before). NeuralNetwork always serializes outputs as
-        # float, so the distinction is only observable on mlprogram.
+        # mlprogram preserves output dtype; neuralnetwork always returns float
         if backend[0] == "mlprogram":
             prediction = list(res[3].values())[0]
             assert np.issubdtype(prediction.dtype, np.integer), (

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -6798,6 +6798,41 @@ class TestActivation(TorchBaseTest):
             expected_results=out,
         )
 
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend, rounding_mode",
+        itertools.product(compute_units, backends, frontends, ["floor", "trunc"]),
+    )
+    def test_div_integer_dtype(self, compute_unit, backend, frontend, rounding_mode):
+        # When a rounding mode is given, torch.div preserves the integer dtype if
+        # both operands are integers, e.g. div(7, 2, rounding_mode="floor") -> 3
+        # (not 3.0). The converter used to always cast the operands to fp32, so an
+        # all-integer division leaked an fp32 result. Use negative operands as well
+        # to cover the floor (towards -inf) vs trunc (towards 0) distinction.
+        model = ModuleWrapper(function=torch.div, kwargs={"rounding_mode": rounding_mode})
+        x1 = torch.from_numpy(np.array([10, -10, 7, -7], dtype=np.int32))
+        x2 = torch.from_numpy(np.array([3, 3, 2, 2], dtype=np.int32))
+        out = torch.div(x1, x2, rounding_mode=rounding_mode)
+        res = self.run_compare_torch(
+            [x1, x2],
+            model,
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+            input_as_shape=False,
+            expected_results=out,
+        )
+        # The numerical check above passes even without the fix, since the integer
+        # quotient is exactly representable as a float too. The fix is about dtype:
+        # an all-integer division must come back as integers on the ML Program
+        # backend (it was fp32 before). NeuralNetwork always serializes outputs as
+        # float, so the distinction is only observable on mlprogram.
+        if backend[0] == "mlprogram":
+            prediction = list(res[3].values())[0]
+            assert np.issubdtype(prediction.dtype, np.integer), (
+                f"div(int, int, rounding_mode={rounding_mode!r}) should predict "
+                f"integers on mlprogram, got {prediction.dtype}"
+            )
+
 
 class TestElementWiseUnary(TorchBaseTest):
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

`torch.div(a, b, rounding_mode="floor"|"trunc")` preserves the integer dtype when both operands are integers (e.g. `div(7, 2, rounding_mode="floor")` → `3`, not `3.0`); only true division (no rounding mode) returns a float. The PyTorch frontend `div` converter cast both operands to `fp32` up front and never cast the rounded result back, so an all-integer division produced an **fp32** output on the ML Program backend — diverging from PyTorch's contract.

Fixes #2733.

This is a different code path from `floor_divide` (#2570 / #2681); that fix only touches the `floor_divide` converter and does not cover `aten::div` with a rounding mode.

## Fix

- Capture whether both operands are integers **before** casting to fp32.
- When a rounding mode is set, cast the result back to `int32` to match torch; otherwise keep fp32.
- True division (no rounding mode) is unchanged and still returns a float. Float operands with a rounding mode are unchanged.

## Test

Adds `TestActivation.test_div_integer_dtype` covering `floor`/`trunc` with negative operands (to exercise floor-toward-`-inf` vs trunc-toward-`0`). The existing `test_div` always used a float operand, so it never exercised the integer case.

The dtype regression is only observable on `mlprogram` — NeuralNetwork always serializes outputs as float — so the assertion is guarded accordingly.

## Verification

Built against coremltools 9.0 + torch on macOS:

- **Without this change:** the new test's 4 `mlprogram` parametrizations fail (output is `float32`); the 4 NeuralNetwork ones pass.
- **With this change:** all 8 pass.
- Spot-checked values against PyTorch for int/int, float/float, int/float, and no-rounding cases (e.g. floor `[10,-10,7,-7] / [3,3,2,2]` → `[3,-4,3,-4]`; trunc → `[3,-3,3,-3]`), dtypes and values all match.