### PR TITLE
Do not fuse const / conv into the conv weights

### DIFF
--- a/coremltools/converters/mil/mil/passes/defs/optimize_conv.py
+++ b/coremltools/converters/mil/mil/passes/defs/optimize_conv.py
@@ -870,6 +870,10 @@ class fuse_conv_scale(AbstractGraphPass):
 
     @staticmethod
     def _try_to_transform(conv_op, scale_op):
+        # real_div is not commutative, so const / conv cannot be folded into the weights
+        if scale_op.op_type == "real_div" and scale_op.x is not conv_op.outputs[0]:
+            return False
+
         # get the scale
         if scale_op.x.val is None and scale_op.y.val is None:
             return False

--- a/coremltools/converters/mil/mil/passes/tests/test_passes.py
+++ b/coremltools/converters/mil/mil/passes/tests/test_passes.py
@@ -3986,6 +3986,35 @@ class TestConvScaleFusion:
             backend=backend,
         )
 
+    @pytest.mark.parametrize("backend", backends)
+    def test_conv_const_numerator_not_fused(self, backend):
+        """
+        Input graph:
+        input -----> conv -----> real_div(x=const, y=conv) ---> out
+
+        real_div is not commutative, so this must be left alone.
+        """
+        Cin, Cout = 3, 4
+        input_shape = (1, Cin, 2, 2)
+        scale = np.arange(1, Cout + 1).astype(np.float32).reshape(1, Cout, 1, 1)
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=input_shape)])
+        def prog(x):
+            conv = mb.conv(x=x, weight=np.ones((Cout, Cin, 1, 1), np.float32))
+            return mb.real_div(x=scale, y=conv)
+
+        prev_prog, prev_block, block = apply_pass_and_basic_check(prog, "common::fuse_conv_scale")
+
+        assert get_op_types_in_program(prev_prog) == ["conv", "real_div"]
+        assert get_op_types_in_program(prog) == ["conv", "real_div"]
+
+        assert_model_is_valid(
+            prog,
+            {"x": input_shape},
+            expected_output_shapes={block.outputs[0].name: (1, Cout, 2, 2)},
+            backend=backend,
+        )
+
     @pytest.mark.parametrize(
         "rank, groups, has_bias, scale_op, scale_type, backend",
         itertools.product(


### PR DESCRIPTION
### Problem

`fuse_conv_scale._try_to_transform` picks the scale operand as `scale_op.x if scale_op.x.val is not None else scale_op.y`, then for `real_div` folds `1.0 / scale` into the conv weights. That is correct for `mul`, which is commutative, but nothing checks that the conv output is the *numerator* of the division. For `const / conv` the whole division is dropped and the optimized program is a bare `conv`.

Reachable from ordinary PyTorch — `self.n / self.c(x)` with a per-channel buffer:

```
torch : [0.3333, 0.6667, 1.0000, 1.3333]
coreml: [3.0000, 1.5000, 1.0000, 0.7500]
```

Max absolute error 2.67, a factor of 9 on the first channel.

### Fix

Bail out when the op is `real_div` and the conv output is not the numerator.

### Why it was never caught

`_apply_weight_transform` has an `is_conv_first_input` parameter, but it is only applied to the `mul` branch — the `real_div` branch always builds `mb.real_div(x=conv, y=scale)`, so the reversed shape was untested.

### Testing

New test asserts the pass leaves `["conv", "real_div"]` intact. Fails on `main` on both backends, passes with the fix. Targeted pass tests go 585 → 587 passed with no regressions.

(Note: the full `test_passes.py` segfaults on `upstream/main` as well — pre-existing and unrelated.)
