### PR TITLE
Add TORCHSCRIPT_MODULE_PATH scope source preserving ModuleList names

### DIFF
--- a/coremltools/converters/mil/frontend/torch/converter.py
+++ b/coremltools/converters/mil/frontend/torch/converter.py
@@ -1255,10 +1255,11 @@ class TorchConverter:
     def convert_const(self) -> None:
         for name, val in self.graph.params.items():
             if self.context.frontend == TorchFrontend.TORCHSCRIPT:
-                scope_name, scope_type = self.graph.params_scope[name]
+                scope_name, scope_type, module_path = self.graph.params_scope[name]
                 with mb.scope(
                     ScopeInfo(source=ScopeSource.TORCHSCRIPT_MODULE_TYPE, data=scope_type),
                     ScopeInfo(source=ScopeSource.TORCHSCRIPT_MODULE_NAME, data=scope_name),
+                    ScopeInfo(source=ScopeSource.TORCHSCRIPT_MODULE_PATH, data=module_path),
                 ):
                     self._add_const(name, val)
             elif self.context.frontend in TORCH_EXPORT_BASED_FRONTENDS:

--- a/coremltools/converters/mil/frontend/torch/internal_graph.py
+++ b/coremltools/converters/mil/frontend/torch/internal_graph.py
@@ -171,6 +171,7 @@ class InternalTorchIRNode:
         attr: Optional[Dict[str, Any]] = None,
         blocks: Optional[List["InternalTorchIRBlock"]] = None,
         model_hierarchy: Optional[str] = None,
+        module_path: Optional[str] = None,
         meta: Optional[Dict] = None,
     ):
         """
@@ -199,6 +200,7 @@ class InternalTorchIRNode:
         self.attr = attr if attr is not None else {"value": None}
         self.blocks = blocks if blocks is not None else []
         self.model_hierarchy = model_hierarchy
+        self.module_path = module_path
         self.meta = meta
 
     @classmethod
@@ -231,6 +233,7 @@ class InternalTorchIRNode:
             attr=attr,
             blocks=None,
             model_hierarchy=node.getModuleHierarchy(),
+            module_path=node.scopeName(),
         )
         internal_node.blocks = [
             InternalTorchIRBlock.from_torchscript_block(block=b, parent=internal_node)
@@ -339,9 +342,9 @@ class InternalTorchIRNode:
         for block in self.blocks:
             block.replace_name(old_name, new_name)
 
-    def get_scope_info(self) -> Tuple[List[str], List[str]]:
+    def get_scope_info(self) -> Tuple[List[str], List[str], List[str]]:
         """
-        Get the scope information (``scope_name``, ``scope_type``) of a TorchScript node.
+        Get the scope information (``scope_name``, ``scope_type``, ``module_path``) of a TorchScript node.
         In a TorchScript node, a model hierarchy is represented in a string of format:
             ``scope_name_1(scope_type_1).scope_name_2(scope_type_1).<...>.scope_name_n(scope_type_n)``
         For instance, given a torch model:
@@ -386,6 +389,30 @@ class InternalTorchIRNode:
         ``["submodule_1", "linear_1", "submodule_1.linear_1.weight"]``.
         This function does a special handling to trim it to:
         ``["submodule_1", "linear_1", "weight"]``
+
+        ``module_path`` is parsed from ``torch._C.Node.scopeName()`` because ``getModuleHierarchy()``
+        drops ``nn.ModuleList`` / ``nn.ModuleDict`` container attribute names that are needed
+        to reconstruct the original ``named_modules()`` path.
+        For example, given a model with two sibling ``nn.ModuleList`` containers:
+
+            class Model(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.layers_a = torch.nn.ModuleList([SubModule()])
+                    self.layers_b = torch.nn.ModuleList([SubModule()])
+
+                def forward(self, x):
+                    return self.layers_a[0](x) + self.layers_b[0](x)
+
+        an op ``x_1`` emitted inside ``layers_a[0].linear_1`` and one inside
+        ``layers_b[0].linear_1`` yield the same ``scope_name = ["0", "linear_1", "x_1"]``
+        (the container attribute name is dropped in both cases), so backtracing from
+        ``scope_name`` alone cannot distinguish them even given the full set of
+        ``named_modules()`` paths. ``module_path`` keeps the container name and
+        disambiguates::
+
+            layers_a[0].linear_1: module_path = ["layers_a", "0", "linear_1"]
+            layers_b[0].linear_1: module_path = ["layers_b", "0", "linear_1"]
         """
 
         def _trim_scopename_for_weight(scope_names: List[str]) -> List[str]:
@@ -414,7 +441,17 @@ class InternalTorchIRNode:
         scope_types.append(self.kind)
         if self.kind == "getattr":
             scope_names = _trim_scopename_for_weight(scope_names)
-        return scope_names, scope_types
+
+        if self.module_path == "" or self.module_path is None:
+            module_path = []
+        else:
+            last_frame = self.module_path.split("/")[-1]
+            if last_frame.startswith("__module."):
+                module_path = last_frame.split(".")[1:]
+            else:
+                module_path = []
+
+        return scope_names, scope_types, module_path
 
 
 class InternalTorchIRGraph:

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -148,10 +148,11 @@ def convert_single_node(context: TranscriptionContext, node: InternalTorchIRNode
 
     scopes = []
     if context.frontend == TorchFrontend.TORCHSCRIPT:
-        scope_name, scope_type = node.get_scope_info()
+        scope_name, scope_type, module_path = node.get_scope_info()
         scopes = [
             ScopeInfo(source=ScopeSource.TORCHSCRIPT_MODULE_TYPE, data=scope_type),
             ScopeInfo(source=ScopeSource.TORCHSCRIPT_MODULE_NAME, data=scope_name),
+            ScopeInfo(source=ScopeSource.TORCHSCRIPT_MODULE_PATH, data=module_path),
         ]
     elif context.frontend in TORCH_EXPORT_BASED_FRONTENDS:
         scopes = [

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_conversion_api.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_conversion_api.py
@@ -32,6 +32,7 @@ from coremltools.converters.mil.frontend.torch.torch_op_registry import (
     TorchOpsRegistry,
     register_torch_op,
 )
+from coremltools.converters.mil.mil.scope import ScopeSource
 from coremltools.converters.mil.mil.types import builtin_to_string
 from coremltools.converters.mil.mil.types.symbolic import any_symbolic
 from coremltools.converters.mil.testing_reqs import backends
@@ -161,6 +162,48 @@ class TestTorchScriptValidation:
 
         current_date = str(date.today())
         assert mlmodel.user_defined_metadata[_METADATA_CONVERSION_DATE] == current_date
+
+
+@pytest.mark.skipif(not _HAS_TORCH, reason=MSG_TORCH_NOT_FOUND)
+class TestTorchScriptScopes:
+    @staticmethod
+    @pytest.mark.parametrize("backend", backends)
+    def test_module_path_preserves_modulelist_names(backend):
+        class TwoLists(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers_a = nn.ModuleList([nn.Linear(3, 3)])
+                self.layers_b = nn.ModuleList([nn.Linear(3, 3)])
+
+            def forward(self, x):
+                return self.layers_a[0](x) + self.layers_b[0](x)
+
+        model = TwoLists().eval()
+        traced = torch.jit.trace(model, torch.rand(1, 3))
+        mlmodel = ct.convert(
+            traced,
+            source="pytorch",
+            inputs=[ct.TensorType(shape=(1, 3))],
+            convert_to=backend[0],
+        )
+
+        ops = mlmodel._mil_program.functions["main"].operations
+        linear_ops = [op for op in ops if op.op_type == "linear"]
+        assert len(linear_ops) == 2
+
+        # MODULE_PATH keeps each ModuleList container's attribute name + index.
+        assert sorted(
+            op.scopes[ScopeSource.TORCHSCRIPT_MODULE_PATH] for op in linear_ops
+        ) == [["layers_a", "0"], ["layers_b", "0"]]
+
+        # MODULE_NAME drops the container name.
+        assert sorted(
+            op.scopes[ScopeSource.TORCHSCRIPT_MODULE_NAME][:-1] for op in linear_ops
+        ) == [["0"], ["0"]]
+
+        assert {
+            tuple(op.scopes.get(ScopeSource.TORCHSCRIPT_MODULE_PATH, [])) for op in ops
+        } == {("layers_a", "0"), ("layers_b", "0"), ()}
 
 
 @pytest.mark.skipif(not _HAS_TORCH, reason=MSG_TORCH_NOT_FOUND)

--- a/coremltools/converters/mil/frontend/torch/torchir_passes.py
+++ b/coremltools/converters/mil/frontend/torch/torchir_passes.py
@@ -177,6 +177,7 @@ def generate_tensor_assignment_ops(graph: InternalTorchIRGraph) -> None:
                 kind=kind,
                 blocks=[],
                 model_hierarchy=node.model_hierarchy,
+                module_path=node.module_path,
             )
             graph.nodes[i] = tensor_assign_node
 
@@ -211,6 +212,7 @@ def populate_native_const_model_hierarchy(graph: InternalTorchIRGraph) -> None:
     """
 
     cached_model_hierarchy = {}
+    cached_module_path = {}
     child_ops = defaultdict(list)
 
     for node in graph.nodes:
@@ -219,14 +221,18 @@ def populate_native_const_model_hierarchy(graph: InternalTorchIRGraph) -> None:
 
     for node in graph.nodes:
         cached_model_hierarchy[node.name] = node.model_hierarchy
+        cached_module_path[node.name] = node.module_path
         for val in node.inputs:
             child_ops[val].append(node.name)
 
     for node in graph.nodes:
-        if node.kind != "constant":
+        if node.kind != "constant" or len(child_ops[node.name]) != 1:
             continue
-        if node.model_hierarchy == "" and len(child_ops[node.name]) == 1:
-            node.model_hierarchy = cached_model_hierarchy[child_ops[node.name][0]]
+        consumer = child_ops[node.name][0]
+        if node.model_hierarchy == "":
+            node.model_hierarchy = cached_model_hierarchy[consumer]
+        if node.module_path == "":
+            node.module_path = cached_module_path[consumer]
 
 
 def remove_getattr_nodes(graph: InternalTorchIRGraph) -> None:

--- a/coremltools/converters/mil/mil/scope.py
+++ b/coremltools/converters/mil/mil/scope.py
@@ -26,6 +26,11 @@ class ScopeSource(Enum):
         * If provided as str, it denotes a single scope.
         * Nested scopes are represented by a list of str.
 
+    TORCHSCRIPT_MODULE_PATH:
+        * Tokens of the innermost frame of ``node.scopeName()``. Preserves ``nn.ModuleList`` / ``nn.ModuleDict``
+        * container attribute names that ``TORCHSCRIPT_MODULE_NAME`` drops.
+        * Stored as a list of str.
+
     # Core ML converter graph passes related:
     COREMLTOOLS_GRAPH_PASS:
         * This scope traces the graph transformations (graph passes) applied on the program.
@@ -83,6 +88,7 @@ class ScopeSource(Enum):
     COREMLTOOLS_GRAPH_PASS = 2
     EXIR_STACK_TRACE = 3  # no serialization for such debug info should be allowed yet
     EXIR_DEBUG_HANDLE = 4
+    TORCHSCRIPT_MODULE_PATH = 5
 
 
 class ScopeStack(defaultdict):
@@ -220,6 +226,7 @@ class ScopeInfo:
         if self.source in (
             ScopeSource.TORCHSCRIPT_MODULE_NAME,
             ScopeSource.TORCHSCRIPT_MODULE_TYPE,
+            ScopeSource.TORCHSCRIPT_MODULE_PATH,
             ScopeSource.COREMLTOOLS_GRAPH_PASS,
         ):
             if not isinstance(self.data, list):


### PR DESCRIPTION
The goal of this change is to enable full and simple tracing from .mlpackage MIL ops back to their originating torch submodules. 

When working with edge ML teams, MIL graph passes fuse/rename ops in ways that make numerical-error debugging difficult and make end-to-end optimization manual and inefficient. The existing TORCHSCRIPT_MODULE_NAME scope is derived from torch._C.Node.getModuleHierarchy(), which drops nn.ModuleList / nn.ModuleDict container attribute names - so any two ops emitted from sibling ModuleList submodules carry identical scope tokens and cannot be reverse-mapped to a unique named_modules() path.

This change adds a new TORCHSCRIPT_MODULE_PATH scope source populated from torch._C.Node.scopeName(), which preserves those container names. The new source is additive — TORCHSCRIPT_MODULE_NAME and TORCHSCRIPT_MODULE_TYPE outputs are byte-identical for backward compatibility.

Answers [apple/coremltools#2749](https://github.com/apple/coremltools/issues/2749)