### PR TITLE
Fix torch.triu/torch.tril turning infinite input into NaN

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -7340,6 +7340,20 @@ def clamp(context, node):
     context.add(res, node.name)
 
 
+def _zero_out_band(x: Var, lower: int, upper: int) -> Var:
+    """
+    Zero out the ``band_part(lower, upper)`` band of ``x``, keeping everything else.
+
+    The obvious ``x - band_part(x, lower, upper)`` evaluates to NaN wherever ``x`` holds
+    +/-inf, so select against a mask instead, which does not depend on the values of x.
+    """
+    in_band = mb.band_part(
+        x=mb.fill(shape=mb.shape(x=x), value=1.0), lower=lower, upper=upper
+    )
+    zero = mb.cast(x=mb.const(val=0), dtype=builtin_to_string(x.dtype))
+    return mb.select(cond=mb.cast(x=in_band, dtype="bool"), a=zero, b=x)
+
+
 @register_torch_op
 def triu(context, node):
     assert context.frontend != TorchFrontend.EXECUTORCH, "triu is not a core aten op"
@@ -7359,16 +7373,7 @@ def triu(context, node):
     if diagonal <= 0:
         res = mb.band_part(x=x, lower=-diagonal, upper=-1)
     else:
-        y = mb.band_part(x=x, lower=-1, upper=diagonal - 1)
-        use_bool = False
-        if types.is_bool(x.dtype):
-            # The `mb.sub` op doesn't support bool.
-            use_bool = True
-            x = mb.cast(x=x, dtype="int32")
-            y = mb.cast(x=y, dtype="int32")
-        res = mb.sub(x=x, y=y)
-        if use_bool:
-            res = mb.cast(x=res, dtype="bool")
+        res = _zero_out_band(x, lower=-1, upper=diagonal - 1)
     context.add(res, node.name)
 
 
@@ -7391,16 +7396,7 @@ def tril(context, node):
     if diagonal >= 0:
         res = mb.band_part(x=x, lower=-1, upper=diagonal)
     else:
-        y = mb.band_part(x=x, lower=-diagonal - 1, upper=-1)
-        use_bool = False
-        if types.is_bool(x.dtype):
-            # The `mb.sub` op doesn't support bool.
-            use_bool = True
-            x = mb.cast(x=x, dtype="int32")
-            y = mb.cast(x=y, dtype="int32")
-        res = mb.sub(x=x, y=y)
-        if use_bool:
-            res = mb.cast(x=res, dtype="bool")
+        res = _zero_out_band(x, lower=-diagonal - 1, upper=-1)
     context.add(res, node.name)
 
 

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -7265,6 +7265,24 @@ class TestTriu(TorchBaseTest):
             frontend=frontend,
         )
 
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend",
+        itertools.product(compute_units, backends, frontends),
+    )
+    def test_triu_infinite_input(self, compute_unit, backend, frontend):
+        # The dropped triangle has to be zeroed rather than subtracted away, otherwise
+        # +/-inf elements turn into NaN.
+        model = ModuleWrapper(torch.triu, {"diagonal": 1})
+        input_data = torch.full((4, 4), float("-inf"))
+        self.run_compare_torch(
+            input_data,
+            model,
+            input_as_shape=False,
+            compute_unit=compute_unit,
+            backend=backend,
+            frontend=frontend,
+        )
+
 
 class TestTril(TorchBaseTest):
     @pytest.mark.parametrize(
@@ -7288,6 +7306,24 @@ class TestTril(TorchBaseTest):
             input_data = torch.randint(low=-10, high=10, size=shape)
         elif dtype == torch.bool:
             input_data = torch.randint(low=0, high=2, size=shape).to(torch.bool)
+        self.run_compare_torch(
+            input_data,
+            model,
+            input_as_shape=False,
+            compute_unit=compute_unit,
+            backend=backend,
+            frontend=frontend,
+        )
+
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend",
+        itertools.product(compute_units, backends, frontends),
+    )
+    def test_tril_infinite_input(self, compute_unit, backend, frontend):
+        # The dropped triangle has to be zeroed rather than subtracted away, otherwise
+        # +/-inf elements turn into NaN.
+        model = ModuleWrapper(torch.tril, {"diagonal": -1})
+        input_data = torch.full((4, 4), float("-inf"))
         self.run_compare_torch(
             input_data,
             model,


### PR DESCRIPTION
### Problem

`triu(x, diagonal > 0)` and `tril(x, diagonal < 0)` are lowered as `x - band_part(x, ...)`. Any element that should be dropped is therefore computed as `x - x`, which is `inf - inf = NaN` rather than `0` when the input holds ±inf.

```
torch.triu(torch.full((3, 3), -inf), diagonal=1)

torch : [[  0, -inf, -inf],
         [  0,    0, -inf],
         [  0,    0,    0]]

before: [[nan, -inf, -inf],
         [nan,  nan, -inf],
         [nan,  nan,  nan]]
```

### Fix

Added a `_zero_out_band` helper that selects against a band mask built from a constant `fill`, so the result no longer depends on the input's values.

This also lets the bool special case go: `select` handles bool, while `sub` does not.

### Testing

Added `test_triu_infinite_input` and `test_tril_infinite_input`. Before: `8 failed`. After: `296 passed` across the full `TestTriu` + `TestTril`. Spot-checked `triu` / `tril` at `diagonal` ∈ {−2, 0, 1, 2} on fp32, int32 and rank-3 inputs — all match eager PyTorch.

### Note on reachability

The classic causal-mask idiom `torch.triu(torch.full_like(scores, -inf), 1)` is const-folded by `torch.jit.trace` into `-3.4e38`, so that exact shape dodges the NaN. This bites when the `triu` / `tril` input is a runtime tensor that can hold ±inf, which is why it has gone unnoticed.