### PR TITLE
Fix layer norm beta shape validation

### DIFF
--- a/coremltools/converters/mil/mil/ops/defs/iOS15/normalization.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS15/normalization.py
@@ -291,7 +291,7 @@ class layer_norm(Operation):
         if self.gamma is not None and not layer_norm._is_compatible_shape(list(self.gamma.shape), normalized_shape):
             raise ValueError("Expect shape {} for gamma, but get shape {} instead".format(normalized_shape, self.gamma.shape))
 
-        if self.beta is not None and not layer_norm._is_compatible_shape(list(self.gamma.shape), normalized_shape):
+        if self.beta is not None and not layer_norm._is_compatible_shape(list(self.beta.shape), normalized_shape):
             raise ValueError("Expect shape {} for beta, but get shape {} instead".format(normalized_shape, self.beta.shape))
 
         x_shape = self.x.shape

--- a/coremltools/converters/mil/mil/ops/tests/iOS14/test_normalization.py
+++ b/coremltools/converters/mil/mil/ops/tests/iOS14/test_normalization.py
@@ -557,6 +557,17 @@ class TestNormalizationLayerNorm:
             backend=backend,
         )
 
+    def test_builder_rejects_invalid_beta_shape(self):
+        x = mb.placeholder(shape=(1, 3, 2))
+        gamma_val = np.ones((2,), dtype=np.float32)
+        beta_val = np.ones((3,), dtype=np.float32)
+
+        with pytest.raises(ValueError, match=r"Expect shape \[2\] for beta"):
+            with Function({"x": x}) as ssa_fun:
+                mb.layer_norm(
+                    x=ssa_fun.inputs["x"], axes=[2], gamma=gamma_val, beta=beta_val
+                )
+
     @pytest.mark.parametrize(
         "compute_unit, backend",
         itertools.product(


### PR DESCRIPTION
## Summary

- Fix `layer_norm` type inference so the optional `beta` tensor is validated against `beta.shape` instead of `gamma.shape`.
- Add a regression test that rejects an invalid `beta` shape when `gamma` has the expected normalized shape.

## Testing

Targeted layer norm tests:

```text
.venv/bin/python -m pytest \
  coremltools/converters/mil/mil/ops/tests/iOS14/test_normalization.py::TestNormalizationLayerNorm::test_builder_rejects_invalid_beta_shape \
  coremltools/converters/mil/mil/ops/tests/iOS14/test_normalization.py::TestNormalizationLayerNorm::test_builder_eval_stress \
  -q

...........                                                              [100%]
```

Syntax compilation:

```text
.venv/bin/python -m compileall -q \
  coremltools/converters/mil/mil/ops/defs/iOS15/normalization.py \
  coremltools/converters/mil/mil/ops/tests/iOS14/test_normalization.py
```
