### PR TITLE
Support per-channel PReLU alpha for rank 2 and rank 3 input

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -1603,13 +1603,25 @@ def prelu(context, node):
         alpha = alpha.val
         alpha = np.ones((x.shape[1],)) * alpha
 
-    if x.rank <= 2:
-        axes = [1, 2] if x.rank == 1 else [2]
+    # mb.prelu accepts a per-channel alpha only when x is rank 4. For rank 3 it
+    # additionally requires every alpha value to be identical, which
+    # torch.nn.PReLU(num_parameters=C) does not satisfy. prelu is elementwise, so
+    # expand rank 2 and rank 3 input out to rank 4 rather than to the rank 3
+    # minimum: same result, and inside what mb.prelu supports.
+    axes = None
+    if x.rank == 1:
+        axes = [1, 2]
+    elif x.rank == 2:
+        axes = [2, 3]
+    elif x.rank == 3:
+        axes = [3]
+
+    if axes is None:
+        res = mb.prelu(x=x, alpha=alpha, name=node.name)
+    else:
         x = mb.expand_dims(x=x, axes=axes)
         x = mb.prelu(x=x, alpha=alpha)
         res = mb.squeeze(x=x, axes=axes, name=node.name)
-    else:
-        res = mb.prelu(x=x, alpha=alpha, name=node.name)
 
     context.add(res)
 

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -6534,6 +6534,31 @@ class TestActivation(TorchBaseTest):
             assert len(prog.find_ops(op_type="prelu")) == 0
 
     @pytest.mark.parametrize(
+        "compute_unit, backend, frontend, shape",
+        itertools.product(compute_units, backends, frontends, [(2, 3), (2, 3, 4)]),
+    )
+    def test_prelu_per_channel_alpha(self, compute_unit, backend, frontend, shape):
+        """
+        ``nn.PReLU(num_parameters=C)`` learns one alpha per channel. ``mb.prelu``
+        only accepts such an alpha when its input is rank 4, so rank 2 and rank 3
+        input has to be expanded out to rank 4 rather than to the rank 3 minimum.
+        ``test_prelu`` above never covers this because it initializes every channel
+        to the same alpha.
+        """
+        num_parameters = shape[1]
+        model = nn.PReLU(num_parameters).eval()
+        with torch.no_grad():
+            model.weight.copy_(torch.linspace(0.1, 0.5, num_parameters))
+
+        self.run_compare_torch(
+            shape,
+            model,
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+        )
+
+    @pytest.mark.parametrize(
         "compute_unit, backend, frontend, shape, alpha, minimum_deployment_target",
         itertools.product(
             compute_units,


### PR DESCRIPTION
## Problem

`torch.nn.PReLU(num_parameters=C)` keeps one alpha per channel and accepts input of any rank `>= 2`. `mb.prelu` honors a per-channel alpha only when its input is rank 4 — for rank 3 (and rank 5) its type inference additionally requires every alpha value to be identical.

The torch converter expanded rank 1 and rank 2 input out to rank 3, and passed rank 3 input straight through, so `nn.PReLU(C)` on `(N, C)` or `(N, C, L)` input aborts conversion. This hits 1-D convnets (audio, time series) and plain `(N, C)` MLPs, where `nn.PReLU(C)` is the normal way to use the layer.

### Reproduction

```python
import torch, torch.nn as nn, coremltools as ct

model = nn.PReLU(3).eval()          # one alpha per channel
with torch.no_grad():
    model.weight.copy_(torch.tensor([0.1, 0.3, 0.5]))

x = torch.randn(2, 3, 4)            # (N, C, L)
ct.convert(
    torch.jit.trace(model, x),
    inputs=[ct.TensorType(shape=x.shape)],
    convert_to="mlprogram",
)
```

```
ValueError: prelu op: rank 3 or rank 5 input is only supported when all the values of
alpha are same,which is not the case here
```

`(2, 3)` input fails the same way — the converter expands it to rank 3 first.

## Fix

`prelu` is elementwise along the channel axis, so expanding rank 2 and rank 3 input out to **rank 4** instead of to the rank 3 minimum gives an identical result while staying inside what `mb.prelu` supports. Rank 1 input keeps its existing rank 3 expansion (torch only allows a single alpha there, so the restriction can never bite), and rank 4 input is unchanged.

Rank 5 is deliberately left alone: it hits the same `mb.prelu` restriction, but it cannot be expanded further, and `test_prelu` already `xfail`s every rank 5 case under `rdar://92175249`. Happy to follow up on it separately if you would like it lowered some other way.

## Test

`TestActivation::test_prelu_per_channel_alpha` converts `nn.PReLU(C)` with distinct per-channel weights over `(2, 3)` and `(2, 3, 4)` input and compares against torch.

Without the fix all 8 parametrizations fail with the `ValueError` above; with it they pass.

The existing `test_prelu` never reached this path because it initializes every channel to the same alpha, which the `prelu_to_lrelu` pass then folds into `leaky_relu` — the test even asserts `find_ops(op_type="prelu") == 0`.

## Verification

```
pytest coremltools/converters/mil/frontend/torch/test/test_torch_ops.py -k TestActivation
```
passes (macOS, Apple silicon, torch 2.12, mlprogram + neuralnetwork, TorchScript + TorchExport frontends). Rank 5 `test_prelu` cases remain `xfail`ed as before.
