### PR TITLE
merge_consecutive_reshapes: do not merge past a trailing shape containing 0

### DIFF
--- a/coremltools/converters/mil/mil/passes/defs/optimize_repeat_ops.py
+++ b/coremltools/converters/mil/mil/passes/defs/optimize_repeat_ops.py
@@ -240,6 +240,20 @@ class merge_consecutive_reshapes(AbstractGraphPass):
             self._merge_consecutive_reshapes_block(f)
 
     @staticmethod
+    def _shape_inherits_input_dims(reshape_op) -> bool:
+        """
+        Whether ``reshape_op``'s shape contains a ``0``, which means "inherit the
+        corresponding dimension from *this* reshape's input".
+
+        Returns False when the shape is not known at compile time, in which case we
+        cannot tell.
+        """
+        shape = reshape_op.shape.sym_val
+        if shape is None:
+            return False
+        return any(dim == 0 for dim in shape)
+
+    @staticmethod
     def _match_pattern(reshape_op):
         """
         Given a ``reshape`` op,
@@ -264,6 +278,13 @@ class merge_consecutive_reshapes(AbstractGraphPass):
                 break
 
             op = op.outputs[0].child_ops[0]
+
+        # The merged reshape takes its shape from the last op of the sequence but its
+        # input from the first one. A trailing ``0`` would then inherit a dimension from
+        # a different tensor than it originally did, silently changing the output shape,
+        # so drop such ops from the end of the sequence.
+        while len(res) > 1 and merge_consecutive_reshapes._shape_inherits_input_dims(res[-1]):
+            res.pop()
 
         return res
 

--- a/coremltools/converters/mil/mil/passes/tests/test_passes.py
+++ b/coremltools/converters/mil/mil/passes/tests/test_passes.py
@@ -1722,6 +1722,63 @@ class TestMergeConsecutiveReshapes:
         )
         """
 
+    def test_keep_trailing_reshape_inheriting_input_dims(self):
+        """
+        A ``0`` in the last reshape's shape inherits the corresponding dimension from
+        that reshape's own input. Merging would re-bind it to the head of the
+        sequence's input, changing the output shape, so the merge must not happen.
+        """
+        INPUT_SHAPE = (2, 3, 4)
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=INPUT_SHAPE)])
+        def prog(x):
+            y1 = mb.reshape(x=x, shape=(4, 3, 2))
+            y2 = mb.reshape(x=y1, shape=(0, 6, -1))
+            return y2
+
+        prev_prog, _, block = apply_pass_and_basic_check(prog, "common::merge_consecutive_reshapes")
+        assert get_op_types_in_program(prev_prog) == ["reshape"] * 2
+        assert get_op_types_in_program(prog) == ["reshape"] * 2
+        assert block.outputs[0].shape == (4, 6, 1)
+
+    def test_merge_up_to_reshape_inheriting_input_dims(self):
+        """
+        Only the trailing reshape's ``0`` is a problem: the preceding ones can still
+        be merged together.
+        """
+        INPUT_SHAPE = (2, 3, 4)
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=INPUT_SHAPE)])
+        def prog(x):
+            y1 = mb.reshape(x=x, shape=(4, 3, 2))
+            y2 = mb.reshape(x=y1, shape=(6, 2, 2))
+            y3 = mb.reshape(x=y2, shape=(0, 4, -1))
+            return y3
+
+        prev_prog, _, block = apply_pass_and_basic_check(prog, "common::merge_consecutive_reshapes")
+        assert get_op_types_in_program(prev_prog) == ["reshape"] * 3
+        assert get_op_types_in_program(prog) == ["reshape"] * 2
+        assert block.outputs[0].shape == (6, 4, 1)
+
+    def test_merge_reshape_with_leading_zero_shape(self):
+        """
+        A ``0`` that is not in the last reshape's shape is discarded by the merge, so
+        it does not block it.
+        """
+        INPUT_SHAPE = (2, 3, 4)
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=INPUT_SHAPE)])
+        def prog(x):
+            y1 = mb.reshape(x=x, shape=(0, 4, 3))
+            y2 = mb.reshape(x=y1, shape=(6, 4))
+            return y2
+
+        prev_prog, _, block = apply_pass_and_basic_check(prog, "common::merge_consecutive_reshapes")
+        assert get_op_types_in_program(prev_prog) == ["reshape"] * 2
+        assert get_op_types_in_program(prog) == ["reshape"]
+        assert block.outputs[0].shape == (6, 4)
+
+
 class TestCastOptimizationReduendantCastRemoval:
     """
     Test single cast op removal.


### PR DESCRIPTION
### Problem

Per the `reshape` op's own docstring, a `0` in `shape` means *"if `K == rank(x)` then `0` means inheriting from the corresponding dimension in `x.shape`"*.

`merge_consecutive_reshapes` builds the merged op as `mb.reshape(x=reshape_ops[0].x, shape=reshape_ops[-1].shape)` — shape from the **last** op of the sequence, input from the **first**. So a `0` in the trailing shape is re-bound to a different tensor and the model's output shape silently changes:

```python
@mb.program(input_specs=[mb.TensorSpec(shape=(2, 3, 4))])
def prog(x):
    y = mb.reshape(x=x, shape=(4, 3, 2))
    return mb.reshape(x=y, shape=(0, 6, -1))

apply_pass_and_basic_check(prog, "common::merge_consecutive_reshapes")
# ['reshape', 'reshape'] -> ['reshape']
# output shape (4, 6, 1) -> (2, 6, 2)
```

The `0` originally inherited dim 0 of `(4, 3, 2)` = 4; after the merge it inherits dim 0 of `(2, 3, 4)` = 2. The `-1` then absorbs the difference, so the volume still checks out and nothing raises — the converted model just has a different output shape than the program it was built from.

`common::merge_consecutive_reshapes` is in the default pipeline (`pass_pipeline.py`).

### Fix

Trim ops whose shape contains a `0` off the **end** of the matched sequence, rather than rejecting the sequence outright. Only the trailing position matters — a `0` anywhere earlier has its shape discarded by the merge and stays harmless — so the reshapes before the offending one still merge and the optimization is preserved as far as it is valid.

When the shape is not known at compile time (`shape.sym_val is None`) we cannot tell whether it holds a `0`; that case keeps the existing behaviour rather than disabling the merge for all dynamically-shaped reshapes.

### Tests

In `TestMergeConsecutiveReshapes`:

- `test_keep_trailing_reshape_inheriting_input_dims` — the repro above; both reshapes must survive and the output shape must stay `(4, 6, 1)`. Fails on `main`.
- `test_merge_up_to_reshape_inheriting_input_dims` — three reshapes with a `0` in the last; the first two must still merge, leaving two ops. Fails on `main`.
- `test_merge_reshape_with_leading_zero_shape` — a `0` in the *first* reshape must not block the merge (guards against over-narrowing). Passes before and after.

The existing tests in the class are untouched. I ran the whole class before and after; the failure sets are identical (this environment cannot load CoreML.framework, so the `assert_model_is_valid` predictions fail there either way — the graph-structure assertions preceding them all run and pass).

Note: this touches `optimize_repeat_ops.py`, which my PR #2784 also modifies, in a different class.
