### PR TITLE
Lower adaptive pooling to output size 1 as a global reduce in 1D

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -2532,6 +2532,24 @@ def _adaptive_pool1d(context, node, reduce_op):
     assert len(inputs[1].val) == 1
     out_length = inputs[1].val[0]
 
+    if out_length == 1:
+        # Represent an output length of 1 with a global reduce op. This mirrors the
+        # output size == (1, 1) case of _adaptive_pool2d, and is the only form that
+        # also works when the pooled dimension is symbolic.
+        context.add(reduce_op(x=x, axes=[-1], keep_dims=True, name=node.name))
+        return
+
+    if x.shape is None or any_symbolic(x.shape):
+        # The slicing below indexes the input with concrete positions, so a symbolic
+        # shape would otherwise surface as a sympy "Cannot convert expression to
+        # float" TypeError. _adaptive_pool2d reports the same situation this way.
+        raise ValueError(
+            "Adaptive pooling is only supported when input tensor size is known or "
+            "output size == 1. Received: input size == {}, output size == {}".format(
+                x.shape_str(), out_length
+            )
+        )
+
     if len(x.shape) == 3:
         # 3D input
         begin_prefix = [0, 0]

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -3367,6 +3367,47 @@ class TestAdaptiveAvgPool(TorchBaseTest):
         )
 
     @pytest.mark.parametrize(
+        "compute_unit, backend, frontend, input_shape",
+        itertools.product(compute_units, backends, frontends, [(1, 64, 8), (20, 10)]),
+    )
+    def test_adaptive_avg_pool1d_output_size_1(
+        self, compute_unit, backend, frontend, input_shape
+    ):
+        # Output size 1 is plain global pooling, and unlike the other output sizes it
+        # does not need the pooled dimension to be known.
+        model = nn.AdaptiveAvgPool1d(1)
+        self.run_compare_torch(
+            input_shape,
+            model,
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+        )
+
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend",
+        itertools.product(compute_units, backends, frontends),
+    )
+    def test_adaptive_avg_pool1d_symbolic_input(self, compute_unit, backend, frontend):
+        if frontend in TORCH_EXPORT_BASED_FRONTENDS:
+            pytest.skip("torch.export decomposes AdaptiveAvgPool1d(1) into a mean op")
+
+        model = nn.AdaptiveAvgPool1d(1)
+        input_shape = (1, 64, 8)
+        upper_bound_coreml = 20 if backend[0] == "mlprogram" else -1
+        converter_input_type = [
+            TensorType(shape=(1, 64, RangeDim(upper_bound=upper_bound_coreml)), dtype=np.float32)
+        ]
+        self.run_compare_torch(
+            input_shape,
+            model,
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+            converter_input_type=converter_input_type,
+        )
+
+    @pytest.mark.parametrize(
         "compute_unit, backend, frontend, output_size, magnification, delta, depth, n",
         itertools.product(
             compute_units,


### PR DESCRIPTION
## Problem

`nn.AdaptiveAvgPool1d(1)` over a flexible length — global pooling across a variable-length sequence, the standard head of a 1-D convnet — aborts conversion:

```python
import torch, torch.nn as nn, coremltools as ct

model = nn.AdaptiveAvgPool1d(1).eval()
x = torch.rand(1, 64, 8)
ct.convert(
    torch.jit.trace(model, x),
    inputs=[ct.TensorType(shape=ct.Shape([1, 64, ct.RangeDim(upper_bound=20)]))],
    convert_to="mlprogram",
)
```

```
File ".../sympy/core/expr.py", line 375, in __float__
    raise TypeError("Cannot convert expression to float")
TypeError: Cannot convert expression to float
```

`_adaptive_pool1d` always slices the input into one window per output element, computing the window boundaries in python from the pooled dimension:

```python
start = _math.floor(i * in_dimension / out_dimension)
end = _math.ceil((i + 1) * in_dimension / out_dimension)
```

For a flexible input `in_dimension` is a sympy symbol, so `floor` / `ceil` raise out of sympy, from the middle of the converter with no indication of what the user did wrong.

The 2-D equivalent has no such problem: `_adaptive_pool2d` special-cases output size `(1, 1)` into a global `reduce_mean` / `reduce_max`, which needs no window boundaries, so `nn.AdaptiveAvgPool2d((1, 1))` over a flexible input converts today. The 1-D path just never got the same treatment.

## Fix

Give `_adaptive_pool1d` the two cases `_adaptive_pool2d` already has:

- output size == 1 → a single global reduce over the last axis. This is exactly what the window loop already computes for that case (its one window spans the whole dimension), so the result is unchanged for static shapes — it just no longer needs to know the size.
- any other output size with a symbolic input shape → the same clear `ValueError` `_adaptive_pool2d` raises, instead of a sympy `TypeError`.

## Tests

- `TestAdaptiveAvgPool::test_adaptive_avg_pool1d_symbolic_input` — `nn.AdaptiveAvgPool1d(1)` with a `RangeDim` length. Fails with the sympy `TypeError` without the fix.
- `TestAdaptiveAvgPool::test_adaptive_avg_pool1d_output_size_1` — output size 1 with static shapes over rank 3 and rank 2 input, pinning the new global-reduce path against torch. The existing `test_adaptive_max_pool1d` parametrizations only use output sizes 3 and 5, so output size 1 was uncovered.

The symbolic test skips the torch.export frontends, which decompose `AdaptiveAvgPool1d(1)` into a `mean` op before the converter sees it.

## Verification

```
pytest coremltools/converters/mil/frontend/torch/test/test_torch_ops.py -k "TestAdaptiveAvgPool or TestAdaptiveMaxPool"
```
618 passed, 2 skipped on macOS / Apple silicon, torch 2.12, across mlprogram + neuralnetwork and the TorchScript / TorchExport / ExecuTorch frontends.