### PR TITLE
Do not add MIL's stability epsilon in torch.reciprocal

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -7469,7 +7469,9 @@ def reciprocal(context, node):
     # reciprocal(prim::NumToTensor(int))) fail to convert.
     if types.is_int(x.dtype):
         x = mb.cast(x=x, dtype="fp32")
-    context.add(mb.inverse(x=x, name=node.name))
+    # torch.reciprocal is exactly 1 / x, so opt out of the stability epsilon
+    # (default 1e-4) that mb.inverse would otherwise add to the input.
+    context.add(mb.inverse(x=x, epsilon=0.0, name=node.name))
 
 
 @register_torch_op

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -7236,6 +7236,27 @@ class TestElementWiseUnary(TorchBaseTest):
         )
 
     @pytest.mark.parametrize(
+        "compute_unit, backend, frontend",
+        itertools.product(compute_units, backends, frontends),
+    )
+    def test_reciprocal_small_input(self, compute_unit, backend, frontend):
+        # mb.inverse adds a stability epsilon (1e-4 by default) that torch does
+        # not, which dominates the result once the input gets small.
+        input_data = torch.tensor([[0.25, 0.5, 1.0, 2.0]])
+        model = ModuleWrapper(function=torch.reciprocal)
+        mlmodel = self.run_compare_torch(
+            input_data,
+            model,
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+            input_as_shape=False,
+        )
+        inverse_ops = mlmodel[1]._mil_program.find_ops(op_type="inverse")
+        assert len(inverse_ops) == 1
+        assert inverse_ops[0].epsilon.val == 0
+
+    @pytest.mark.parametrize(
         "compute_unit, backend, frontend, dtype",
         itertools.product(
             compute_units,


### PR DESCRIPTION
### Problem

`mb.inverse` computes `1 / (x + epsilon)` with `epsilon` defaulting to **1e-4**. `torch.reciprocal` is exactly `1 / x`. The converter never set `epsilon`, so every converted reciprocal is off by roughly `epsilon / x²` — which is negligible for large inputs and catastrophic for small ones.

Measured through real `predict()` (mlprogram, CPU_ONLY, fp32):

```
input      : [1.0e-04 1.0e-03 1.0e-02 2.5e-01 1.0e+00]
torch      : [1.0000000e+04 9.9999994e+02 1.0000000e+02 4.0000000e+00 1.0000000e+00]

before     : [5.0000005e+03 9.0909094e+02 9.9009903e+01 3.9984009e+00 9.9990004e-01]
rel err    : [5.0e-01      9.09e-02     9.90e-03     4.00e-04     1.00e-04]

after      : [1.0000001e+04 9.9999988e+02 1.0000000e+02 4.0000000e+00 1.0000000e+00]
rel err    : [9.77e-08     6.10e-08     0.0          0.0          0.0        ]
```

**50% relative error at 1e-4.** This also affects plain `1.0 / tensor`, which TorchScript traces to `aten::reciprocal` — the inverse-frequency / RoPE / normalization idiom, where small denominators are exactly the normal case.

`log1p` in the same file already opts out of the equivalent default (`mb.log(x=x, epsilon=1.0)`).

### Why existing tests missed it

`test_elementwise_numerically_stable` is the only reciprocal test and uses `rand_range=(20, 100)`, where the offset stays well under tolerance.

### Note on the `neuralnetwork` backend

On `neuralnetwork` the improvement is 1e-4 → 1e-6 rather than to zero: proto3 omits zero-valued scalars, so the field disappears from the serialized model and the NN runtime substitutes its own 1e-6 default.

For the same reason I did **not** apply this to `rsqrt`, even though it has the identical shape. I tried it and measured a *regression* on `neuralnetwork` — MIL's `rsqrt` default is 1e-12, so dropping the field there replaces 1e-12 with the runtime's 1e-6. Left alone deliberately.

`coremltools/converters/mil/frontend/tf/ops.py` has the same defect in the TF frontend, but TensorFlow isn't installed in my environment so I left it untested and out of this diff.

### Testing

Added `TestElementWiseUnary::test_reciprocal_small_input`. On `main` 4/4 params fail (`assert np.float16(0.0001) == 0`, and `Max absolute difference among violations: 0.00159907`); with the fix 4/4 pass. Full `TestElementWiseUnary` (228 params) green.
