### PR TITLE
Fix crash folding an exclusive cumsum

### DIFF
--- a/coremltools/converters/mil/mil/ops/defs/iOS15/tensor_operation.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS15/tensor_operation.py
@@ -153,9 +153,14 @@ class cumsum(Operation):
             data = np.flip(data, axis=axis)
         data = np.cumsum(data, axis=axis)
         if exclusive:
-            zero_shape = np.copy(data.shape)
+            # Exclusive prefix sum: shift the inclusive cumsum one step along ``axis``
+            # and fill the first position with zero (out[0] = 0, out[i] = sum(x[:i])).
+            zero_shape = list(data.shape)
             zero_shape[axis] = 1
-            data = np.concatenate((np.zeros(zero_shape, data)), axis=axis)
+            zeros = np.zeros(zero_shape, dtype=data.dtype)
+            slc = [slice(None)] * data.ndim
+            slc[axis] = slice(0, -1)
+            data = np.concatenate((zeros, data[tuple(slc)]), axis=axis)
         if reverse:
             data = np.flip(data, axis=axis)
         return data

--- a/coremltools/converters/mil/mil/ops/tests/iOS14/test_tensor_operation.py
+++ b/coremltools/converters/mil/mil/ops/tests/iOS14/test_tensor_operation.py
@@ -211,6 +211,21 @@ class TestCumSum:
         np.testing.assert_allclose(np.cumsum(x_val, axis=0), v.val, atol=1e-04, rtol=1e-05)
 
     @ssa_fn
+    def test_builder_eval_exclusive(self):
+        # Constant folding an exclusive cumsum used to crash (the data array was passed as
+        # np.zeros' dtype) and never produced the exclusive prefix sum. Cover every
+        # axis/reverse combination against the numpy ground truth.
+        x_val = random_gen(shape=(2, 3, 4), rand_min=-100, rand_max=100)
+        for axis in range(x_val.ndim):
+            for reverse in (False, True):
+                v = mb.cumsum(x=x_val, axis=axis, exclusive=True, reverse=reverse)
+                data = np.flip(x_val, axis=axis) if reverse else x_val
+                expected = np.cumsum(data, axis=axis) - data  # exclusive = inclusive - self
+                if reverse:
+                    expected = np.flip(expected, axis=axis)
+                np.testing.assert_allclose(expected, v.val, atol=1e-04, rtol=1e-05)
+
+    @ssa_fn
     def test_invalid_arg(self):
         x_val = random_gen(shape=(1, 2, 3, 4, 5), rand_min=-100, rand_max=100)
         with pytest.raises(ValueError):


### PR DESCRIPTION
Fixes #2759.

### Problem

Constant-folding a `cumsum` with `exclusive=True` crashes at graph-construction time:

```python
from coremltools.converters.mil.mil import Builder as mb
import numpy as np

@mb.program(input_specs=[])
def prog():
    return mb.cumsum(x=np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32), axis=0, exclusive=True)
# TypeError: Cannot construct a dtype from an array
```

`cumsum.value_inference` did:

```python
data = np.concatenate((np.zeros(zero_shape, data)), axis=axis)
```

which (1) passes the `data` ndarray as `np.zeros`' `dtype` argument → `TypeError`, and (2) wraps a single array in `np.concatenate` instead of a `(zeros, data)` sequence. Beyond the crash, the exclusive prefix sum was never actually computed — the inclusive `data` was returned unshifted. This is reachable from real frontends (e.g. `tf.cumsum(..., exclusive=True)` on a foldable tensor).

### Fix

Build the leading zeros with `data.dtype` and shift the inclusive cumsum one step along `axis` (prepend a zero, drop the last element) to produce the exclusive prefix sum `out[0] = 0`, `out[i] = sum(x[:i])`. `reverse` is unaffected — it still flips around the exclusive step.

### Tests

Added `test_builder_eval_exclusive`, covering the folded exclusive cumsum across every axis and `reverse` value against the numpy ground truth. It raises `TypeError` before this change and passes after; the existing `TestCumSum` cases are unchanged. Verified the value-inference path locally (the `@ssa_fn` eval tests run without the CoreML runtime).
