### PR TITLE
Validate compiled model path before loading structure or compute plan

### DIFF
--- a/coremltools/models/compute_plan.py
+++ b/coremltools/models/compute_plan.py
@@ -4,6 +4,7 @@
 #  found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
 
+import os as _os
 from dataclasses import dataclass as _dataclass
 from typing import Any as _Any
 from typing import Dict as _Dict
@@ -27,6 +28,40 @@ try:
 except Exception as e:
     _logger.warning(f"Failed to load _MLComputePlanProxy: {e}")
     _MLComputePlanProxy = None
+
+
+def _validate_compiled_model_path(path: _Any) -> None:
+    """
+    Validates that ``path`` refers to a compiled model directory (``.mlmodelc``).
+
+    The underlying framework API terminates the process with SIGABRT, rather than
+    reporting an error, when given a path that exists but is not a compiled model -
+    for instance an uncompiled ``.mlpackage``. The C++ exception is raised on an
+    internal dispatch queue, so it cannot be caught from Python and the caller loses
+    the whole process. Validating up front keeps that mistake recoverable.
+
+    ``coremldata.bin`` is used as the marker because it is the file the framework
+    itself fails to open, and it is present in compiled ``mlprogram`` and
+    ``neuralnetwork`` models alike.
+    """
+    if not isinstance(path, str):
+        raise TypeError('The "path" parameter must be of type "str".')
+
+    if not _os.path.isdir(path):
+        raise ValueError(
+            f'The compiled model path does not exist or is not a directory: "{path}".'
+        )
+
+    if not _os.path.isfile(_os.path.join(path, "coremldata.bin")):
+        message = f'The path is not a compiled model directory: "{path}".'
+        if path.rstrip("/").endswith(".mlpackage"):
+            message += (
+                " It looks like an uncompiled model package. Compile it first with"
+                ' "coremltools.models.utils.compile_model", or use'
+                ' "MLModel.get_compiled_model_path()".'
+            )
+        raise ValueError(message)
+
 
 @_dataclass(frozen=True)
 class MLModelStructureNeuralNetworkLayer:
@@ -288,6 +323,8 @@ class MLModelStructure:
         if _MLModelProxy is None:
             raise ValueError("MLModelStructure is not supported.")
 
+        _validate_compiled_model_path(compiled_model_path)
+
         return _MLModelProxy.get_model_structure(compiled_model_path)
 
 
@@ -444,5 +481,7 @@ class MLComputePlan:
 
         if _MLModelProxy is None:
             raise ValueError("MLComputePlan is not supported.")
+
+        _validate_compiled_model_path(path)
 
         return _MLModelProxy.get_compute_plan(path, compute_units.name)

--- a/coremltools/test/api/test_api_examples.py
+++ b/coremltools/test/api/test_api_examples.py
@@ -687,6 +687,22 @@ class TestMLModelStructure:
                 layer.type in VALID_OPERATORS
             ), f"Expected layer type to be one of {', '.join(VALID_OPERATORS)}, but got '{layer.type}'."
 
+    def test_uncompiled_model_path_raises(self, tmp_path):
+        # An uncompiled .mlpackage path used to abort the process with SIGABRT.
+        model = TestMLModelStructure._get_test_model(type="mlprogram")
+        package_path = str(tmp_path / "model.mlpackage")
+        model.save(package_path)
+        with pytest.raises(ValueError, match="not a compiled model directory"):
+            MLModelStructure.load_from_path(package_path)
+
+    def test_missing_model_path_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="does not exist or is not a directory"):
+            MLModelStructure.load_from_path(str(tmp_path / "no-such-model.mlmodelc"))
+
+    def test_non_string_model_path_raises(self):
+        with pytest.raises(TypeError, match='must be of type "str"'):
+            MLModelStructure.load_from_path(None)
+
 
 @pytest.mark.skipif(
     ct.utils._macos_version() < (14, 4),
@@ -748,6 +764,22 @@ class TestMLComputePlan:
             assert len(compute_device_usage.supported_compute_devices) > 0
             for compute_device in compute_device_usage.supported_compute_devices:
                 assert isinstance(compute_device, MLComputeDevice)
+
+    def test_uncompiled_model_path_raises(self, tmp_path):
+        # An uncompiled .mlpackage path used to abort the process with SIGABRT.
+        model = TestMLModelStructure._get_test_model(type="mlprogram")
+        package_path = str(tmp_path / "model.mlpackage")
+        model.save(package_path)
+        with pytest.raises(ValueError, match="not a compiled model directory"):
+            MLComputePlan.load_from_path(package_path)
+
+    def test_missing_model_path_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="does not exist or is not a directory"):
+            MLComputePlan.load_from_path(str(tmp_path / "no-such-model.mlmodelc"))
+
+    def test_non_string_model_path_raises(self):
+        with pytest.raises(TypeError, match='must be of type "str"'):
+            MLComputePlan.load_from_path(None)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Fixes #2757.

I just hit this exact same issue on an M5 Max and came diving in.

`MLComputePlan.load_from_path` and `MLModelStructure.load_from_path` pass their `path`
argument straight to the native proxy. When the path exists but is not a compiled model,
most commonly an uncompiled `.mlpackage`, the framework throws a C++ exception from
`IArchive`'s constructor on its internal `structureLoadQueue`. That escapes the
`-[MLModelAssetResourceFactoryOnDiskImpl modelStructureWithError:]` `NSError` contract,
reaches `std::terminate`, and aborts the host process. The Python caller is blocked on a
semaphore waiting for the completion handler, so nothing can be caught and the process is
simply gone.

This validates the path first and raises `ValueError` instead.

### Two things worth flagging

**`MLModelStructure.load_from_path` has the same defect**, which the issue does not
mention. It is the same unvalidated hand-off in the same file, and it aborts identically.
Both are fixed here.

**A nonexistent path was already fine.** The native layer surfaces a normal `RuntimeError`
for a missing path, so only the exists-but-wrong-type case was unrecoverable. This change
makes the two consistent rather than introducing a new convention.

### On the marker used

The check keys on `coremldata.bin` rather than the `.mlmodelc` suffix. That file is what
the framework itself fails to open, and I confirmed it is present in compiled `mlprogram`
and `neuralnetwork` models alike:

```
mlprogram      -> ['analytics', 'coremldata.bin', 'model.mil', 'weights']
neuralnetwork  -> ['analytics', 'coremldata.bin', 'model', 'model.espresso.net',
                   'model.espresso.shape', 'model.espresso.weights',
                   'neural_network_optionals']
```

Keying on content rather than the suffix also catches a truncated or renamed directory,
and avoids rejecting a validly compiled model that was saved without the conventional
suffix. If you would rather not couple to the on-disk layout, an extension check alone
would still fix the reported case, and I am happy to switch.

### Question

The issue offered two options: validate and raise, or accept an `.mlpackage` and compile
it internally. I implemented the first, since the second changes the API contract and felt
like your call rather than mine. Happy to add it if you want it.

### Testing

- Reproduced the abort on macOS 26.5.1, M5 Max, coremltools 9.0. Both entry points return
  exit code 134 (SIGABRT) before the change, and raise `ValueError` after.
- Verified a valid `.mlmodelc` still loads unchanged.
- Six new tests in `coremltools/test/api/test_api_examples.py`, three per class, covering
  the uncompiled-package path, the missing path, and a non-string path.
- Full `TestMLModelStructure` and `TestMLComputePlan` classes pass, 10 tests.

The reporter also filed the framework-side issue with Apple as FB23763190.
