### PR TITLE
Fix torch.atan2 for y == 0 with negative x

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -7263,7 +7263,10 @@ def atan2(context, node):
     x_equal_0 = mb.equal(x=x, y=0.0)
 
     # combined logical expressions
-    ygreater0_and_xless0 = mb.logical_and(x=y_greater_0, y=x_less_0)
+    # y == 0 belongs to the upper half plane, i.e. torch.atan2(0, x) is pi for x < 0,
+    # so the rotation by pi has to cover y >= 0 rather than y > 0
+    y_greater_equal_0 = mb.greater_equal(x=y, y=0.0)
+    ygreater0_and_xless0 = mb.logical_and(x=y_greater_equal_0, y=x_less_0)
     yless0_and_xless0 = mb.logical_and(x=y_less_0, y=x_less_0)
     ygreater0_and_xequal0 = mb.logical_and(x=y_greater_0, y=x_equal_0)
     yless0_and_xequal0 = mb.logical_and(x=y_less_0, y=x_equal_0)
@@ -7284,11 +7287,16 @@ def atan2(context, node):
 
     # if -1e-8 < x < 1e-8, x += 2e-8 to avoid y / 0
     # this shift makes atan2(0, 0) = 0, which is consistent with PyTorch torch.atan2
+    # the shift follows the sign of x, since flipping a tiny negative x to positive would
+    # move atan(y / x_safe) into the other half plane while the quadrant coefficients
+    # above still correct for x < 0
     x0left = mb.greater(x=x, y=-1e-8)
     x0right = mb.less(x=x, y=1e-8)
     x0 = mb.logical_and(x=x0left, y=x0right)
     x0numeric = mb.cast(x=x0, dtype="fp32")
-    safe_shift = mb.mul(x=x0numeric, y=2e-8)
+    x_less_0_numeric = mb.cast(x=x_less_0, dtype="fp32")
+    shift_sign = mb.sub(x=1.0, y=mb.mul(x=x_less_0_numeric, y=2.0))
+    safe_shift = mb.mul(x=mb.mul(x=x0numeric, y=2e-8), y=shift_sign)
     x_safe = mb.add(x=x, y=safe_shift)
 
     # compute atan(y / x)

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -7208,6 +7208,47 @@ class TestAtan2(TorchBaseTest):
         )
 
     @pytest.mark.parametrize(
+        "compute_unit, backend, frontend",
+        itertools.product(compute_units, backends, frontends),
+    )
+    def test_atan2_y0_xnegative(self, compute_unit, backend, frontend):
+        # torch.atan2(0, x) is pi for x < 0, so the quadrant correction has to cover
+        # y == 0 as well, not only y > 0
+        model = ModuleWrapper(function=torch.atan2)
+        y = torch.tensor([0.0, 0.0, 0.0])
+        x = torch.tensor([-1.0, -3.0, -0.5])
+        self.run_compare_torch(
+            (y, x),
+            model,
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+            input_as_shape=False,
+        )
+
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend",
+        itertools.product(compute_units, backends, frontends),
+    )
+    def test_atan2_x_tiny_negative(self, compute_unit, backend, frontend):
+        # x is shifted away from 0 to avoid dividing by it; the shift has to keep the
+        # sign of x, otherwise atan(y / x_safe) lands in the wrong half plane while the
+        # quadrant correction still assumes x < 0, and the result is off by pi
+        if backend[1] == "fp16":
+            pytest.skip("1e-9 is not representable in fp16, it flushes to 0")
+        model = ModuleWrapper(function=torch.atan2)
+        y = torch.tensor([1.0, -1.0, 0.0])
+        x = torch.tensor([-1e-9, -1e-9, -1e-9])
+        self.run_compare_torch(
+            (y, x),
+            model,
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+            input_as_shape=False,
+        )
+
+    @pytest.mark.parametrize(
         "compute_unit, backend, frontend, rank",
         itertools.product(compute_units, backends, frontends, range(1, 6)),
     )


### PR DESCRIPTION
### Problem

`torch.atan2` returns the wrong quadrant in two cases.

The rotation by π for `x < 0` is gated on strictly `y > 0`, so `atan2(0, x)` for `x < 0` returns `0` instead of `π`. Separately, the "avoid divide-by-zero" shift adds a fixed `+2e-8`, which flips the sign of any `x` in `(-1e-8, 0)` — moving `atan(y / x_safe)` into the other half plane while the quadrant coefficients still correct for `x < 0`, giving another ±π error.

```
y = [0, 0,  1, -1]
x = [-1, -3, -1e-9, -1e-9]

torch : [ 3.14159,  3.14159,  1.57080, -1.57080]
before: [ 0.00000,  0.00000,  4.71239, -4.71239]
after : [ 3.14159,  3.14159,  1.57080, -1.57080]
```

### Fix

Use `greater_equal(y, 0)` for the `x < 0` rotation, and make the safe shift follow `sign(x)`.

The `x == 0` branches keep strict `>` / `<`, so `atan2(0, 0) == 0` is preserved to match PyTorch.

### Testing

Added `test_atan2_y0_xnegative` and `test_atan2_x_tiny_negative`. Before: `6 failed, 2 skipped`. After: `46 passed, 2 skipped`, and the full `TestAtan2` class passes 84.

A 2000-element random sweep including zeros and tiny negatives shows 0 mismatches against eager PyTorch, max error 2.4e-7.

The existing `TestAtan2` covers random inputs, `x == 0`, and `y == 0 & x == 0` — the `y == 0, x < 0` quadrant was never exercised.