### PR TITLE
Preserve integer dtype for torch.floor_divide

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -2045,10 +2045,7 @@ def div(context, node):
 def floor_divide(context, node):
     inputs = _get_inputs(context, node, expected=2)
     inputs = promote_input_dtypes(inputs)
-    div_res = mb.floor_div(x=inputs[0], y=inputs[1])
-    # Pytorch's floor_divide always returns fp32, even if the inputs are int
-    res = mb.cast(x=div_res, dtype='fp32', name=node.name)
-    context.add(res)
+    context.add(mb.floor_div(x=inputs[0], y=inputs[1], name=node.name))
 
 
 @register_torch_op

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -6825,6 +6825,29 @@ class TestActivation(TorchBaseTest):
                 f"integers on mlprogram, got {prediction.dtype}"
             )
 
+    @pytest.mark.parametrize(
+        "compute_unit, frontend",
+        itertools.product(compute_units, frontends),
+    )
+    def test_floor_divide_int_inputs_preserves_int_output(self, compute_unit, frontend):
+        model = ModuleWrapper(function=torch.floor_divide)
+        x1 = torch.from_numpy(np.array([-5, -4, 4, 5], dtype=np.int32))
+        x2 = torch.from_numpy(np.array([2, 2, 2, 2], dtype=np.int32))
+        out = torch.floor_divide(x1, x2)
+        res = self.run_compare_torch(
+            [x1, x2],
+            model,
+            frontend=frontend,
+            backend=("mlprogram", "fp32"),
+            compute_unit=compute_unit,
+            input_as_shape=False,
+            expected_results=out,
+        )
+        prediction = list(res[3].values())[0]
+        assert np.issubdtype(prediction.dtype, np.integer), (
+            f"floor_divide(int, int) should predict integers on mlprogram, got {prediction.dtype}"
+        )
+
 
 class TestElementWiseUnary(TorchBaseTest):
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- remove the unconditional fp32 cast from the PyTorch floor_divide converter
- let MIL floor_div preserve the promoted input dtype for integer tensors
- add a regression test that verifies integer torch.floor_divide lowers to an int32 MIL output for TorchScript and torch.export

Fixes #2570.

## Testing
- /private/tmp/coremltools-floor-div-venv/bin/python -m pytest coremltools/converters/mil/frontend/torch/test/test_torch_ops.py::TestActivation::test_floor_divide_int_inputs_preserves_int_output -q
- /private/tmp/coremltools-floor-div-venv/bin/python -m compileall -q coremltools/converters/mil/frontend/torch/ops.py coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
- git diff --check