### PR TITLE
Copy the weight before per-channel-scale normalization in palettize_weights

### DIFF
--- a/coremltools/optimize/coreml/_quantization_passes.py
+++ b/coremltools/optimize/coreml/_quantization_passes.py
@@ -1065,9 +1065,11 @@ class palettize_weights(AbstractCompressionPass):
                 return
 
         if op_config.enable_per_channel_scale:
-            # Normalize by per channel scales before doing palettization.
+            # Normalize by per channel scales before doing palettization. Copy first, because
+            # op.outputs[0].val is the const's own buffer and compression may still be skipped.
             per_channel_scale = np.max(np.abs(weight_to_compress), axis=channel_axis, keepdims=True)
             per_channel_scale[per_channel_scale == 0] = 1
+            weight_to_compress = weight_to_compress.copy()
             weight_to_compress /= per_channel_scale
 
         lut_params = self.blockwise_compress(

--- a/coremltools/test/optimize/coreml/test_post_training_quantization.py
+++ b/coremltools/test/optimize/coreml/test_post_training_quantization.py
@@ -1694,6 +1694,45 @@ class TestPalettizeWeights:
         if _macos_version() >= (15, 0):
             verify_model_outputs(mlmodel, mlmodel_palettized, coreml_input_values)
 
+    def test_palettization_pcs_skipped_keeps_weight(self):
+        """A skipped op must keep its original weight, not the per-channel-scaled one."""
+        inputs = [ct.TensorType(name="data", shape=(1, 128))]
+        model = torch.nn.Linear(128, 120, bias=False).eval()
+        weight = model.weight.detach().numpy().copy()
+
+        torchmodel = torch.jit.trace(model, [torch.rand(1, 128)])
+        mlmodel = ct.convert(
+            torchmodel,
+            inputs=inputs,
+            convert_to="mlprogram",
+            minimum_deployment_target=ct.target.iOS18,
+            compute_precision=ct.precision.FLOAT32,
+        )
+
+        # 120 output channels is not divisible by group_size 16, so palettization is skipped.
+        config = cto.coreml.OptimizationConfig(
+            global_config=cto.coreml.OpPalettizerConfig(
+                mode="uniform",
+                nbits=4,
+                granularity="per_grouped_channel",
+                group_size=16,
+                enable_per_channel_scale=True,
+                weight_threshold=500,
+            )
+        )
+        mlmodel_palettized = cto.coreml.palettize_weights(mlmodel, config)
+
+        assert get_op_types_in_program(mlmodel_palettized._mil_program) == get_op_types_in_program(
+            mlmodel._mil_program
+        )
+        consts = [
+            op.outputs[0].val
+            for op in mlmodel_palettized._mil_program.functions["main"].find_ops(op_type="const")
+            if op.outputs[0].val is not None and op.outputs[0].val.size == weight.size
+        ]
+        assert len(consts) == 1
+        np.testing.assert_allclose(consts[0].reshape(weight.shape), weight, rtol=1e-6)
+
 
 class TestPruneWeights:
     @staticmethod


### PR DESCRIPTION
### Problem

`weight_to_compress = op.outputs[0].val` is the const's live numpy buffer, and `weight_to_compress /= per_channel_scale` mutates it in place. The two earlier skip points sit before that division, but the `blockwise_compress` skip sits after it — so when compression declines, the const survives un-palettized **and** divided by its per-channel max.

The only signal is a `logger.warning("... Skipped this op.")`, which says the opposite of what happened to the weight.

Triggered by an ordinary config — `granularity="per_grouped_channel"`, `group_size=16`, `enable_per_channel_scale=True` on a 120-output-channel `Linear`. 120 isn't divisible by 16, so compression is declined:

```
op types: ['const', 'linear']        (correctly not palettized)
torch : [17.385, -8.286, -19.897, -2.406, -25.859]
coreml: [ 6.430, -3.609,  -7.175, -0.851,  -8.917]
```

Max absolute error 16.94.

### Fix

Copy before normalizing.

### Testing

New test fails on `main` with 15360/15360 elements mismatched, passes with the fix. The success path is bit-identical before and after, verified by checksum. Full PTQ suite has 3 pre-existing failures on both `main` and this branch (they need scikit-learn for k-means); no new ones.
