### PR TITLE
fix(mil): reject symbolic classifier probability shapes

### DIFF
--- a/coremltools/converters/mil/frontend/torch/test/test_torch_conversion_api.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_conversion_api.py
@@ -462,7 +462,9 @@ class TestPyTorchConverterExamples:
         return traced_model, example_input
 
     @staticmethod
-    def _convert_classifier_model(traced_model, example_input, class_type, backend="mlprogram"):
+    def _convert_classifier_model(
+        traced_model, example_input, class_type, backend="mlprogram", input_shape=None
+    ):
         label = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         if class_type == "str":
             label = list(map(lambda x: str(x), label))
@@ -474,12 +476,31 @@ class TestPyTorchConverterExamples:
             inputs=[
                 ct.TensorType(
                     name="input",
-                    shape=example_input.shape,
+                    shape=example_input.shape if input_shape is None else input_shape,
                     dtype=example_input.numpy().dtype,
                 )
             ],
             classifier_config=classifier_config,
         )
+
+    @staticmethod
+    def test_torch_classifier_rejects_symbolic_probabilities():
+        class Net(torch.nn.Module):
+            def forward(self, probabilities):
+                return torch.relu(probabilities)
+
+        example_input = torch.rand(1, 10)
+        traced_model = torch.jit.trace(Net().eval(), example_input)
+        input_shape = ct.EnumeratedShapes(
+            shapes=[(1, 10), (4, 10), (8, 10)]
+        )
+
+        with pytest.raises(
+            ValueError, match="Classifier probabilities must have a fully known shape"
+        ):
+            TestPyTorchConverterExamples._convert_classifier_model(
+                traced_model, example_input, "str", input_shape=input_shape
+            )
 
     @staticmethod
     def test_torch_classifier():

--- a/coremltools/converters/mil/mil/ops/defs/iOS15/classify.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS15/classify.py
@@ -66,11 +66,13 @@ class classify(Operation):
             msg = "Type of elements in 'classes' in the op 'classify' must be either str or int64. Instead it is {}."
             raise ValueError(msg.format(classes_elem_type.__type_info__()))
 
+        if any_symbolic(self.probabilities.shape):
+            raise ValueError("Classifier probabilities must have a fully known shape.")
+
         # check that the size of "classes" is compatible with the size of "probabilities"
-        if not any_symbolic(self.probabilities.shape):
-            size = np.prod(self.probabilities.shape)
-            if len(self.classes.val) != size:
-                msg = "In op 'classify', number of classes must match the size of the tensor corresponding to 'probabilities'."
-                raise ValueError(msg)
+        size = np.prod(self.probabilities.shape)
+        if len(self.classes.val) != size:
+            msg = "In op 'classify', number of classes must match the size of the tensor corresponding to 'probabilities'."
+            raise ValueError(msg)
 
         return classes_elem_type, types.dict(classes_elem_type, types.double)


### PR DESCRIPTION
Fixes #2764.

Reject symbolic classifier probability shapes during `classify` type inference, preventing conversion from producing an undeployable classifier artifact.

Tests:
- `pytest coremltools/converters/mil/frontend/torch/test/test_torch_conversion_api.py::TestPyTorchConverterExamples::test_torch_classifier_rejects_symbolic_probabilities coremltools/converters/mil/frontend/torch/test/test_torch_conversion_api.py::TestPyTorchConverterExamples::test_torch_classifier -q`
- `ruff check coremltools/converters/mil/mil/ops/defs/iOS15/classify.py`