### PR TITLE
Fix torch.narrow with a negative start

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -781,8 +781,16 @@ def narrow(context, node):
     end = list(x.shape)
     end[dim.val] = start.val + length.val
 
+    # torch.narrow accepts a negative start, which counts from the end of the
+    # dim. Such a slice reaches the end of the dim exactly when start + length
+    # is 0, which slice_by_index would read as the absolute index 0 and turn
+    # into an empty slice, so mask that end off instead.
+    end_mask = [False] * len(x.shape)
+    if start.val < 0 and end[dim.val] == 0:
+        end_mask[dim.val] = True
+
     context.add(
-        mb.slice_by_index(x=x, begin=begin, end=end, name=node.name)
+        mb.slice_by_index(x=x, begin=begin, end=end, end_mask=end_mask, name=node.name)
     )
 
 

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -759,6 +759,43 @@ class TestNarrow(TorchBaseTest):
                         compute_unit=compute_unit,
                     )
 
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend, shape",
+        itertools.product(
+            compute_units,
+            backends,
+            frontends,
+            COMMON_SHAPES,
+        ),
+    )
+    def test_narrow_negative_start(self, compute_unit, backend, frontend, shape):
+        """A negative start counts from the end of the dim, e.g. the last
+        element of the last dim is narrow(x, -1, -1, 1)."""
+
+        class Model(torch.nn.Module):
+            def __init__(self, dim, start, length):
+                super().__init__()
+                self.dim = dim
+                self.start = start
+                self.length = length
+
+            def forward(self, x):
+                return torch.narrow(x, self.dim, self.start, self.length)
+
+        for cur_dim in range(len(shape)):
+            for cur_start in range(-shape[cur_dim], 0):
+                for cur_length in range(1, -cur_start + 1):
+
+                    m = Model(cur_dim, cur_start, cur_length)
+
+                    TorchBaseTest.run_compare_torch(
+                        shape,
+                        m,
+                        frontend=frontend,
+                        backend=backend,
+                        compute_unit=compute_unit,
+                    )
+
 
 class TestWeightNorm(TorchBaseTest):
     @pytest.mark.parametrize(


### PR DESCRIPTION
### Problem

`torch.narrow` accepts a negative `start`, counting from the end of the dim. The converter forwarded `start` and `start + length` straight to `slice_by_index`. A negative-start slice that reaches the end of the dim has `start + length == 0`, which `slice_by_index` reads as the **absolute** index 0 — producing an empty slice or an error.

`torch.narrow(x, -1, -1, 1)`, taking the last element, is the common case.

Measured with `x = arange(24).reshape(2, 3, 4)`, `torch.narrow(x, -1, -1, 1)`:

```
before, mlprogram fp32     torch (2,3,1) = [3. 7. 11. 15. 19. 23.]
                           coreml (2,3,0) = []            <-- silently empty

before, mlprogram fp16     ValueError: slice_by_index op: unsupported values
                           for dimension 2, (begin, end, stride) : (3, 0, 1)

after,  both               coreml (2,3,1) = [3. 7. 11. 15. 19. 23.]
```

The fp32 case is the dangerous one — no error, just a silently empty result.

### Fix

Mask the end off for that dim rather than passing a `0` that means "the beginning". Swept 19 `(dim, start, length)` combinations: broken exactly when `start < 0 and start + length == 0`, on every dim including negative `dim`; all 19 correct afterwards.

### Testing

Added `TestNarrow::test_narrow_negative_start`. On `main` 6/16 params fail — all on the TorchScript frontend, since `torch.export` normalizes the start before it reaches the converter. With the fix 16/16 pass, and the full `TestNarrow` is 32/32.

The existing `TestNarrow` only loops `cur_start in range(shape[dim] - 1)`, so negative starts were never exercised.
