### PR TITLE
reduce_transposes: stop passing transposes through pow and softplus_parametric

### DIFF
--- a/coremltools/converters/mil/mil/passes/defs/optimize_repeat_ops.py
+++ b/coremltools/converters/mil/mil/passes/defs/optimize_repeat_ops.py
@@ -780,10 +780,25 @@ class _TransposeOptimization:
         "sigmoid",
         "sigmoid_hard",
         "softplus",
-        "softplus_parametric",
         "softsign",
         "thresholded_relu",
     }
+
+    @staticmethod
+    def _is_unary_like_op(op) -> bool:
+        """
+        Whether ``Transpose(op(x)) == op(Transpose(x))`` holds for this particular op.
+
+        Most of the op types in ``_UNARY_LIKE_OP_TYPES`` qualify unconditionally, but
+        ``pow`` is an elementwise binary op whose exponent broadcasts against ``x``.
+        A transpose may only be passed through it when the exponent broadcasts the same
+        way for every ordering of the axes, i.e. when all of its dims are 1.
+        """
+        if op.op_type not in _TransposeOptimization._UNARY_LIKE_OP_TYPES:
+            return False
+        if op.op_type == "pow":
+            return op.y.rank <= op.x.rank and all(dim == 1 for dim in op.y.shape)
+        return True
 
     def __init__(self, block):
         self.block = block
@@ -1008,7 +1023,7 @@ class _TransposeOptimization:
 
         if op in self.output_sink_ops:
             self._visit_materialize_op(op)
-        elif op.op_type in self._UNARY_LIKE_OP_TYPES:
+        elif self._is_unary_like_op(op):
             self._visit_unary_like_op(op)
         elif op.op_type in self._AXIS_UPDATE_OPS:
             self._visit_axis_update_op(op)

--- a/coremltools/converters/mil/mil/passes/tests/test_reduce_transposes_pass.py
+++ b/coremltools/converters/mil/mil/passes/tests/test_reduce_transposes_pass.py
@@ -1955,6 +1955,74 @@ class TransposeOptimizationPass(unittest.TestCase):
         )
 
 
+    def test_no_fusion_pow_with_broadcasting_exponent(self):
+        """
+        Input graph:
+        input --> transpose(perm=[1,0]) --> pow(y=[1,2,3]) --> transpose(perm=[1,0]) --> out
+
+        The exponent broadcasts along the last axis of pow's input, so it selects a
+        different element of x once the transposes are cancelled. The transposes must
+        therefore be kept.
+        """
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(3, 3))])
+        def prog(x):
+            x = mb.transpose(x=x, perm=[1, 0])
+            x = mb.pow(x=x, y=np.array([1.0, 2.0, 3.0], dtype=np.float32))
+            x = mb.transpose(x=x, perm=[1, 0])
+            return x
+
+        prev_prog, prev_block, block = apply_pass_and_basic_check(prog, "common::reduce_transposes")
+
+        self.assertEqual(get_op_types_in_program(prev_prog), ["transpose", "pow", "transpose"])
+        self.assertEqual(get_op_types_in_program(prog), ["transpose", "pow", "transpose"])
+
+    def test_fusion_pow_with_scalar_exponent(self):
+        """
+        A scalar exponent broadcasts the same way for every ordering of the axes, so
+        the transposes around pow can still be cancelled.
+        """
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(3, 4))])
+        def prog(x):
+            x = mb.transpose(x=x, perm=[1, 0])
+            x = mb.pow(x=x, y=np.float32(2.0))
+            x = mb.transpose(x=x, perm=[1, 0])
+            return x
+
+        prev_prog, prev_block, block = apply_pass_and_basic_check(prog, "common::reduce_transposes")
+
+        self.assertEqual(get_op_types_in_program(prev_prog), ["transpose", "pow", "transpose"])
+        self.assertEqual(get_op_types_in_program(prog), ["pow"])
+
+    def test_no_fusion_softplus_parametric(self):
+        """
+        softplus_parametric's alpha/beta are indexed by axis 1 of its input, so passing
+        a transpose that moves axis 1 through it changes which channel each parameter
+        applies to. The transposes must be kept.
+        """
+        alpha = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
+        beta = np.ones(4, dtype=np.float32)
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 4, 4, 2))])
+        def prog(x):
+            x = mb.transpose(x=x, perm=[0, 2, 1, 3])
+            x = mb.softplus_parametric(x=x, alpha=alpha, beta=beta)
+            x = mb.transpose(x=x, perm=[0, 2, 1, 3])
+            return x
+
+        prev_prog, prev_block, block = apply_pass_and_basic_check(prog, "common::reduce_transposes")
+
+        self.assertEqual(
+            get_op_types_in_program(prev_prog),
+            ["transpose", "softplus_parametric", "transpose"],
+        )
+        self.assertEqual(
+            get_op_types_in_program(prog),
+            ["transpose", "softplus_parametric", "transpose"],
+        )
+
+
 class TestTransposePassUtilityMethods:
     @staticmethod
     @pytest.mark.parametrize("rank", [1, 2, 3, 4, 5])


### PR DESCRIPTION
### Problem

`_TransposeOptimization._UNARY_LIKE_OP_TYPES` documents itself as ops with a *"single non constant input"* for which *"`Transpose(op(x)) == op(Transpose(x))`"*. Two of its entries do not satisfy that, and `common::reduce_transposes` runs in the default pipeline.

**`pow`** is an elementwise *binary* op (`class pow(elementwise_binary)` in `iOS15/elementwise_binary.py`) — its exponent broadcasts against `x`. Cancelling the transposes around it re-binds the exponent to a different axis:

```python
@mb.program(input_specs=[mb.TensorSpec(shape=(3, 3))])
def prog(x):
    t = mb.transpose(x=x, perm=[1, 0])
    p = mb.pow(x=t, y=np.array([1., 2., 3.], dtype=np.float32))
    return mb.transpose(x=p, perm=[1, 0])

apply_pass_and_basic_check(prog, "common::reduce_transposes")
# ['transpose', 'pow', 'transpose']  ->  ['pow']
```

The original program computes `out[a][b] = x[a][b] ** y[a]`; the rewritten one computes `out[a][b] = x[a][b] ** y[b]`. With `x = np.arange(1, 10).reshape(3, 3)`:

| | result |
|---|---|
| original | `[[1, 2, 3], [16, 25, 36], [343, 512, 729]]` |
| after the pass | `[[1, 4, 27], [4, 25, 216], [7, 64, 729]]` |

No warning, no error. With a non-square input the rewritten program does not even build — the same program with `x` of shape `(3, 2)` raises `ValueError: Incompatible dim 1 in shapes (3, 2) vs. (1, 3)` from inside the pass.

**`softplus_parametric`** applies `alpha[i]` / `beta[i]` along **axis 1** of its input (see `iOS15/activation.py`, which requires `alpha.shape == (x.shape[1],)`). A transpose that moves axis 1 therefore changes which channel each parameter applies to. The torch frontend emits this op for `nn.Softplus` with a non-default `beta`, so it is reachable from a normal conversion. Same repro shape:

```python
@mb.program(input_specs=[mb.TensorSpec(shape=(1, 4, 4, 2))])
def prog(x):
    t = mb.transpose(x=x, perm=[0, 2, 1, 3])
    s = mb.softplus_parametric(x=t, alpha=np.array([1., 2., 3., 4.], np.float32),
                                    beta=np.ones(4, np.float32))
    return mb.transpose(x=s, perm=[0, 2, 1, 3])
# ['transpose', 'softplus_parametric', 'transpose'] -> ['softplus_parametric']
```

`max|original - rewritten|` here is `75.0`.

### Fix

- `pow` stays in the set but is only treated as unary-like when its exponent broadcasts identically for every ordering of the axes, i.e. all of its dims are 1 and its rank does not exceed `x`'s. This keeps the optimization for the common `pow(x, 2.0)` case while making the broadcasting case fall through to `_visit_materialize_op`, which is the conservative/correct handling.
- `softplus_parametric` is removed from the set; there is no input for which passing an axis-permuting transpose through it is safe.

A possible follow-up (not done here, to keep this change small) would be to register `pow` as an axis-update op alongside `add`/`mul`/`sub`/… in `_TransformAdd`, which would recover the optimization for a broadcasting exponent by transposing the exponent as well.

### Tests

Three tests in `test_reduce_transposes_pass.py`:

- `test_no_fusion_pow_with_broadcasting_exponent` — fails on `main` (transposes are removed), passes with the fix.
- `test_no_fusion_softplus_parametric` — fails on `main`, passes with the fix.
- `test_fusion_pow_with_scalar_exponent` — guards that the scalar case still fuses (passes both before and after).

I ran the whole of `coremltools/converters/mil/mil/passes/tests/test_reduce_transposes_pass.py` before and after; the set of failures is identical (my environment cannot load CoreML.framework, so the `assert_model_is_valid` predictions fail there either way — the graph-structure assertions that precede them all run and pass).
