### PR TITLE
Add torch.polar converter (fixes #2258)

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -8708,6 +8708,15 @@ def view_as_real(context, node):
 
 
 @register_torch_op
+def polar(context, node):
+    abs_val, angle = _get_inputs(context, node, expected=2)
+    real = mb.mul(x=abs_val, y=mb.cos(x=angle))
+    imag = mb.mul(x=abs_val, y=mb.sin(x=angle))
+    result = mb.complex(real_data=real, imag_data=imag, name=node.name)
+    context.add(result)
+
+
+@register_torch_op
 def fft_fft(context, node):
     """Lowers torch.fft.fft by the dialect op `complex_fft` from complex_dialect_ops.py."""
     input_data, n, dim, norm = _get_inputs(context, node, expected=[4])

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -12869,6 +12869,34 @@ class TestComplex(TorchBaseTest):
             compute_unit=compute_unit,
         )
 
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend",
+        itertools.product(
+            compute_units,
+            backends,
+            frontends,
+        ),
+    )
+    def test_polar(self, compute_unit, backend, frontend):
+        if frontend == TorchFrontend.EXECUTORCH:
+            pytest.skip("torch._ops.aten.polar.default is not Aten Canonical")
+
+        class PolarModel(torch.nn.Module):
+            def forward(self, abs_val, angle):
+                z = torch.polar(abs_val, angle)
+                return torch.stack([z.real, z.imag], dim=0)
+
+        abs_val = torch.tensor([1.0, 2.0, 0.5], dtype=torch.float32)
+        angle = torch.tensor([0.0, torch.pi / 4, torch.pi], dtype=torch.float32)
+        TorchBaseTest.run_compare_torch(
+            [abs_val, angle],
+            PolarModel(),
+            input_as_shape=False,
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+        )
+
 
 class TestReal(TorchBaseTest):
     @pytest.mark.parametrize(


### PR DESCRIPTION
`torch.polar(abs, angle)` had no converter so models using it (RoPE, Stable Diffusion, etc.) failed with `PyTorch convert function for op 'polar' not implemented`. Decomposes into `abs * cos(angle)` (real) and `abs * sin(angle)` (imag) using existing MIL ops, same pattern as the `complex`/`real`/`imag` converters nearby.

Adds `TestComplex.test_polar` covering both backends with concrete angle values (`0`, `π/4`, `π`). ExecuTorch skipped since `aten::polar.default` isn't Aten Canonical.

Fixes #2258.