### PR TITLE
Resize a symbolic input to a fixed output size with the iOS17 resize op

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -4163,6 +4163,39 @@ def upsample_bilinear2d(context, node):
 
     x, output_size, align_corners, scales_h, scales_w = _parse_positional_args(context, node)
     scales_h, scales_w = _parse_keyword_args(context, node, scales_h, scales_w)
+
+    # mb.upsample_bilinear resizes by a constant scale factor, which cannot be
+    # derived from a target output size while the source spatial dims are only
+    # known at runtime -- dividing by them raises out of sympy. The iOS 17 resize
+    # op takes the target size directly, so it can express this case.
+    if (
+        x.rank == 4
+        and any_symbolic(x.shape[-2:])
+        and scales_h is None
+        and scales_w is None
+        and isinstance(output_size, Var)
+        and output_size.val is not None
+        and len(np.atleast_1d(output_size.val)) == 2
+    ):
+        if not is_current_opset_version_compatible_with(target.iOS17):
+            raise NotImplementedError(
+                "Resizing an input with a symbolic height or width to a fixed output "
+                f"size, as the upsample op {node.name} does, needs "
+                "minimum_deployment_target >= ct.target.iOS17."
+            )
+        context.add(
+            mb.resize(
+                x=x,
+                shape=np.array(output_size.val, dtype=np.int32),
+                resized_dims=np.uint32(2),
+                interpolation_mode="LINEAR",
+                # Core ML's UNALIGN_CORNERS is torch's align_corners=False
+                sampling_mode="ALIGN_CORNERS" if align_corners else "UNALIGN_CORNERS",
+                name=node.name,
+            )
+        )
+        return
+
     scales_h, scales_w = _translate_torch_args(x, output_size, align_corners, scales_h, scales_w)
 
     if scales_h is not None and scales_w is not None:

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -2727,6 +2727,84 @@ class TestUpsample(TorchBaseTest):
                     assert len(layer.upsample.fractionalScalingFactor) == 0
 
     @pytest.mark.parametrize(
+        "compute_unit, backend, frontend, output_size, align_corners",
+        itertools.product(
+            compute_units, backends, frontends, [(4, 4), (16, 20)], [True, False]
+        ),
+    )
+    def test_upsample_bilinear2d_with_output_size_dynamic(
+        self, compute_unit, backend, frontend, output_size, align_corners
+    ):
+        """
+        A fixed output size over an input whose spatial dims are only known at run
+        time. There is no constant scale factor to derive here, so this needs the
+        iOS 17 resize op, which takes the target size directly.
+        """
+        if backend[0] == "neuralnetwork":
+            pytest.skip("the iOS17 resize op needs the mlprogram backend")
+        if frontend == TorchFrontend.EXECUTORCH:
+            pytest.xfail("executorch incorrectly propagates dynamic shape")
+
+        input_shape = (1, 3, 9, 22)
+
+        if frontend in TORCH_EXPORT_BASED_FRONTENDS:
+
+            class Model(nn.Module):
+                def __init__(self, size, align_corners):
+                    super().__init__()
+                    self.size = size
+                    self.align_corners = align_corners
+
+                def forward(self, args):
+                    return nn.functional.interpolate(
+                        args,
+                        size=self.size,
+                        mode="bilinear",
+                        align_corners=self.align_corners,
+                    )
+
+            model = Model(output_size, align_corners)
+            converter_input_type = None
+            torch_export_dynamic_shapes = {
+                "args": {
+                    2: torch.export.Dim(name="height", min=2, max=30),
+                    3: torch.export.Dim(name="width", min=2, max=30),
+                }
+            }
+        else:
+            model = ModuleWrapper(
+                nn.functional.interpolate,
+                {
+                    "size": output_size,
+                    "mode": "bilinear",
+                    "align_corners": align_corners,
+                },
+            )
+            converter_input_type = [
+                TensorType(
+                    shape=(
+                        1,
+                        3,
+                        RangeDim(default=9, upper_bound=30),
+                        RangeDim(default=22, upper_bound=30),
+                    ),
+                    dtype=np.float32,
+                )
+            ]
+            torch_export_dynamic_shapes = None
+
+        self.run_compare_torch(
+            input_shape,
+            model,
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+            converter_input_type=converter_input_type,
+            torch_export_dynamic_shapes=torch_export_dynamic_shapes,
+            minimum_deployment_target=ct.target.iOS17,
+        )
+
+    @pytest.mark.parametrize(
         "compute_unit, backend, frontend, scales_h, scales_w, align_corners, recompute_scale_factor",
         itertools.product(
             compute_units,


### PR DESCRIPTION
## Problem

`F.interpolate(x, size=(H, W), mode="bilinear")` — resize to a fixed output size — aborts conversion as soon as the input's spatial dims are flexible:

```python
import torch, torch.nn as nn, torch.nn.functional as F, coremltools as ct

class M(nn.Module):
    def forward(self, x):
        return F.interpolate(x, size=(4, 4), mode="bilinear", align_corners=False)

x = torch.rand(1, 2, 8, 8)
ct.convert(
    torch.jit.trace(M().eval(), x),
    inputs=[ct.TensorType(shape=ct.Shape([1, 2, 8, ct.RangeDim(1, 64)]))],
    convert_to="mlprogram",
    minimum_deployment_target=ct.target.iOS17,
)
```

```
File ".../sympy/core/expr.py", line 375, in __float__
    raise TypeError("Cannot convert expression to float")
TypeError: Cannot convert expression to float
```

`mb.upsample_bilinear` resizes by a constant scale factor, so the converter derives one from the requested output size via `_get_scales_from_output_size`, i.e. `output_size / input_size`. When `input_size` is a sympy symbol that division has no constant answer and the `floor` inside raises, from the middle of the converter with nothing pointing at what the model did.

Resizing a variably-sized input down to a fixed size is the normal shape of image preprocessing inside a model, and it is a long-standing complaint — the same `_get_scales_from_output_size` failure is what #970 hit, and #1916 is the nearest-neighbor sibling of it.

## Fix

The iOS 17 `resize` op takes the **target size** directly rather than a scale factor, precisely for "a tensor needs to be resized to a dynamic shape" (its own docstring). So when

- the input's height or width is symbolic, **and**
- no scale factor was supplied, **and**
- the output size is a compile-time constant,

lower to `mb.resize` instead. Static input shapes are untouched and still go through `mb.upsample_bilinear`, as do all the scale-factor forms.

Sampling mode: I checked `mb.resize` against torch for every mode on this shape — `UNALIGN_CORNERS` is bit-identical to torch's `align_corners=False` and `ALIGN_CORNERS` to `align_corners=True`, so the mapping is exact rather than approximate.

Below iOS 17 there is no op that can express this, so it now raises a `NotImplementedError` naming the deployment target to raise, instead of the sympy `TypeError`.

## Scope

Deliberately bilinear-only. I probed `mb.resize` with `interpolation_mode="NEAREST_NEIGHBOR"` for `upsample_nearest2d` and it only accepts `DEFAULT` sampling, whose rounding disagrees with torch except when the scale is an exact integer, so mapping it would trade a crash for silently different numbers. `upsample_nearest2d` (the failure in #1916) keeps its current behavior.

## Test

`TestUpsample::test_upsample_bilinear2d_with_output_size_dynamic` resizes a `(1, 3, 9, 22)` input with both spatial dims flexible to `(4, 4)` (down) and `(16, 20)` (up, and non-square) with `align_corners` both ways, on the TorchScript and torch.export frontends, and compares against torch at two different input sizes.

Without the fix all 8 `mlprogram` parametrizations fail with the sympy `TypeError`; with it they pass. `neuralnetwork` is skipped since `resize` is an iOS 17 mlprogram op.

## Verification

```
pytest coremltools/converters/mil/frontend/torch/test/test_torch_ops.py -k TestUpsample
```
passes on macOS / Apple silicon, torch 2.12, with the pre-existing xfails unchanged.
