### PR TITLE
remove_redundant_ops: do not merge state ops

### DIFF
--- a/coremltools/converters/mil/mil/passes/defs/cleanup/remove_redundant_ops.py
+++ b/coremltools/converters/mil/mil/passes/defs/cleanup/remove_redundant_ops.py
@@ -53,7 +53,12 @@ class remove_redundant_ops(AbstractGraphPass):
     For more examples, see "TestRemoveRedundantOpsPass".
     """
 
-    _NON_REDUNDANT_OPS = tuple()
+    # Ops that are not a pure function of their inputs, so two of them with identical
+    # inputs are not interchangeable. The state ops read from / write to mutable state
+    # that is not threaded through their inputs, hence two ``read_state`` ops on the same
+    # state can observe different values, and two identical ``coreml_update_state`` ops
+    # are not redundant if another write to the same state sits between them.
+    _NON_REDUNDANT_OPS = ("read_state", "coreml_update_state")
 
     def __init__(self):
         self._num_of_visited_ops: int = (

--- a/coremltools/converters/mil/mil/passes/tests/test_cleanup_passes.py
+++ b/coremltools/converters/mil/mil/passes/tests/test_cleanup_passes.py
@@ -2473,6 +2473,63 @@ class TestRemoveRedundantOps:
         assert get_op_types_in_program(prog) == ["cos"] + ["leaky_relu"] * 3 + ["sin"]
         assert graph_pass._num_of_visited_ops == 13
 
+    def test_read_state_around_update_is_not_redundant(self):
+        """
+        The two read_state ops have identical inputs but observe different values,
+        because the state is written to in between. Neither may be removed.
+        """
+
+        @mb.program(
+            input_specs=[
+                mb.StateTensorSpec((2, 3), dtype=types.fp16),
+                mb.TensorSpec((2, 3), dtype=types.fp16),
+            ],
+            opset_version=ct.target.iOS18,
+        )
+        def prog(state, x):
+            before = mb.read_state(input=state)
+            mb.coreml_update_state(state=state, value=x)
+            after = mb.read_state(input=state)
+            return mb.add(x=before, y=after)
+
+        apply_pass_and_basic_check(prog, "common::remove_redundant_ops")
+
+        assert get_op_types_in_program(prog) == [
+            "read_state",
+            "coreml_update_state",
+            "read_state",
+            "add",
+        ]
+        add_op = prog.functions["main"].find_ops(op_type="add")[0]
+        assert add_op.x is not add_op.y
+
+    def test_repeated_coreml_update_state_is_not_redundant(self):
+        """
+        The first and the last coreml_update_state have identical inputs, but a
+        different value is written to the same state in between, so removing the
+        last one would leave the state holding the wrong value.
+        """
+
+        @mb.program(
+            input_specs=[
+                mb.StateTensorSpec((2, 3), dtype=types.fp16),
+                mb.TensorSpec((2, 3), dtype=types.fp16),
+                mb.TensorSpec((2, 3), dtype=types.fp16),
+            ],
+            opset_version=ct.target.iOS18,
+        )
+        def prog(state, x, y):
+            mb.coreml_update_state(state=state, value=x)
+            mb.coreml_update_state(state=state, value=y)
+            mb.coreml_update_state(state=state, value=x)
+            return mb.read_state(input=state)
+
+        apply_pass_and_basic_check(prog, "common::remove_redundant_ops")
+
+        assert get_op_types_in_program(prog) == ["coreml_update_state"] * 3 + ["read_state"]
+        update_ops = prog.functions["main"].find_ops(op_type="coreml_update_state")
+        assert [op.value.name for op in update_ops] == ["x", "y", "x"]
+
 
 class TestRemoveSymbolicReshape:
     def test_remove_symbolic_reshape(self):


### PR DESCRIPTION
### Problem

`common::remove_redundant_ops` treats two ops of the same type with identical inputs as interchangeable (`_are_ops_identical` compares `op.inputs` only). That is valid for ops that are a pure function of their inputs. The state ops are not — they read from / write to mutable state that is *not* threaded through their inputs, so identical inputs do not imply identical behaviour.

**`read_state`.** Two reads separated by a write observe different values, but the pass merges them:

```python
@mb.program(input_specs=[mb.StateTensorSpec((2, 3), dtype=types.fp16),
                         mb.TensorSpec((2, 3), dtype=types.fp16)],
            opset_version=ct.target.iOS18)
def prog(state, x):
    before = mb.read_state(input=state)
    mb.coreml_update_state(state=state, value=x)
    after = mb.read_state(input=state)
    return mb.add(x=before, y=after)

apply_pass_and_basic_check(prog, "common::remove_redundant_ops")
# ['read_state', 'coreml_update_state', 'read_state', 'add']
#   -> ['read_state', 'coreml_update_state', 'add']
# and add.x is add.y
```

The program used to compute `s0 + x` and now computes `s0 + s0`. Reading a state, updating it, and using both values is the normal shape of a KV-cache / running-statistics model.

**`coreml_update_state`.** Given writes of `x`, `y`, `x` to the same state, the first and the last have identical inputs, so the last is removed:

```python
mb.coreml_update_state(state=state, value=x)
mb.coreml_update_state(state=state, value=y)
mb.coreml_update_state(state=state, value=x)
# -> only the writes of x and y survive
```

The state is left holding `y` instead of `x`, which is visible on the next prediction.

`common::remove_redundant_ops` is in the default pipeline (`pass_pipeline.py`), so both are reachable from a plain `ct.convert` of a stateful model.

### Fix

`_NON_REDUNDANT_OPS` already exists on the pass for exactly this purpose (it is consulted by `_is_op_eligible_to_be_removed` alongside the `random*` exclusion) but was an empty tuple. Populate it with `read_state` and `coreml_update_state`.

The list ops (`list_read` / `list_write` / …) do not need the same treatment: they thread the list through their inputs and outputs in SSA form, so two reads of different list versions already compare as non-identical.

### Tests

Two tests in `TestRemoveRedundantOps`, both of which fail on `main` and pass with the fix:

- `test_read_state_around_update_is_not_redundant`
- `test_repeated_coreml_update_state_is_not_redundant`

The rest of `TestRemoveRedundantOps` is untouched; I ran the class before and after and the set of failures is identical (my environment cannot load CoreML.framework, so the `assert_model_is_valid` predictions fail there either way — the graph-structure assertions preceding them all run and pass).
