### PR TITLE
Promote int alpha/beta in torch.addmm and torch.baddbmm

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -1118,14 +1118,17 @@ def addmm(context, node):
     if isinstance(alpha, Var):
         alpha = alpha.val
 
+    # beta and alpha are torch scalars, so they may be ints even for float tensors
     if beta != 1.0:
         # Apply beta scaling factor to the input.
+        x, beta = promote_input_dtypes([x, beta])
         x = mb.mul(x=x, y=beta)
 
     matmul = mb.matmul(x=mat1, y=mat2)
 
     if alpha != 1.0:
         # Apply alpha scaling factor to the matrix multiplicaiton
+        alpha, matmul = promote_input_dtypes([alpha, matmul])
         matmul = mb.mul(x=alpha, y=matmul)
 
     result = mb.add(x=x, y=matmul, name=node.name)
@@ -1170,6 +1173,8 @@ def baddbmm(context, node):
 
     if alpha != 1.0:
         # Apply scaling factor alpha to the input.
+        # alpha is a torch scalar, so it may be an int even for float tensors
+        alpha, batch1 = promote_input_dtypes([alpha, batch1])
         batch1 = mb.mul(x=alpha, y=batch1, name=batch1.name + "_scaled")
         context.add(batch1)
 

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -11776,8 +11776,9 @@ class TestAddmm(TorchBaseTest):
             backends,
             frontends,
             ((2, 2, 2), (4, 5, 9)),
-            (1.0, 2.0),
-            (1.0, 3.0),
+            # beta and alpha may be given as ints
+            (1.0, 2.0, 2),
+            (1.0, 3.0, 3),
         ),
     )
     def test_addmm(self, compute_unit, backend, frontend, shapes, beta, alpha):
@@ -11822,16 +11823,17 @@ class TestAddmm(TorchBaseTest):
 
 class TestBaddbmm(TorchBaseTest):
     @pytest.mark.parametrize(
-        "compute_unit, backend, frontend, shapes, beta",
+        "compute_unit, backend, frontend, shapes, beta, alpha",
         itertools.product(
             compute_units,
             backends,
             frontends,
             [(2, 4, 6, 8), (4, 12, 6, 16)],
             [0.0, 0.5, 1.0, 2],
+            [1.0, 3],
         ),
     )
-    def test_baddbmm(self, compute_unit, backend, frontend, shapes, beta):
+    def test_baddbmm(self, compute_unit, backend, frontend, shapes, beta, alpha):
         B, N, M, P = shapes
 
         # input shape: any shape broadcastable to (B, N, P)
@@ -11845,7 +11847,7 @@ class TestBaddbmm(TorchBaseTest):
                 self.batch2 = torch.randn(B, M, P)
 
             def forward(self, x):
-                return torch.baddbmm(x, self.batch1, self.batch2, beta=beta)
+                return torch.baddbmm(x, self.batch1, self.batch2, beta=beta, alpha=alpha)
 
         model = BaddbmmModel()
         # Makes it broadcastable to (B, N, P).


### PR DESCRIPTION
`torch.addmm` and `torch.baddbmm` declare `beta` and `alpha` as `Scalar`, so an integer literal is legal even when the tensors are float. Both converters passed the scalar straight to `mb.mul`, which requires matching dtypes, so conversion failed:

```python
torch.addmm(x, mat1, mat2, beta=2)   # x, mat1, mat2 are float
```
```
ValueError: In op, of type mul, named mul_0, the named input `y` must have the same data type
as the named input `x`. However, y has dtype int32 whereas x has dtype fp32.
```

Writing `2.0` works. The same happens for `alpha` in both ops.

`baddbmm` already casts `beta` for this reason (#1925) but never did the same for `alpha`, and `addmm` does neither. This routes all three scalars through `promote_input_dtypes`, the helper already used for this throughout `ops.py`.

Tests: `test_addmm` gains int values in its existing `beta`/`alpha` parameters; `test_baddbmm` gains an `alpha` parameter, which it previously never exercised. Reverting `ops.py` fails 32 of those tests with the dtype error above.
