### PR TITLE
Fix pow with a constant base of 2 squaring the exponent

### DIFF
--- a/coremltools/converters/mil/backend/mil/passes/decompose_const_base2_pow.py
+++ b/coremltools/converters/mil/backend/mil/passes/decompose_const_base2_pow.py
@@ -1,0 +1,65 @@
+#  Copyright (c) 2025, Apple Inc. All rights reserved.
+#
+#  Use of this source code is governed by a BSD-3-clause license that can be
+#  found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+
+import numpy as np
+
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil import types
+from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
+from coremltools.converters.mil.mil.passes.helper import block_context_manager
+from coremltools.converters.mil.mil.passes.pass_registry import register_pass
+
+
+def _is_const_base2_pow(op):
+    # match pow(x, y) where x is a floating-point constant equal to 2
+    if op.op_type != "pow":
+        return False
+    if not types.is_float(op.y.dtype):
+        return False
+    return op.x.val is not None and np.all(op.x.val == 2)
+
+
+def _try_to_transform(op, block):
+    # 2 ** y == exp(y * log(2))
+    log2 = np.log(2.0).astype(types.nptype_from_builtin(op.y.dtype))
+    scaled = mb.mul(x=op.y, y=log2, before_op=op)
+    new_var = mb.exp(x=scaled, name=op.outputs[0].name, before_op=op)
+    op.enclosing_block.replace_uses_of_var_after_op(
+        anchor_op=op, old_var=op.outputs[0], new_var=new_var
+    )
+    block.remove_ops([op])
+
+
+@block_context_manager
+def _decompose_const_base2_pow(block):
+    for op in list(block.operations):
+        if op.enclosing_block is None:
+            continue
+        for b in op.blocks:
+            _decompose_const_base2_pow(b)
+        if len(op.blocks) > 0:
+            continue
+        if _is_const_base2_pow(op):
+            _try_to_transform(op, block)
+
+
+@register_pass(namespace="mil_backend")
+class decompose_const_base2_pow(AbstractGraphPass):
+    """
+    Rewrite pow(2, y) into exp(y * log(2)).
+
+    Works around a Core ML runtime bug where pow with a constant base of 2
+    returns y ** 2 instead of 2 ** y. Floating-point pow only.
+
+    Given:
+        %out = pow(x=2, y=%y)
+
+    Result:
+        %scaled = mul(x=%y, y=0.6931471805599453)
+        %out = exp(x=%scaled)
+    """
+    def apply(self, prog):
+        for f in prog.functions.values():
+            _decompose_const_base2_pow(f)

--- a/coremltools/converters/mil/backend/mil/passes/test_passes.py
+++ b/coremltools/converters/mil/backend/mil/passes/test_passes.py
@@ -1185,3 +1185,96 @@ class TestPassFusePow2Sqrt:
             backend=("mlprogram", "fp32"),
             expected_output_shapes={block.outputs[0].name: x_shape},
         )
+
+
+class TestPassDecomposeConstBase2Pow:
+    """
+    Input graph:
+    input --> pow(x=2, y=input) --> output
+    Output graph:
+    input --> mul(input, log(2)) --> exp --> output
+    """
+
+    @pytest.mark.skipif(ct.utils._macos_version() < (12, 0), reason="mlprogram predict available only on macOS12+")
+    def test_decompose(self):
+        x_shape = tuple(np.random.randint(low=1, high=4, size=5))
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=x_shape)])
+        def program(x):
+            return mb.pow(x=2.0, y=x)
+
+        prev_prog, _, block = apply_pass_and_basic_check(
+            program, "mil_backend::decompose_const_base2_pow"
+        )
+
+        assert get_op_types_in_program(prev_prog) == ["pow"]
+        assert get_op_types_in_program(program) == ["mul", "exp"]
+
+        assert_model_is_valid(
+            program=program,
+            inputs={"x": x_shape},
+            backend=("mlprogram", "fp32"),
+            expected_output_shapes={block.outputs[0].name: tuple(x_shape)},
+        )
+
+    @pytest.mark.skipif(ct.utils._macos_version() < (12, 0), reason="mlprogram predict available only on macOS12+")
+    def test_no_decompose_other_base(self):
+        x_shape = tuple(np.random.randint(low=1, high=4, size=5))
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=x_shape)])
+        def program(x):
+            return mb.pow(x=3.0, y=x)
+
+        prev_prog, _, block = apply_pass_and_basic_check(
+            program, "mil_backend::decompose_const_base2_pow"
+        )
+
+        assert get_op_types_in_program(prev_prog) == ["pow"]
+        assert get_op_types_in_program(program) == ["pow"]
+
+        assert_model_is_valid(
+            program=program,
+            inputs={"x": x_shape},
+            backend=("mlprogram", "fp32"),
+            expected_output_shapes={block.outputs[0].name: tuple(x_shape)},
+        )
+
+    @pytest.mark.skipif(ct.utils._macos_version() < (12, 0), reason="mlprogram predict available only on macOS12+")
+    def test_no_decompose_non_const_base(self):
+        x_shape = tuple(np.random.randint(low=1, high=4, size=5))
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=x_shape)])
+        def program(x):
+            return mb.pow(x=x, y=2.0)
+
+        prev_prog, _, block = apply_pass_and_basic_check(
+            program, "mil_backend::decompose_const_base2_pow"
+        )
+
+        assert get_op_types_in_program(prev_prog) == ["pow"]
+        assert get_op_types_in_program(program) == ["pow"]
+
+        assert_model_is_valid(
+            program=program,
+            inputs={"x": x_shape},
+            backend=("mlprogram", "fp32"),
+            expected_output_shapes={block.outputs[0].name: tuple(x_shape)},
+        )
+
+    @pytest.mark.skipif(ct.utils._macos_version() < (12, 0), reason="mlprogram predict available only on macOS12+")
+    @pytest.mark.parametrize("compute_precision", [ct.precision.FLOAT32, ct.precision.FLOAT16])
+    def test_decompose_predict_values(self, compute_precision):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(5,), dtype=types.fp32)])
+        def program(x):
+            return mb.pow(x=2.0, y=x, name="out")
+
+        mlmodel = ct.convert(
+            program,
+            source="milinternal",
+            convert_to="mlprogram",
+            compute_precision=compute_precision,
+        )
+        x = np.array([-2.0, 0.0, 1.0, 3.0, 5.0], dtype=np.float32)
+        out = mlmodel.predict({"x": x})["out"]
+        rtol = 1e-2 if compute_precision == ct.precision.FLOAT16 else 1e-4
+        np.testing.assert_allclose(out, 2.0 ** x, rtol=rtol, atol=1e-2)

--- a/coremltools/converters/mil/mil/passes/__init__.py
+++ b/coremltools/converters/mil/mil/passes/__init__.py
@@ -6,6 +6,7 @@
 # Import all frontend/backend passes to make sure they got registered.
 from coremltools.converters.mil.backend.mil.passes import (
     adjust_io_to_supported_types,
+    decompose_const_base2_pow,
     fuse_activation_silu,
     fuse_pow2_sqrt,
     insert_image_preprocessing_op,

--- a/coremltools/converters/mil/mil/passes/pass_pipeline.py
+++ b/coremltools/converters/mil/mil/passes/pass_pipeline.py
@@ -196,6 +196,7 @@ _BACKEND_MIL_PASSES: List[Text] = [
     "mil_backend::insert_image_preprocessing_ops",
     "mil_backend::fuse_activation_silu",
     "mil_backend::fuse_pow2_sqrt",
+    "mil_backend::decompose_const_base2_pow",
     "common::const_elimination",  # rank0_expand_dims_swap might introduce some new const tensor
     "common::const_deduplication",  # after all consts have been settled
     "common::cast_optimization",


### PR DESCRIPTION
`pow(x, y)` with a constant base of 2 returns `y ** 2` instead of `2 ** y`. Only an exact constant base of 2 is affected. Other bases, and a constant exponent of 2 (`pow(x, 2)`), are computed correctly. The behavior matches a `pow(_, 2)` square fast path in the runtime that keys on a constant operand of 2 regardless of which side it is on.

`decompose_const_base2_pow` rewrites `pow(2, y)` into `exp(y * log(2))`, which is equal and avoids the constant-2 base. It runs in the backend pipeline, so it applies to every frontend and to `milinternal` input. Floating-point pow only.

`test_decompose_predict_values` converts `pow(2, y)` and checks the predicted output against `2 ** y` in fp32 and fp16. It fails on main without the fix.

Fixes #2628.
