### PR TITLE
Read only the length of layer_norm's normalized_shape

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -3108,6 +3108,25 @@ def _int(context, node):
     _cast(context, node, int, "int32")
 
 
+def _normalized_shape_rank(normalized_shape: Union[Var, List[Var], Tuple[Var]]) -> int:
+    """
+    Number of trailing axes a normalization op normalizes over.
+
+    ``normalized_shape`` is a const Var holding the trailing dims when they are
+    static, but a shape derived from a flexible input, e.g.
+    ``F.layer_norm(x, x.shape[-1:])``, is a ``prim::ListConstruct`` of symbolic
+    sizes, which binds to a python list of Vars with no ``.val``. Only the count
+    of trailing axes matters here -- torch requires ``normalized_shape`` to match
+    the trailing dims of ``x`` -- so read the count without the values.
+    """
+    if isinstance(normalized_shape, (list, tuple)):
+        return len(normalized_shape)
+    if normalized_shape.val is None:
+        # a 1-D shape tensor whose sizes are only known at runtime
+        return normalized_shape.shape[0]
+    return len(np.atleast_1d(normalized_shape.val))
+
+
 @register_torch_op(torch_alias=["native_layer_norm"])
 def layer_norm(context, node):
     def _parse_positional_args(context, node) -> Tuple[Var]:
@@ -3130,7 +3149,7 @@ def layer_norm(context, node):
 
     layer_norm = mb.layer_norm(
         x=x,
-        axes=list(range(-len(normalized_shape.val), 0)),
+        axes=list(range(-_normalized_shape_rank(normalized_shape), 0)),
         gamma=weight,
         beta=bias,
         epsilon=eps,
@@ -3151,7 +3170,7 @@ def rms_norm(context, node):
     normalized_shape = inputs[1]
     weight = inputs[2]
     eps = inputs[3]
-    axes = list(range(-len(normalized_shape.val), 0))
+    axes = list(range(-_normalized_shape_rank(normalized_shape), 0))
     # Store epsilon value to ensure ZeroDivisionError doesn't occur
     # while computing RMSNorm
     eps_val = eps.val if eps is not None else 1e-5

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -5187,6 +5187,45 @@ class TestLayerNorm(TorchBaseTest):
             input_shape, model, compute_unit=compute_unit, backend=backend, frontend=frontend
         )
 
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend, normalized_rank",
+        itertools.product(compute_units, backends, frontends, [1, 2]),
+    )
+    def test_layer_norm_dynamic_normalized_shape(
+        self, compute_unit, backend, frontend, normalized_rank
+    ):
+        """
+        ``F.layer_norm(x, x.shape[-k:])`` over a flexible dimension. Such a
+        normalized_shape comes from a ``prim::ListConstruct`` of symbolic sizes,
+        which binds to a python list of Vars rather than to a const Var, so only
+        its length may be read.
+        """
+        if backend[0] == "neuralnetwork":
+            pytest.skip("nn backend does not support a dynamic shape input for layer_norm")
+
+        class Model(nn.Module):
+            def forward(self, x):
+                return torch.nn.functional.layer_norm(x, x.shape[-normalized_rank:])
+
+        input_shape = (2, 4, 8)
+        input_type = ct.TensorType(
+            shape=ct.Shape([input_shape[0], input_shape[1], ct.RangeDim(2, 64)])
+        )
+        torch_export_dynamic_shapes = None
+        if frontend in TORCH_EXPORT_BASED_FRONTENDS:
+            last_dim = torch.export.Dim(name="last_dim", min=2, max=64)
+            torch_export_dynamic_shapes = {"x": {2: last_dim}}
+
+        self.run_compare_torch(
+            [input_shape],
+            Model().eval(),
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+            converter_input_type=[input_type],
+            torch_export_dynamic_shapes=torch_export_dynamic_shapes,
+        )
+
 
 class TestPixelShuffle(TorchBaseTest):
     @pytest.mark.parametrize(


### PR DESCRIPTION
`F.layer_norm(x, x.shape[-1:])`, with `normalized_shape` read off the input rather than hard coded, aborts conversion as soon as that input dimension is flexible:

```
File "coremltools/converters/mil/frontend/torch/ops.py", line 3133, in layer_norm
    axes=list(range(-len(normalized_shape.val), 0)),
AttributeError: 'list' object has no attribute 'val'
```

`normalized_shape` is a const Var when the trailing dims are static, which is why the same model converts fine with a fixed shape. Derived from a flexible input it comes from a `prim::ListConstruct` of symbolic sizes, and `_get_bindings` binds that to a python list of Vars with no `.val`. `rms_norm` computes its axes from the same expression and fails identically.

Fix: only the number of trailing axes matters here, since `mb.layer_norm` normalizes over trailing axes and torch requires `normalized_shape` to match the trailing dims of `x`. So take the count without reaching for values that may not exist. The static path still resolves to exactly the same `axes`.

Test: `TestLayerNorm::test_layer_norm_dynamic_normalized_shape` converts `F.layer_norm(x, x.shape[-k:])` for k in {1, 2} with a `RangeDim` last dimension, on all three frontends. Each one hits the `AttributeError` above without the fix. The `neuralnetwork` backend is skipped because its `layer_norm` mapping rejects a dynamic shape input regardless of frontend (`NotImplementedError: dynamic shape input nor supported for layer_norm`), which is a separate pre-existing limitation.

```
pytest coremltools/converters/mil/frontend/torch/test/test_torch_ops.py -k TestLayerNorm
```

30 passed, 6 skipped on macOS / Apple silicon, torch 2.12, executorch 1.4.

I also confirmed by hand that `F.rms_norm(x, x.shape[-1:])` over a `RangeDim` goes from the same `AttributeError` to matching torch, but did not add a test for it since `F.rms_norm` needs torch >= 2.4 and the suite has no `rms_norm` coverage to extend. Happy to add a version gated one if you would like it.
