### PR TITLE
Honor interleave in concat's value_inference

### DIFF
--- a/coremltools/converters/mil/mil/ops/defs/iOS15/tensor_operation.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS15/tensor_operation.py
@@ -1101,7 +1101,19 @@ class concat(Operation):
             return None
 
         if not isinstance(values[0], np.ndarray) or values[0].shape == ():
+            # Every value is a scalar, so interleaving and concatenating are the same.
             return np.stack(values, axis=self.axis.val)
+
+        if self.interleave.val:
+            # All the inputs share the same shape (enforced by type_inference), so
+            # interleaving along `axis` is a stack right after `axis` followed by
+            # folding the new dimension back into `axis`.
+            axis = self.axis.val
+            if axis < 0:
+                axis += values[0].ndim
+            interleaved_shape = list(values[0].shape)
+            interleaved_shape[axis] *= len(values)
+            return np.reshape(np.stack(values, axis=axis + 1), interleaved_shape)
 
         return np.concatenate(values, axis=self.axis.val)
 

--- a/coremltools/converters/mil/mil/ops/tests/iOS14/test_tensor_operation.py
+++ b/coremltools/converters/mil/mil/ops/tests/iOS14/test_tensor_operation.py
@@ -1727,6 +1727,46 @@ class TestConcat:
             backend=backend,
         )
 
+    @pytest.mark.parametrize("axis", [0, 1, -1, -2])
+    def test_builder_eval_interleave(self, axis):
+        """Constant folding must honor the interleave option."""
+        val1 = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
+        val2 = np.array([[7.0, 8.0], [9.0, 10.0], [11.0, 12.0]], dtype=np.float32)
+
+        @mb.program(input_specs=[])
+        def prog():
+            return mb.concat(values=[val1, val2], axis=axis, interleave=True)
+
+        expected = np.empty(
+            [2 * d if i == axis % 2 else d for i, d in enumerate(val1.shape)], np.float32
+        )
+        index = [slice(None), slice(None)]
+        index[axis % 2] = slice(0, None, 2)
+        expected[tuple(index)] = val1
+        index[axis % 2] = slice(1, None, 2)
+        expected[tuple(index)] = val2
+
+        output = prog.functions["main"].outputs[0]
+        assert output.shape == expected.shape
+        np.testing.assert_allclose(output.val, expected, atol=1e-04, rtol=1e-05)
+
+    def test_builder_eval_interleave_docstring_example(self):
+        """The example spelled out in the concat op's docstring."""
+        val1 = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
+        val2 = np.array([[7.0, 8.0], [9.0, 10.0], [11.0, 12.0]], dtype=np.float32)
+
+        @mb.program(input_specs=[])
+        def prog():
+            return mb.concat(values=[val1, val2], axis=0, interleave=True)
+
+        expected = np.array(
+            [[1.0, 2.0], [7.0, 8.0], [3.0, 4.0], [9.0, 10.0], [5.0, 6.0], [11.0, 12.0]],
+            dtype=np.float32,
+        )
+        np.testing.assert_allclose(
+            prog.functions["main"].outputs[0].val, expected, atol=1e-04, rtol=1e-05
+        )
+
     def test_builder_eval_different_dtypes_error_out(self):
         """If the input to the concat op has different dtypes, it will error out."""
         with pytest.raises(


### PR DESCRIPTION
### Problem

`concat.value_inference` always calls `np.concatenate(values, axis=self.axis.val)` and never reads `self.interleave`. So a `concat` of const inputs with `interleave=True` const-folds to the plain, non-interleaved concatenation.

Using the example spelled out in the op's own docstring:

```python
in1 = [[1, 2], [3, 4], [5, 6]]     # (3, 2)
in2 = [[7, 8], [9, 10], [11, 12]]  # (3, 2)

@mb.program(input_specs=[])
def prog():
    return mb.concat(values=[in1, in2], axis=0, interleave=True)
```

| | value |
|---|---|
| docstring / runtime | `[[1,2],[7,8],[3,4],[9,10],[5,6],[11,12]]` |
| `value_inference` | `[[1,2],[3,4],[5,6],[7,8],[9,10],[11,12]]` |

`type_inference` computes the correct shape `(6, 2)`, so nothing flags the mismatch, and `common::const_elimination` then replaces the `concat` with a `const` holding the wrong values — the compiled model computes the wrong answer at runtime:

```python
@mb.program(input_specs=[mb.TensorSpec(shape=(6, 2))])
def prog(x):
    c = mb.concat(values=[in1, in2], axis=0, interleave=True)
    return mb.add(x=x, y=c)

apply_pass_and_basic_check(prog, "common::const_elimination")
# ['concat', 'add'] -> ['add'],  with the non-interleaved constant baked in
```

### Fix

All inputs of an interleaved `concat` share the same shape (`type_inference` enforces exactly this), so interleaving along `axis` is a `stack` immediately after `axis` followed by folding that new dimension back into `axis`.

The all-scalar branch above is deliberately left alone: interleaving N scalars and stacking them produce the same result.

I checked the folded value against a slice-assignment reference (`out[k::N] = values[k]` along the axis) for ranks 1–3, every positive and negative axis, and 2 or 3 inputs — all match.

### Tests

In `TestConcat` (`ops/tests/iOS14/test_tensor_operation.py`):

- `test_builder_eval_interleave[axis=0,1,-1,-2]` — checks the folded value against the slice-assignment reference, including negative axes.
- `test_builder_eval_interleave_docstring_example` — the exact example from the op docstring.

All five fail on `main` and pass with the fix.

The existing interleave coverage, `TestConcat.test_builder_to_backend_stress_interleave` in `ops/tests/iOS14/test_tensor_transformation.py`, feeds `mb.placeholder` inputs, so `value_inference` never runs there — which is why this went unnoticed.

I ran all of `ops/tests/iOS14/test_tensor_operation.py` and the concat-related pass tests before and after; the failure sets are identical (this environment cannot load CoreML.framework, so the `run_compare_builder` / `assert_model_is_valid` tests fail there either way).
