### PR TITLE
fuse_reduce_mean: do not fuse when the scalar operand raises the rank

### DIFF
--- a/coremltools/converters/mil/mil/passes/defs/cleanup/fuse_reduce_mean.py
+++ b/coremltools/converters/mil/mil/passes/defs/cleanup/fuse_reduce_mean.py
@@ -89,6 +89,13 @@ class fuse_reduce_mean(AbstractGraphPass):
         else:
             return False
 
+        # `_check_var_scalar_value` accepts any size-1 tensor, including one whose rank
+        # exceeds the reduce_sum output's, e.g. a shape (1, 1, 1) const. The mul /
+        # real_div then broadcasts the rank up, which reduce_mean would not do, so the
+        # rewrite would change the output shape.
+        if child_op.outputs[0].shape != reduce_sum_op.outputs[0].shape:
+            return False
+
         ops_to_remove.append(child_op)
 
         # remove all the ops, and replace with a reduce_mean op

--- a/coremltools/converters/mil/mil/passes/tests/test_cleanup_passes.py
+++ b/coremltools/converters/mil/mil/passes/tests/test_cleanup_passes.py
@@ -1194,6 +1194,56 @@ class TestReduceMeanFusion:
         PASS_REGISTRY[pass_name](prog)
         assert get_op_types_in_program(prog) == ["reduce_sum", "real_div", "mul", "add"]
 
+    def test_invalid_pattern_rank_raising_mul(self):
+        """
+        The multiplier holds a single value but has a higher rank than reduce_sum's
+        output, so the mul broadcasts the rank up. reduce_mean would not, so fusing
+        would change the model's output shape.
+        """
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 3))])
+        def prog(x):
+            x1 = mb.reduce_sum(x=x, axes=[1], keep_dims=False)
+            return mb.mul(x=x1, y=np.array([[[1.0 / 3]]], dtype=np.float32))
+
+        assert prog.functions["main"].outputs[0].shape == (1, 1, 2)
+
+        pass_name = "common::fuse_reduce_mean"
+        PASS_REGISTRY[pass_name](prog)
+        assert get_op_types_in_program(prog) == ["reduce_sum", "mul"]
+        assert prog.functions["main"].outputs[0].shape == (1, 1, 2)
+
+    def test_invalid_pattern_rank_raising_real_div(self):
+        """Same as above, through the real_div branch."""
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 3))])
+        def prog(x):
+            x1 = mb.reduce_sum(x=x, axes=[1], keep_dims=False)
+            return mb.real_div(x=x1, y=np.array([[[3.0]]], dtype=np.float32))
+
+        assert prog.functions["main"].outputs[0].shape == (1, 1, 2)
+
+        pass_name = "common::fuse_reduce_mean"
+        PASS_REGISTRY[pass_name](prog)
+        assert get_op_types_in_program(prog) == ["reduce_sum", "real_div"]
+        assert prog.functions["main"].outputs[0].shape == (1, 1, 2)
+
+    def test_valid_pattern_size_one_tensor_multiplier(self):
+        """
+        A size-1 multiplier that does not raise the rank still broadcasts to the same
+        shape, so it must keep fusing.
+        """
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 3))])
+        def prog(x):
+            x1 = mb.reduce_sum(x=x, axes=[1], keep_dims=False)
+            return mb.mul(x=x1, y=np.array([1.0 / 3], dtype=np.float32))
+
+        pass_name = "common::fuse_reduce_mean"
+        PASS_REGISTRY[pass_name](prog)
+        assert get_op_types_in_program(prog) == ["reduce_mean"]
+        assert prog.functions["main"].outputs[0].shape == (2,)
+
 
 class TestLoopInvariantElimination:
     def test_loop_invariant_elimination1(self):


### PR DESCRIPTION
### Problem

`fuse_reduce_mean`'s docstring says the multiplier is a `const (scalar)`. The code validates it with `_check_var_scalar_value`, which accepts **any** tensor whose `size == 1`, regardless of rank:

```python
if isinstance(x.val, np.ndarray):
    if x.val.size != 1:
        return False
```

A shape `(1, 1, 1)` const holding `1/count` therefore passes the check. But `mul` broadcasts `reduce_sum`'s output up to rank 3, and the `reduce_mean` that replaces the pair does not:

```python
@mb.program(input_specs=[mb.TensorSpec(shape=(2, 3))])
def prog(x):
    s = mb.reduce_sum(x=x, axes=[1], keep_dims=False)          # (2,)
    return mb.mul(x=s, y=np.array([[[1.0 / 3]]], dtype=np.float32))

PASS_REGISTRY["common::fuse_reduce_mean"](prog)
# ['reduce_sum', 'mul'] -> ['reduce_mean']
# output shape (1, 1, 2) -> (2,)
```

The `real_div` branch has the same problem with a shape `(1, 1, 1)` count. Both are the model's declared output, so the converted model has a different output shape than the program it was built from.

`common::fuse_reduce_mean` is in the default pipeline.

### Fix

Check that the child op's output shape matches `reduce_sum`'s output shape before rewriting. A size-1 operand that does *not* raise the rank (a plain scalar, or a shape `(1,)` const against a rank-1 reduce output) broadcasts to the same shape and keeps fusing, so the pattern the pass actually targets is unaffected.

I deliberately put the check in this pass rather than tightening `_check_var_scalar_value`, which is shared with several other passes that may legitimately want the looser size-1 test.

### Tests

In `TestReduceMeanFusion`:

- `test_invalid_pattern_rank_raising_mul` — the repro above. Fails on `main`.
- `test_invalid_pattern_rank_raising_real_div` — same through the `real_div` branch. Fails on `main`.
- `test_valid_pattern_size_one_tensor_multiplier` — a shape `(1,)` multiplier that does not raise the rank must still fuse (guards against over-narrowing). Passes before and after.

The existing `test_valid_pattern*` / `test_invalid_pattern*` tests are untouched. I ran the whole class before and after; the failure sets are identical (this environment cannot load CoreML.framework, so `assert_model_is_valid` fails there either way — the graph-structure assertions preceding it all run and pass).

Note: this touches `test_cleanup_passes.py`, which my PR #2786 also modifies, in a different class.
