### PR TITLE
Fix torch.diagonal converter to return the 1-D diagonal

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -8392,10 +8392,54 @@ def diagonal(context, node):
     x, offset, dim1, dim2 = _parse_positional_args(context, node)
     offset, dim1, dim2 = _parse_keyword_args(context, node, offset, dim1, dim2)
 
-    if offset == 0 and dim1 == 0 and dim2 == 1:
-        diagonal = mb.band_part(x=x, lower=0, upper=0, name=node.name)
+    # Normalize the scalar args to python ints.
+    offset = offset.val if isinstance(offset, Var) else offset
+    dim1 = dim1.val if isinstance(dim1, Var) else dim1
+    dim2 = dim2.val if isinstance(dim2, Var) else dim2
+
+    rank = x.rank
+    # Normalize negative dims to their positive counterparts.
+    if dim1 < 0:
+        dim1 += rank
+    if dim2 < 0:
+        dim2 += rank
+
+    # torch.diagonal returns the requested diagonal as a 1-D vector (not a
+    # matrix with the off-diagonal zeroed out). Only the 2-D main-diagonal
+    # axes (dim1 == 0, dim2 == 1) are supported here.
+    if rank != 2 or dim1 != 0 or dim2 != 1:
+        raise NotImplementedError(
+            "torch.diagonal is only supported for rank-2 inputs with "
+            "dim1 == 0 and dim2 == 1"
+        )
+
+    shape = x.shape
+    if any(is_symbolic(s) for s in shape):
+        raise NotImplementedError(
+            "torch.diagonal is not supported for dynamically-shaped inputs"
+        )
+
+    n_rows, n_cols = int(shape[0]), int(shape[1])
+    # NOTE: `min`/`max` are shadowed by torch-op converter functions defined in
+    # this module, so we clamp explicitly instead of using the builtins.
+    if offset >= 0:
+        length = n_cols - offset
+        if length > n_rows:
+            length = n_rows
     else:
-        raise NotImplementedError("Only offset == 0 and dim1 == 0 and dim2 == 1 handled")
+        length = n_rows + offset
+        if length > n_cols:
+            length = n_cols
+    if length < 0:
+        length = 0
+
+    if offset >= 0:
+        indices = [[i, i + offset] for i in range(length)]
+    else:
+        indices = [[i - offset, i] for i in range(length)]
+
+    indices = np.array(indices, dtype=np.int32).reshape(-1, 2)
+    diagonal = mb.gather_nd(x=x, indices=indices, name=node.name)
 
     context.add(diagonal)
 

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -7274,6 +7274,33 @@ class TestTril(TorchBaseTest):
         )
 
 
+class TestDiagonal(TorchBaseTest):
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend, shape, offset",
+        itertools.product(
+            compute_units,
+            backends,
+            frontends,
+            [(5, 5), (3, 6), (6, 3), (4, 4), (2, 7)],
+            [0, 1, 2, -1, -2],
+        ),
+    )
+    def test_diagonal(self, compute_unit, backend, frontend, shape, offset):
+        # torch.diagonal extracts the requested diagonal as a 1-D vector, so the
+        # converter must gather those elements rather than masking the
+        # off-diagonal entries (which would keep the input's 2-D shape).
+        model = ModuleWrapper(torch.diagonal, {"offset": offset})
+        input_data = torch.randn(shape)
+        self.run_compare_torch(
+            input_data,
+            model,
+            input_as_shape=False,
+            compute_unit=compute_unit,
+            backend=backend,
+            frontend=frontend,
+        )
+
+
 class TestMatMul(TorchBaseTest):
     @pytest.mark.parametrize(
         "compute_unit, backend, frontend",


### PR DESCRIPTION
## Summary

The PyTorch `diagonal` op was converted using `mb.band_part(lower=0, upper=0)`, which only zeroes out the off-diagonal entries and returns a tensor with the same 2-D shape as the input. `torch.diagonal` instead returns the requested diagonal as a 1-D vector, so the converted model produced incorrect output (a masked matrix instead of the diagonal values).

This changes the converter to gather the diagonal elements with `gather_nd`, producing the correct 1-D result. Positive/negative `offset` and negative `dim1`/`dim2` values are handled. Configurations that are not supported (rank > 2 inputs, dynamically-shaped inputs) now raise an explicit `NotImplementedError` instead of silently returning wrong values.

Fixes #2565.

## Testing

- Added `TestDiagonal` in `test_torch_ops.py` covering square and rectangular shapes across offsets `[0, 1, 2, -1, -2]`.
- Verified locally end-to-end (`ct.convert` + `predict`) that the CoreML output matches PyTorch, e.g. `torch.diagonal` of a 5x5 range tensor now returns `[0, 6, 12, 18, 24]`.
