### PR TITLE
Fix log2 and log10 converters to handle integer input

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -8116,6 +8116,8 @@ def _pad_packed_sequence(context, node):
 def log10(context, node):
     inputs = _get_inputs(context, node)
     x = inputs[0]
+    if types.is_int(x.dtype):
+        x = mb.cast(x=x, dtype="fp32")
     log_x = mb.log(x=x)
     context.add(mb.mul(x=log_x, y=1 / np.log(10.0)), node.name)
 
@@ -8124,6 +8126,8 @@ def log10(context, node):
 def log2(context, node):
     inputs = _get_inputs(context, node)
     x = inputs[0]
+    if types.is_int(x.dtype):
+        x = mb.cast(x=x, dtype="fp32")
     log_x = mb.log(x=x)
     context.add(mb.mul(x=log_x, y=1 / np.log(2.0)), node.name)
 

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -8705,6 +8705,33 @@ class TestLog10(TorchBaseTest):
             input_shape, model, compute_unit=compute_unit, backend=backend, frontend=frontend
         )
 
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend, dtype",
+        itertools.product(
+            compute_units,
+            backends,
+            frontends,
+            [np.int32, np.float32],
+        ),
+    )
+    def test_log10_dtype(self, compute_unit, backend, frontend, dtype):
+        SHAPE = (2, 3)
+
+        input_data = np.random.randint(1, 100, SHAPE).astype(dtype)
+        input_data = torch.from_numpy(input_data)
+        model = ModuleWrapper(torch.log10)
+        converter_input_type = [TensorType(shape=SHAPE, dtype=dtype)]
+
+        self.run_compare_torch(
+            input_data,
+            model,
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+            input_as_shape=False,
+            converter_input_type=converter_input_type,
+        )
+
 
 class TestLog2(TorchBaseTest):
     @pytest.mark.parametrize(
@@ -8723,6 +8750,33 @@ class TestLog2(TorchBaseTest):
         model = Log2Model()
         self.run_compare_torch(
             input_shape, model, compute_unit=compute_unit, backend=backend, frontend=frontend
+        )
+
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend, dtype",
+        itertools.product(
+            compute_units,
+            backends,
+            frontends,
+            [np.int32, np.float32],
+        ),
+    )
+    def test_log2_dtype(self, compute_unit, backend, frontend, dtype):
+        SHAPE = (2, 3)
+
+        input_data = np.random.randint(1, 100, SHAPE).astype(dtype)
+        input_data = torch.from_numpy(input_data)
+        model = ModuleWrapper(torch.log2)
+        converter_input_type = [TensorType(shape=SHAPE, dtype=dtype)]
+
+        self.run_compare_torch(
+            input_data,
+            model,
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+            input_as_shape=False,
+            converter_input_type=converter_input_type,
         )
 
 


### PR DESCRIPTION
### Summary

The PyTorch `log2` and `log10` converters pass their input straight into MIL's `mb.log`, which only accepts floats (`fp16`/`fp32`). The issue is that `torch.log2` and `torch.log10` take integer tensors and return float, so converting a model that calls either of them on an int tensor currently fails MIL type inference.

The neighboring `log` and `log1p` converters already handle this by casting int input to float first (that cast was added to `log` in #2017). This change gives `log2` and `log10` the same two-line guard:

```python
if types.is_int(x.dtype):
    x = mb.cast(x=x, dtype="fp32")
```

Float inputs behave exactly as before. Integer inputs now lower correctly instead of erroring out.

Both changes are in `coremltools/converters/mil/frontend/torch/ops.py`, right next to the `log`/`log1p` guards they mirror.

### Testing

I added `test_log10_dtype` and `test_log2_dtype` to `TestLog10`/`TestLog2` in `coremltools/converters/mil/frontend/torch/test/test_torch_ops.py`, parametrized over `np.int32` and `np.float32`, following the existing `test_log_dtype` that already covers `torch.log` on integer input.

I ran them against coremltools 9.0 both ways. Without the fix, the `int32` cases fail (the `log2`/`log10` conversion errors on integer input) while `float32` passes. With the fix, all 8 selected cases pass (`int32` and `float32` across the mlprogram and neuralnetwork backends, on CPU, TorchScript frontend).