### PR TITLE
Fix NameSanitizer returning a name already taken by another sanitized name

### DIFF
--- a/coremltools/converters/mil/backend/mil/passes/test_passes.py
+++ b/coremltools/converters/mil/backend/mil/passes/test_passes.py
@@ -903,6 +903,24 @@ class TestSanitizerPass:
         assert block.find_ops(op_type="relu")[1].name == "op_1"
         assert block.find_ops(op_type="add")[0].name == "op_3"
 
+    def test_sanitize_output_name_colliding_with_valid_name(self):
+        """
+        The first output's name, "out/1", gets sanitized into "out_1", which is exactly
+        the (already valid) name of the second output. The two model outputs must still
+        end up with distinct names.
+        """
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 3, 20))])
+        def prog(x):
+            y1 = mb.relu(x=x, name="out/1")
+            y2 = mb.relu(x=x, name="out_1")
+            return y1, y2
+
+        PASS_REGISTRY["mil_backend::sanitize_name_strings"](prog)
+        output_names = [var.name for var in prog.functions["main"].outputs]
+        assert output_names[0] == "out_1"
+        assert len(set(output_names)) == len(output_names)
+
     def test_sanitize_var_names_with_two_functions(self):
         """
         Input:

--- a/coremltools/converters/mil/backend/mil/test_helper.py
+++ b/coremltools/converters/mil/backend/mil/test_helper.py
@@ -25,3 +25,19 @@ class TestNameSanitizer:
         for i, in_and_out_str in enumerate(input_and_expected_strings):
             out = _NameSanitizer().sanitize_name(in_and_out_str[0])
             assert out == in_and_out_str[1]
+
+    def test_name_sanitizer_collides_with_already_valid_name(self):
+        # "a/b" gets sanitized into "a_b", so a subsequent (already valid) "a_b"
+        # must not be handed back unchanged, otherwise two different vars end up
+        # sharing a name.
+        sanitizer = _NameSanitizer()
+        assert sanitizer.sanitize_name("a/b") == "a_b"
+        assert sanitizer.sanitize_name("a_b") == "a_b_0"
+
+    def test_name_sanitizer_unique_suffix(self):
+        # Names that all sanitize into the same string get "_0", "_1", ... appended,
+        # as documented, instead of an ever growing suffix chain.
+        sanitizer = _NameSanitizer()
+        sanitized = [sanitizer.sanitize_name(name) for name in ("x/0", "x-0", "x.0", "x:0")]
+        assert sanitized == ["x_0", "x_0_0", "x_0_1", "x_0_2"]
+        assert len(set(sanitized)) == len(sanitized)

--- a/coremltools/converters/mil/mil/passes/defs/preprocess.py
+++ b/coremltools/converters/mil/mil/passes/defs/preprocess.py
@@ -182,19 +182,19 @@ class NameSanitizer:
             if new_name.startswith("_"):
                 new_name = "var" + new_name
 
-        if new_name == name:
+        if new_name == name and name not in self.all_names:
             # return if nothing has changed
             self.all_names.add(name)
             return name
         else:
-            # name has changed
-            # make sure it is unique, then return
+            # Either the name has changed, or it is already taken by another name that got
+            # sanitized into it (for example "a/b" -> "a_b" makes a subsequent, already valid,
+            # "a_b" a duplicate). Either way, make it unique before returning.
             if new_name in self.all_names:
                 idx = 0
-                new_name += "_" + str(idx)
-                while new_name in self.all_names:
+                while new_name + "_" + str(idx) in self.all_names:
                     idx += 1
-                    new_name += "_" + str(idx)
+                new_name += "_" + str(idx)
             # now we have a unique name
             self.all_names.add(new_name)
             return new_name


### PR DESCRIPTION
### Problem

`NameSanitizer.sanitize_name()` returns the input name unchanged whenever sanitization was a no-op, and only runs the uniqueness check on the "name changed" branch:

```python
if new_name == name:
    # return if nothing has changed
    self.all_names.add(name)
    return name
else:
    # make sure it is unique ...
```

So a name that is already valid can be handed back even though an earlier, different name was sanitized into exactly that string:

```python
from coremltools.converters.mil.mil.passes.defs.preprocess import NameSanitizer

s = NameSanitizer()
s.sanitize_name("a/b")   # -> 'a_b'
s.sanitize_name("a_b")   # -> 'a_b'   <-- duplicate
```

End to end this yields a model whose two outputs share a name:

```python
from coremltools.converters.mil.mil import Builder as mb
from coremltools.converters.mil.mil.passes.pass_registry import PASS_REGISTRY

@mb.program(input_specs=[mb.TensorSpec(shape=(1, 3, 20))])
def prog(x):
    return mb.relu(x=x, name="out/1"), mb.relu(x=x, name="out_1")

PASS_REGISTRY["mil_backend::sanitize_name_strings"](prog)
print([v.name for v in prog.functions["main"].outputs])
# ['out_1', 'out_1']
```

Both `common::sanitize_input_output_names` and `mil_backend::sanitize_name_strings` are affected. Source names containing characters outside `[a-zA-Z0-9_]` are routine in TensorFlow graphs, so a graph that contains both `foo/bar` and `foo_bar` is easy to hit — and the user then cannot address the two outputs separately.

### Fix

Run the uniqueness check whenever the resulting name is already in use, not only when the string changed. The fast path (unchanged *and* unused) is preserved, so the pass stays idempotent: re-running the sanitizer on an already-sanitized program leaves every name alone.

While here, this also fixes the uniquifying loop itself. It appended to the accumulated name on each iteration:

```python
new_name += "_" + str(idx)
while new_name in self.all_names:
    idx += 1
    new_name += "_" + str(idx)
```

producing `x_0`, `x_0_0`, `x_0_0_1`, `x_0_0_1_2`, ... instead of the `_0`, `_1`, ... sequence the method's own docstring describes.

### Tests

Three tests, all of which fail on `main` and pass with the fix:

- `TestNameSanitizer::test_name_sanitizer_collides_with_already_valid_name` — the `a/b` / `a_b` collision above.
- `TestNameSanitizer::test_name_sanitizer_unique_suffix` — the suffix sequence.
- `TestSanitizerPass::test_sanitize_output_name_colliding_with_valid_name` — the end-to-end two-output case through `mil_backend::sanitize_name_strings`.

Existing `TestNameSanitizer` / `TestSanitizerPass` tests are untouched and still pass. I also ran `coremltools/converters/mil/mil/passes/tests/` before and after the change and the set of failures is byte-identical (my environment has no compiled `libcoremlpython`, so the `predict`-based tests fail there both with and without the patch).
