### PR TITLE
Fix torch.all/torch.any for non-boolean input

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -2179,6 +2179,13 @@ def mean(context, node):
 
     node_kind = node.kind.split(".")[0]
     if node_kind in ("all", "any"):
+        # torch treats every non-zero element as true, so casting to int32 and reducing
+        # with min / max would be wrong for non-boolean input: it truncates values in
+        # (-1, 1) to 0 and makes reduce_min / reduce_max compare magnitudes instead of
+        # truthiness
+        if not types.is_bool(x.dtype):
+            x, zero = promote_input_dtypes([x, mb.const(val=0)])
+            x = mb.not_equal(x=x, y=zero)
         x = mb.cast(x=x, dtype="int32")
         kwargs["x"] = x
         if node_kind == "all":

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -12549,6 +12549,34 @@ class TestSum(TorchBaseTest):
             input_as_shape=False,
         )
 
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend, input_dtype",
+        itertools.product(compute_units, backends, frontends, [torch.int32, torch.float32]),
+    )
+    def test_all_any_non_bool(self, compute_unit, backend, frontend, input_dtype):
+        # torch treats every non-zero element as true, so all / any must not compare
+        # magnitudes: [-1, 0] is not all-true even though its minimum is not the largest
+        # value, and [-1, 0] is any-true even though its maximum is 0
+        class TestModel(nn.Module):
+            def forward(self, x):
+                return torch.all(x, dim=1), torch.any(x, dim=1)
+
+        if input_dtype == torch.int32:
+            input_data = torch.tensor([[-1, 0, 3], [-1, -2, -3], [0, 0, 0]], dtype=torch.int32)
+        else:
+            input_data = torch.tensor(
+                [[0.5, 0.5, 0.5], [-0.5, 0.0, 0.5], [0.0, 0.0, 0.0]], dtype=torch.float32
+            )
+
+        self.run_compare_torch(
+            input_data,
+            TestModel(),
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+            input_as_shape=False,
+        )
+
 
 class TestCumSum(TorchBaseTest):
     @pytest.mark.parametrize(

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -12549,27 +12549,46 @@ class TestSum(TorchBaseTest):
             input_as_shape=False,
         )
 
+    @staticmethod
+    def _non_bool_input(input_dtype):
+        # Rows are all-true, mixed and all-false. The float row [0.5, 0.5, 0.5] is
+        # all-true but truncates to zero, and the int row [-1, -2, -3] is all-true
+        # but has a negative minimum and maximum.
+        if input_dtype == torch.int32:
+            return torch.tensor([[3, 2, 1], [-1, 0, 3], [0, 0, 0]], dtype=torch.int32)
+        return torch.tensor(
+            [[0.5, 0.5, 0.5], [-0.5, 0.0, 0.5], [0.0, 0.0, 0.0]], dtype=torch.float32
+        )
+
     @pytest.mark.parametrize(
         "compute_unit, backend, frontend, input_dtype",
         itertools.product(compute_units, backends, frontends, [torch.int32, torch.float32]),
     )
-    def test_all_any_non_bool(self, compute_unit, backend, frontend, input_dtype):
-        # torch treats every non-zero element as true, so all / any must not compare
-        # magnitudes: [-1, 0] is not all-true even though its minimum is not the largest
-        # value, and [-1, 0] is any-true even though its maximum is 0
+    def test_all_non_bool(self, compute_unit, backend, frontend, input_dtype):
         class TestModel(nn.Module):
             def forward(self, x):
-                return torch.all(x, dim=1), torch.any(x, dim=1)
-
-        if input_dtype == torch.int32:
-            input_data = torch.tensor([[-1, 0, 3], [-1, -2, -3], [0, 0, 0]], dtype=torch.int32)
-        else:
-            input_data = torch.tensor(
-                [[0.5, 0.5, 0.5], [-0.5, 0.0, 0.5], [0.0, 0.0, 0.0]], dtype=torch.float32
-            )
+                return torch.all(x, dim=1)
 
         self.run_compare_torch(
-            input_data,
+            self._non_bool_input(input_dtype),
+            TestModel(),
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+            input_as_shape=False,
+        )
+
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend, input_dtype",
+        itertools.product(compute_units, backends, frontends, [torch.int32, torch.float32]),
+    )
+    def test_any_non_bool(self, compute_unit, backend, frontend, input_dtype):
+        class TestModel(nn.Module):
+            def forward(self, x):
+                return torch.any(x, dim=1)
+
+        self.run_compare_torch(
+            self._non_bool_input(input_dtype),
             TestModel(),
             frontend=frontend,
             backend=backend,


### PR DESCRIPTION
### Problem

`torch.all` and `torch.any` are lowered by casting to `int32` and reducing with `reduce_min` / `reduce_max`. That compares magnitudes rather than truthiness, and truncates values in `(-1, 1)` to `0`. PyTorch treats every non-zero element as true.

```
x = [[-1, 0, 3], [-1, -2, -3]]   (int32)
torch : all [False, True]    any [True, True]
before: all [ True, True]    any [True, True]

x = [[0.5, 0.5], [-0.5, 0.0]]    (fp32)
torch : all [ True, False]   any [ True,  True]
before: all [False, False]   any [False, False]
```

Both directions are wrong: negative integers are treated as true by `all` when they should be, but `-1` reduces to a smaller `int32` than `0` so `reduce_min` picks the wrong winner; and fractional floats truncate to `0` so a tensor of `0.5`s reads as all-false.

### Fix

Test truthiness with `not_equal(x, 0)` (with dtype promotion) before the existing int32-cast + min/max + bool-cast tail.

Boolean input — which is all the existing tests cover — takes the same path as before and is unaffected.

### Testing

Added `test_all_any_non_bool`. Before: `8 failed`. After: `32 passed`, including the pre-existing `test_all` / `test_any`.

The existing `test_all` / `test_any` build their inputs exclusively with `dtype=torch.bool`, so non-boolean input was never exercised.