### PR TITLE
Stop slice_by_index type inference rewriting its begin/end consts

### DIFF
--- a/coremltools/converters/mil/mil/ops/defs/_utils.py
+++ b/coremltools/converters/mil/mil/ops/defs/_utils.py
@@ -522,11 +522,17 @@ def solve_slice_by_index_shape(x_shape, begin, end, stride, begin_mask, end_mask
     Helper function to solve the shape of tensor slicing.
     """
     # set default values
+    # begin and end are copied because the negative index normalization below
+    # writes into them, and callers pass the values of their begin/end consts
     rank = len(x_shape)
     if begin is None or len(begin) == 0:
         begin = [None] * rank
+    else:
+        begin = list(begin)
     if end is None or len(end) == 0:
         end = [None] * rank
+    else:
+        end = list(end)
     if stride is None:
         stride = [1] * rank
     if begin_mask is None:

--- a/coremltools/converters/mil/mil/ops/tests/iOS14/test_tensor_transformation.py
+++ b/coremltools/converters/mil/mil/ops/tests/iOS14/test_tensor_transformation.py
@@ -745,6 +745,44 @@ class TestSliceByIndex:
             backend=backend,
         )
 
+    @pytest.mark.parametrize(
+        "compute_unit, backend",
+        itertools.product(compute_units, backends),
+    )
+    def test_shared_negative_begin_const(self, compute_unit, backend):
+        """Type inference must not rewrite the begin const it is handed. A
+        const shared by two slices over differently sized inputs would
+        otherwise get normalized against the first input's shape only."""
+        x_val = np.arange(10).reshape((1, 10)).astype(np.float32)
+        y_val = np.arange(100, 120).reshape((1, 20)).astype(np.float32)
+        input_placeholders = {
+            "x": mb.placeholder(shape=x_val.shape),
+            "y": mb.placeholder(shape=y_val.shape),
+        }
+        input_values = {"x": x_val, "y": y_val}
+
+        def build(x, y):
+            begin = mb.const(val=np.array([0, -1], dtype=np.int32))
+            return [
+                mb.slice_by_index(x=x, begin=begin, end=[1, 10]),
+                mb.slice_by_index(x=y, begin=begin, end=[1, 20]),
+            ]
+
+        expected_output_types = [(1, 1, types.fp32)] * 2
+        expected_outputs = [
+            np.array([[9]], dtype=np.float32),
+            np.array([[119]], dtype=np.float32),
+        ]
+        run_compare_builder(
+            build,
+            input_placeholders,
+            input_values,
+            expected_output_types,
+            expected_outputs,
+            compute_unit=compute_unit,
+            backend=backend,
+        )
+
     def test_type_inference(self):
         s0 = get_new_symbol()
         s1 = get_new_symbol()


### PR DESCRIPTION
### Problem

`solve_slice_by_index_shape` normalizes negative indices with `begin[idx] = max(0, begin[idx] + x_shape[idx])`, writing **into the list it was handed**. `slice_by_index.type_inference` passes `self.begin.val` / `self.end.val` directly, so the op's own const inputs get rewritten to be relative to that op's input shape.

When one const is shared by two slices over differently sized inputs, the second slice inherits the first's normalization and silently produces the wrong shape:

```python
begin = mb.const(val=[0, -1])
a = mb.slice_by_index(x=x, begin=begin, end=[1, 10])   # x is (1, 10)
b = mb.slice_by_index(x=y, begin=begin, end=[1, 20])   # y is (1, 20)
```

```
before   slice_0: begin=[0 9] end=[ 1 10] -> (1, 1)
         slice_1: begin=[0 9] end=[ 1 20] -> (1, 11)     <-- wrong shape, no error
         predict: slice_1 (1,11) [109. ... 119.]   expected [119.]

after    slice_0: begin=[ 0 -1] -> (1, 1)   predict [9.]
         slice_1: begin=[ 0 -1] -> (1, 1)   predict [119.]
```

Directly: `solve_slice_by_index_shape((1,10), begin=[0,-1], ...)` leaves `begin` as `[0 9]` before the fix and `[0 -1]` after.

The sibling helper `solve_slice_by_index_slice` already copies its inputs (`begin = [int(i) for i in list(begin[:])]`); this one just doesn't.

This is also the mechanism behind a confusing secondary symptom: a second inference pass sees the already-rewritten `begin`, which is where the `slice_by_index op: unsupported values ... (begin, end, stride) : (3, 0, 1)` error in #2774 comes from.

### Testing

Added `TestSliceByIndex::test_shared_negative_begin_const`. On `main` 2/2 fail (`Output slice_by_index_1 shape: expect (1, 1), got (1, 11)`); with the fix 2/2 pass.

Regression checks: all three `test_tensor_transformation.py` files (iOS14/15/18) fully green. I specifically probed `_internal_op_tensor_inplace_fill`, which passes `begin.val` in and then reuses the same `Var` downstream — so it *was* consuming the mutated value. Six negative-index assignment forms (`a[:, -1:] = 99`, `a[:, -3:-1] = 99`, `a[:, -1] = 99`, …) give byte-identical correct results before and after.

`TestTensorAssign` + `TestSelect` show one failure, `test_tensor_assign_case_broadcast[mlprogram fp16, shape=(5,4,3), target=9]` — confirmed pre-existing, it fails identically on `upstream/main`.
