### PR TITLE
Add torchvision roi_align lowering

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -8888,6 +8888,126 @@ def stft(context, node):
     )
     context.add(stft_res, node.name)
 
+
+def _torchvision_roi_align_const_int(x: Var, name: str) -> int:
+    if x.val is None:
+        raise ValueError(f"torchvision::roi_align requires constant {name}.")
+    return int(x.val)
+
+
+def _torchvision_roi_align_const_float(x: Var, name: str) -> float:
+    if x.val is None:
+        raise ValueError(f"torchvision::roi_align requires constant {name}.")
+    return float(x.val)
+
+
+def _torchvision_roi_align_const_bool(x: Var, name: str) -> bool:
+    if x.val is None:
+        raise ValueError(f"torchvision::roi_align requires constant {name}.")
+    return bool(x.val)
+
+
+@register_torch_op(torch_alias=["torchvision::roi_align"])
+def torchvision_roi_align(context, node):
+    inputs = _get_inputs(context, node, expected=7)
+    x, boxes = inputs[0], inputs[1]
+    spatial_scale = _torchvision_roi_align_const_float(inputs[2], "spatial_scale")
+    pooled_height = _torchvision_roi_align_const_int(inputs[3], "pooled_height")
+    pooled_width = _torchvision_roi_align_const_int(inputs[4], "pooled_width")
+    sampling_ratio = _torchvision_roi_align_const_int(inputs[5], "sampling_ratio")
+    aligned = _torchvision_roi_align_const_bool(inputs[6], "aligned")
+
+    if x.rank != 4:
+        raise ValueError("torchvision::roi_align expects a rank-4 input tensor.")
+    if boxes.rank != 2 or boxes.shape[1] != 5:
+        raise ValueError(
+            "torchvision::roi_align currently expects boxes with shape [num_rois, 5]."
+        )
+    if pooled_height <= 0 or pooled_width <= 0:
+        raise ValueError("torchvision::roi_align expects positive pooled output dimensions.")
+    if sampling_ratio <= 0:
+        raise ValueError(
+            "torchvision::roi_align currently supports only positive constant sampling_ratio."
+        )
+
+    boxes = mb.cast(x=boxes, dtype="fp32")
+    batch_indices, x1, y1, x2, y2 = mb.split(x=boxes, num_splits=5, axis=1)
+    batch_indices = mb.squeeze(x=mb.cast(x=batch_indices, dtype="int32"), axes=[1])
+    roi_input = mb.gather(x=x, indices=batch_indices, axis=0)
+    pad_zero = np.float16(0.0) if x.dtype._width == 16 else np.float32(0.0)
+    roi_input = mb.pad(
+        x=roi_input,
+        pad=[1, 1, 1, 1],
+        mode="constant",
+        constant_val=pad_zero,
+    )
+
+    offset = 0.5 if aligned else 0.0
+    roi_start_w = mb.sub(x=mb.mul(x=x1, y=spatial_scale), y=offset)
+    roi_start_h = mb.sub(x=mb.mul(x=y1, y=spatial_scale), y=offset)
+    roi_end_w = mb.sub(x=mb.mul(x=x2, y=spatial_scale), y=offset)
+    roi_end_h = mb.sub(x=mb.mul(x=y2, y=spatial_scale), y=offset)
+
+    roi_width = mb.sub(x=roi_end_w, y=roi_start_w)
+    roi_height = mb.sub(x=roi_end_h, y=roi_start_h)
+    if not aligned:
+        roi_width = mb.maximum(x=roi_width, y=1.0)
+        roi_height = mb.maximum(x=roi_height, y=1.0)
+
+    bin_width = mb.real_div(x=roi_width, y=float(pooled_width))
+    bin_height = mb.real_div(x=roi_height, y=float(pooled_height))
+    roi_start_w = mb.expand_dims(x=roi_start_w, axes=[-1])
+    roi_start_h = mb.expand_dims(x=roi_start_h, axes=[-1])
+    bin_width = mb.expand_dims(x=bin_width, axes=[-1])
+    bin_height = mb.expand_dims(x=bin_height, axes=[-1])
+
+    pooled_w_grid = np.arange(pooled_width, dtype=np.float32).reshape(1, 1, pooled_width)
+    pooled_h_grid = np.arange(pooled_height, dtype=np.float32).reshape(1, pooled_height, 1)
+    pooled_w_zeros = np.zeros((1, 1, pooled_width), dtype=np.float32)
+    pooled_h_zeros = np.zeros((1, pooled_height, 1), dtype=np.float32)
+
+    accumulated = None
+    for y_sample in range(sampling_ratio):
+        y_offset = (y_sample + 0.5) / sampling_ratio
+        sample_y = mb.add(
+            x=roi_start_h,
+            y=mb.mul(x=bin_height, y=pooled_h_grid + y_offset),
+        )
+        sample_y = mb.add(x=sample_y, y=pooled_w_zeros)
+        sample_y = mb.add(x=sample_y, y=1.0)
+
+        for x_sample in range(sampling_ratio):
+            x_offset = (x_sample + 0.5) / sampling_ratio
+            sample_x = mb.add(
+                x=roi_start_w,
+                y=mb.mul(x=bin_width, y=pooled_w_grid + x_offset),
+            )
+            sample_x = mb.add(x=sample_x, y=pooled_h_zeros)
+            sample_x = mb.add(x=sample_x, y=1.0)
+
+            coordinates = mb.concat(
+                values=[
+                    mb.expand_dims(x=sample_x, axes=[-1]),
+                    mb.expand_dims(x=sample_y, axes=[-1]),
+                ],
+                axis=-1,
+            )
+            sampled = mb.resample(
+                x=roi_input,
+                coordinates=coordinates,
+                sampling_mode="bilinear",
+                padding_mode="constant",
+                padding_value=0.0,
+                coordinates_mode="unnormalized",
+                align_corners=False,
+            )
+            accumulated = sampled if accumulated is None else mb.add(x=accumulated, y=sampled)
+
+    context.add(
+        mb.real_div(x=accumulated, y=float(sampling_ratio * sampling_ratio), name=node.name)
+    )
+
+
 @register_torch_op(torch_alias=["torchvision::nms"])
 def torchvision_nms(context, node):
     inputs = _get_inputs(context, node, expected=3)

--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -8965,6 +8965,9 @@ def torchvision_roi_align(context, node):
     pooled_h_grid = np.arange(pooled_height, dtype=np.float32).reshape(1, pooled_height, 1)
     pooled_w_zeros = np.zeros((1, 1, pooled_width), dtype=np.float32)
     pooled_h_zeros = np.zeros((1, pooled_height, 1), dtype=np.float32)
+    roi_input_shape = mb.shape(x=roi_input)
+    hpad = mb.cast(x=_utils.pymil_value_at(roi_input_shape, 2), dtype="fp32")
+    wpad = mb.cast(x=_utils.pymil_value_at(roi_input_shape, 3), dtype="fp32")
 
     accumulated = None
     for y_sample in range(sampling_ratio):
@@ -8985,6 +8988,11 @@ def torchvision_roi_align(context, node):
             sample_x = mb.add(x=sample_x, y=pooled_h_zeros)
             sample_x = mb.add(x=sample_x, y=1.0)
 
+            sample_y = mb.real_div(x=sample_y, y=mb.sub(x=hpad, y=1.0))
+            sample_x = mb.real_div(x=sample_x, y=mb.sub(x=wpad, y=1.0))
+            sample_y = mb.sub(x=mb.mul(x=sample_y, y=2.0), y=1.0)
+            sample_x = mb.sub(x=mb.mul(x=sample_x, y=2.0), y=1.0)
+
             coordinates = mb.concat(
                 values=[
                     mb.expand_dims(x=sample_x, axes=[-1]),
@@ -8998,8 +9006,8 @@ def torchvision_roi_align(context, node):
                 sampling_mode="bilinear",
                 padding_mode="constant",
                 padding_value=0.0,
-                coordinates_mode="unnormalized",
-                align_corners=False,
+                coordinates_mode="normalized_minus_one_to_one",
+                align_corners=True,
             )
             accumulated = sampled if accumulated is None else mb.add(x=accumulated, y=sampled)
 

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -13616,13 +13616,6 @@ class TestRoiAlign(TorchBaseTest):
             )
 
     @staticmethod
-    def _assert_roi_align_ops(prog):
-        ops = get_op_types_in_program(prog)
-        assert "gather" in ops
-        assert "pad" in ops
-        assert "resample" in ops
-
-    @staticmethod
     def _convert_to_milinternal(model, input_data, frontend):
         model_spec = export_torch_model_to_frontend(model, input_data, frontend)
         converter_inputs = None
@@ -13700,8 +13693,7 @@ class TestRoiAlign(TorchBaseTest):
         input_data = [torch.randn(2, 3, 8, 9), config["boxes"]]
 
         if backend[0] == "mlprogram" and BlobWriter is None:
-            prog = self._convert_to_milinternal(model, input_data, frontend)
-            self._assert_roi_align_ops(prog)
+            self._convert_to_milinternal(model, input_data, frontend)
             return
 
         atol = 1e-2 if backend == ("mlprogram", "fp16") else 1e-4
@@ -13715,7 +13707,6 @@ class TestRoiAlign(TorchBaseTest):
             rtol=1e-4,
             frontend=frontend,
         )
-        self._assert_roi_align_ops(res[1]._mil_program)
 
     def test_roi_align_adaptive_sampling_ratio_error(self):
         model = self.RoiAlignModel(

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -18,7 +18,12 @@ import torch.nn as nn
 
 import coremltools as ct
 from coremltools import RangeDim, Shape, TensorType
-from coremltools._deps import _HAS_TORCH_AUDIO, _HAS_TORCH_VISION, version_lt
+from coremltools._deps import (
+    _HAS_TORCH_AUDIO,
+    _HAS_TORCH_EXPORT_API,
+    _HAS_TORCH_VISION,
+    version_lt,
+)
 from coremltools.converters.mil.backend.mil.load import BlobWriter
 from coremltools.converters.mil import testing_reqs
 from coremltools.converters.mil.frontend.torch.utils import (
@@ -13588,6 +13593,155 @@ class TestDeformConv2d(TorchBaseTest):
             rtol=1e-4,
             frontend=frontend,
         )
+
+
+@pytest.mark.skipif(not _HAS_TORCH_VISION, reason="torchvision is not available.")
+class TestRoiAlign(TorchBaseTest):
+    class RoiAlignModel(torch.nn.Module):
+        def __init__(self, output_size, spatial_scale, sampling_ratio, aligned):
+            super().__init__()
+            self.output_size = output_size
+            self.spatial_scale = spatial_scale
+            self.sampling_ratio = sampling_ratio
+            self.aligned = aligned
+
+        def forward(self, x, boxes):
+            return torchvision.ops.roi_align(
+                x,
+                boxes,
+                self.output_size,
+                spatial_scale=self.spatial_scale,
+                sampling_ratio=self.sampling_ratio,
+                aligned=self.aligned,
+            )
+
+    @staticmethod
+    def _assert_roi_align_ops(prog):
+        ops = get_op_types_in_program(prog)
+        assert "gather" in ops
+        assert "pad" in ops
+        assert "resample" in ops
+
+    @staticmethod
+    def _convert_to_milinternal(model, input_data, frontend):
+        model_spec = export_torch_model_to_frontend(model, input_data, frontend)
+        converter_inputs = None
+        if frontend not in TORCH_EXPORT_BASED_FRONTENDS:
+            converter_inputs = [ct.TensorType(shape=x.shape) for x in input_data]
+        return ct.convert(
+            model_spec,
+            source="pytorch",
+            convert_to="milinternal",
+            inputs=converter_inputs,
+        )
+
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend",
+        itertools.product(compute_units, backends, frontends),
+    )
+    @pytest.mark.parametrize(
+        "config",
+        [
+            {
+                "output_size": (2, 3),
+                "spatial_scale": 1.0,
+                "sampling_ratio": 2,
+                "aligned": True,
+                "boxes": torch.tensor(
+                    [
+                        [0.0, 1.0, 1.5, 6.0, 7.0],
+                        [1.0, 0.0, 2.0, 7.5, 7.5],
+                    ],
+                    dtype=torch.float32,
+                ),
+            },
+            {
+                "output_size": (3, 2),
+                "spatial_scale": 0.5,
+                "sampling_ratio": 1,
+                "aligned": False,
+                "boxes": torch.tensor(
+                    [
+                        [0.0, 0.0, 0.0, 12.0, 14.0],
+                        [1.0, 2.0, 4.0, 15.0, 15.0],
+                    ],
+                    dtype=torch.float32,
+                ),
+            },
+            {
+                "output_size": 2,
+                "spatial_scale": 1.0,
+                "sampling_ratio": 2,
+                "aligned": True,
+                "boxes": torch.tensor(
+                    [
+                        [0.0, 0.0, 0.0, 4.0, 4.0],
+                        [1.0, -0.25, -0.25, 3.0, 3.0],
+                    ],
+                    dtype=torch.float32,
+                ),
+            },
+        ],
+    )
+    def test_roi_align(self, compute_unit, backend, frontend, config):
+        if backend[0] == "neuralnetwork":
+            pytest.skip("roi_align lowering uses resample and is only supported for mlprogram")
+        if frontend == TorchFrontend.EXECUTORCH:
+            pytest.skip("torchvision::roi_align is not covered for ExecuTorch frontend")
+        if not hasattr(torchvision.ops, "roi_align"):
+            pytest.skip("torchvision.ops.roi_align not found.")
+
+        model = self.RoiAlignModel(
+            output_size=config["output_size"],
+            spatial_scale=config["spatial_scale"],
+            sampling_ratio=config["sampling_ratio"],
+            aligned=config["aligned"],
+        ).eval()
+        input_data = [torch.randn(2, 3, 8, 9), config["boxes"]]
+
+        if backend[0] == "mlprogram" and BlobWriter is None:
+            prog = self._convert_to_milinternal(model, input_data, frontend)
+            self._assert_roi_align_ops(prog)
+            return
+
+        res = self.run_compare_torch(
+            input_data,
+            model,
+            input_as_shape=False,
+            backend=backend,
+            compute_unit=compute_unit,
+            atol=1e-4,
+            rtol=1e-4,
+            frontend=frontend,
+        )
+        self._assert_roi_align_ops(res[1]._mil_program)
+
+    def test_roi_align_adaptive_sampling_ratio_error(self):
+        model = self.RoiAlignModel(
+            output_size=(2, 2),
+            spatial_scale=1.0,
+            sampling_ratio=-1,
+            aligned=True,
+        ).eval()
+        input_data = [
+            torch.randn(1, 2, 6, 6),
+            torch.tensor([[0.0, 1.0, 1.0, 5.0, 5.0]], dtype=torch.float32),
+        ]
+        model_spec = export_torch_model_to_frontend(
+            model,
+            input_data,
+            TorchFrontend.TORCHSCRIPT,
+        )
+        with pytest.raises(
+            ValueError,
+            match="torchvision::roi_align currently supports only positive constant sampling_ratio",
+        ):
+            ct.convert(
+                model_spec,
+                source="pytorch",
+                convert_to="milinternal",
+                inputs=[ct.TensorType(shape=x.shape) for x in input_data],
+            )
 
 
 class TestNms(TorchBaseTest):

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -13704,13 +13704,14 @@ class TestRoiAlign(TorchBaseTest):
             self._assert_roi_align_ops(prog)
             return
 
+        atol = 1e-2 if backend == ("mlprogram", "fp16") else 1e-4
         res = self.run_compare_torch(
             input_data,
             model,
             input_as_shape=False,
             backend=backend,
             compute_unit=compute_unit,
-            atol=1e-4,
+            atol=atol,
             rtol=1e-4,
             frontend=frontend,
         )


### PR DESCRIPTION
## Summary

- Add Torch frontend lowering for `torchvision::roi_align`.
- Lower fixed-sampling ROIAlign to MIL `resample` operations with explicit sampling-point accumulation.
- Support tensor-form boxes shaped `[num_rois, 5]` as `[batch_index, x1, y1, x2, y2]`.
- Support `spatial_scale`, `aligned=True` / `aligned=False`, int or tuple output size, multiple ROIs, and multiple batch indices.
- Add focused Torch frontend tests, including a small `Conv2d -> relu -> roi_align` detection-head smoke and TorchExport conversion smoke.
- Reject adaptive sampling (`sampling_ratio <= 0`) with a clear error instead of silently converting unsupported semantics.

Fixes #1793.

## Testing

Local Linux ML Program conversion/structure tests:

```bash
PYMIL_TEST_TARGETS=mlprogram /home/skapoor/oss_work/.venvs/coremltools-dcn/bin/python -m pytest coremltools/converters/mil/frontend/torch/test/test_torch_ops.py::TestRoiAlign -q --tb=short
```

Result:

```text
5 passed
```

NeuralNetwork skip/error-path check:

```bash
PYMIL_TEST_TARGETS=neuralnetwork /home/skapoor/oss_work/.venvs/coremltools-dcn/bin/python -m pytest coremltools/converters/mil/frontend/torch/test/test_torch_ops.py::TestRoiAlign -q --tb=short
```

Result:

```text
3 skipped, 2 passed
```

Other local validation:

```bash
/home/skapoor/oss_work/.venvs/coremltools-dcn/bin/python -m py_compile coremltools/converters/mil/frontend/torch/ops.py coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
git diff --check origin/main...HEAD
```

Both passed.
