### PR TITLE
Fix torch.roll with a negative shift on a dynamic dimension

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -8521,8 +8521,12 @@ def roll(context, node):
 
     for s, i in zip(shift, dims):
         dim = _utils.pymil_value_at(shape, i)
-        s = mb.mod(x=s, y=dim)
-        start_idx = mb.sub(x=dim, y=s)
+        # The sign of mod with a negative dividend is backend dependent, so keep both
+        # operands non-negative: rolling right by s is rolling left by -s.
+        if s < 0:
+            start_idx = mb.mod(x=int(-s), y=dim)
+        else:
+            start_idx = mb.sub(x=dim, y=mb.mod(x=int(s), y=dim))
         indices0 = mb.range_1d(end=dim, start=start_idx, step=1)
         indices1 = mb.range_1d(end=start_idx, start=0, step=1)
         indices = mb.concat(values=[indices0, indices1], axis=0)

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -12730,6 +12730,26 @@ class TestRoll(TorchBaseTest):
         model = ModuleWrapper(torch.roll, kwargs={"shifts": shifts, "dims": dims})
         self.run_compare_torch(shape, model, backend=backend, compute_unit=compute_unit)
 
+    @pytest.mark.parametrize(
+        "compute_unit, backend, shifts",
+        itertools.product(compute_units, backends, [-1, -5, -8, 3]),
+    )
+    def test_roll_dynamic_dim(self, compute_unit, backend, shifts):
+        # With a symbolic dim the shift is normalized at runtime, where mod of a
+        # negative dividend does not follow numpy's sign convention.
+        upper_bound = 10 if backend[0] == "mlprogram" else -1
+        converter_input_type = [
+            TensorType(shape=(3, RangeDim(default=5, upper_bound=upper_bound)), dtype=np.float32)
+        ]
+        model = ModuleWrapper(torch.roll, kwargs={"shifts": shifts, "dims": 1})
+        self.run_compare_torch(
+            (3, 5),
+            model,
+            backend=backend,
+            compute_unit=compute_unit,
+            converter_input_type=converter_input_type,
+        )
+
 
 class TestArgmax(TorchBaseTest):
     @pytest.mark.parametrize(


### PR DESCRIPTION
### Problem

`roll` normalizes the shift with `mb.mod(x=s, y=dim)`. With a static shape both operands are const, so MIL folds it using numpy's floored `%` and the result is right. With a symbolic dim the `mod` survives to inference, where the runtime uses truncated (`fmod`) semantics — `mod(-2, 5)` returns `-2`, not `3` — so `start_idx` becomes `dim + 2` and the gather indices are wrong.

The model converts and predicts without error; it just returns the input unrolled:

```
torch : [[2,3,4,0,1],[7,8,9,5,6],[12,13,14,10,11]]
coreml: [[0,1,2,3,4],[5,6,7,8,9],[10,11,12,13,14]]
```

I found this by differential-testing MIL const folding against the runtime across ~65 ops. `mod` was the only divergence: `mb.mod([-7,7,-7,7], [2,-2,-2,2])` folds to `[1,-1,-1,1]` but computes `[-1,1,-1,1]` on device. Its sibling `floor_div` is floored in both, so `mod` is inconsistent with the op next to it.

### Fix

Keep both `mod` operands non-negative — rolling right by `s` is rolling left by `-s`. `shift` comes from `inputs[1].val`, so it is always concrete; only the dim size can be symbolic.

This works around the divergence in the `roll` converter rather than changing `mod` itself, since the const-fold/runtime mismatch is a broader question.

### Testing

New `test_roll_dynamic_dim` fails on `main` for shifts `-1` and `-8` on both backends, passes with the fix. All 40 `TestRoll` cases pass.
