### PR TITLE
Handle the aten sort.stable / argsort.stable overloads

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -6958,20 +6958,29 @@ def amin(context, node):
     _add_amax_amin(context, node, mb.reduce_min)
 
 
-@register_torch_op
+@register_torch_op(torch_alias=["argsort.stable"])
 def argsort(context, node):
     def _parse_positional_args(context, node) -> Tuple[Var]:
         inputs = _get_inputs(
             context,
             node,
-            expected={TorchFrontend.TORCHSCRIPT: 3},
+            expected={TorchFrontend.TORCHSCRIPT: (3, 4)},
             min_expected={TorchFrontend.TORCHEXPORT: 1, TorchFrontend.EXECUTORCH: 1},
         )
         nargs = len(inputs)
 
         x = inputs[0]
-        dim = inputs[1] if nargs > 1 else -1
-        descending = inputs[2] if nargs > 2 else False
+        # torch has two schemas here, and the second one inserts an argument
+        # ahead of dim, e.g. for sort:
+        #     aten::sort(Tensor self, int dim=-1, bool descending=False)
+        #     aten::sort.stable(Tensor self, *, bool? stable, int dim=-1,
+        #                       bool descending=False)
+        # torch picks the .stable overload as soon as `stable` is passed at all,
+        # including the semantically default `stable=False`, so dim and
+        # descending have to be read at the matching offset.
+        dim_index = 2 if nargs == 4 else 1
+        dim = inputs[dim_index] if nargs > dim_index else -1
+        descending = inputs[dim_index + 1] if nargs > dim_index + 1 else False
 
         return x, dim, descending
 
@@ -6988,20 +6997,29 @@ def argsort(context, node):
     context.add(argsort)
 
 
-@register_torch_op
+@register_torch_op(torch_alias=["sort.stable"])
 def sort(context, node):
     def _parse_positional_args(context, node) -> Tuple[Var]:
         inputs = _get_inputs(
             context,
             node,
-            expected={TorchFrontend.TORCHSCRIPT: 3},
+            expected={TorchFrontend.TORCHSCRIPT: (3, 4)},
             min_expected={TorchFrontend.TORCHEXPORT: 1, TorchFrontend.EXECUTORCH: 1},
         )
         nargs = len(inputs)
 
         x = inputs[0]
-        dim = inputs[1] if nargs > 1 else -1
-        descending = inputs[2] if nargs > 2 else False
+        # torch has two schemas here, and the second one inserts an argument
+        # ahead of dim, e.g. for sort:
+        #     aten::sort(Tensor self, int dim=-1, bool descending=False)
+        #     aten::sort.stable(Tensor self, *, bool? stable, int dim=-1,
+        #                       bool descending=False)
+        # torch picks the .stable overload as soon as `stable` is passed at all,
+        # including the semantically default `stable=False`, so dim and
+        # descending have to be read at the matching offset.
+        dim_index = 2 if nargs == 4 else 1
+        dim = inputs[dim_index] if nargs > dim_index else -1
+        descending = inputs[dim_index + 1] if nargs > dim_index + 1 else False
 
         return x, dim, descending
 

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -492,6 +492,33 @@ class TestArgSort(TorchBaseTest):
             compute_unit=compute_unit,
         )
 
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend, axis, descending, stable",
+        itertools.product(
+            compute_units, backends, frontends, [-1, 0], [True, False], [True, False]
+        ),
+    )
+    def test_argsort_stable(self, compute_unit, backend, frontend, axis, descending, stable):
+        # Passing `stable` at all -- even the semantically default `stable=False`
+        # -- makes torch emit aten::argsort.stable, which inserts an argument
+        # ahead of dim.
+        if frontend == TorchFrontend.EXECUTORCH:
+            # argsort.stable is composite implicit, so the core ATen
+            # decomposition rewrites it to sort.stable
+            pytest.xfail("torch._ops.aten.sort.stable is not in Core ATen opset")
+
+        model = ModuleWrapper(
+            function=torch.argsort,
+            kwargs={"dim": axis, "descending": descending, "stable": stable},
+        )
+        TorchBaseTest.run_compare_torch(
+            (2, 3, 4),
+            model,
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+        )
+
 
 class TestSort(TorchBaseTest):
     @pytest.mark.parametrize(
@@ -509,6 +536,31 @@ class TestSort(TorchBaseTest):
         model = ModuleWrapper(function=torch.sort, kwargs={"dim": axis, "descending": descending})
         TorchBaseTest.run_compare_torch(
             shape,
+            model,
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+        )
+
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend, axis, descending, stable",
+        itertools.product(
+            compute_units, backends, frontends, [-1, 0], [True, False], [True, False]
+        ),
+    )
+    def test_sort_stable(self, compute_unit, backend, frontend, axis, descending, stable):
+        # Passing `stable` at all -- even the semantically default `stable=False`
+        # -- makes torch emit aten::sort.stable, which inserts an argument ahead
+        # of dim.
+        if frontend == TorchFrontend.EXECUTORCH:
+            pytest.xfail("torch._ops.aten.sort.stable is not in Core ATen opset")
+
+        model = ModuleWrapper(
+            function=torch.sort,
+            kwargs={"dim": axis, "descending": descending, "stable": stable},
+        )
+        TorchBaseTest.run_compare_torch(
+            (2, 3, 4),
             model,
             frontend=frontend,
             backend=backend,


### PR DESCRIPTION
torch has a second schema for each of `sort` and `argsort` that inserts an argument ahead of `dim`:

```
aten::sort(Tensor self, int dim=-1, bool descending=False)
aten::sort.stable(Tensor self, *, bool? stable, int dim=-1, bool descending=False)
```

torch picks the `.stable` overload as soon as `stable` is passed at all, including the default `stable=False`. So `torch.sort(x, dim=1, stable=False)`, which is just `torch.sort(x, dim=1)`, failed to convert: `node 5 (sort) got 4 input(s), expected [3]` on TorchScript, and `Unsupported fx node sort, kind sort.stable` on torch.export. Had the arity check not caught it first, TorchScript would have read `dim` out of the `stable` slot.

Fix: accept 3 or 4 positional inputs and read `dim` / `descending` at the offset the arity implies, and register `sort.stable` / `argsort.stable` as aliases so torch.export resolves the overload. Core ML's `argsort` takes no ties argument, so `stable` itself has nothing to map to.

Tests: `TestSort::test_sort_stable` and `TestArgSort::test_argsort_stable` over `dim`, `descending` and `stable`, so the parametrization pins the argument offset. Both xfail on the executorch frontend, because `aten.sort.stable` is not in the Core ATen opset and `to_edge` rejects it before the converter is reached.

```
pytest coremltools/converters/mil/frontend/torch/test/test_torch_ops.py -k "TestSort or TestArgSort"
```

64 passed and 32 xfailed for the new tests on macOS / Apple silicon, torch 2.12, executorch 1.4, across mlprogram + neuralnetwork and all three frontends.
