### PR TITLE
Reject a classifier whose probabilities have a symbolic shape

### DIFF
--- a/coremltools/converters/mil/backend/mil/load.py
+++ b/coremltools/converters/mil/backend/mil/load.py
@@ -552,6 +552,19 @@ def _add_classify_op(prog, classifier_config):
     probability_var = _get_probability_var_for_classifier(prog, classifier_config)
     original_probability_var = probability_var
 
+    # The Core ML runtime requires a classifier's probabilities to have a fully known shape, so a
+    # symbolic one produces a model that cannot be compiled for any input shape, not even the ones
+    # where the symbol resolves to a size matching the class labels. Reject it here instead of
+    # returning that model: without this the flexible-shape case skips the size check below, which
+    # only runs for a fully known shape.
+    if any_symbolic(probability_var.shape):
+        raise ValueError(
+            "Classifier probabilities must have a fully known shape, but the tensor "
+            f"'{probability_var.name}' selected for the 'ClassifierConfig' has shape "
+            f"{probability_var.shape}. Flexible shapes (for instance an enumerated or "
+            "range-dimension batch) are not supported for classifier outputs."
+        )
+
     # add the classify op now
     # we consider this step as a scope of coremltools graph pass
     with mb.scope(ScopeInfo(source=ScopeSource.COREMLTOOLS_GRAPH_PASS, data=["add_classify_op"])):

--- a/coremltools/converters/mil/backend/mil/test_load.py
+++ b/coremltools/converters/mil/backend/mil/test_load.py
@@ -344,6 +344,31 @@ class TestMILFlexibleShapes:
         assert spec_H_range == [10, 10], "Ranged height mismatch"
         assert spec_W_range == [10, 30], "Ranged width mismatch"
 
+    @pytest.mark.parametrize("flexibility", ["enumerated", "range"])
+    def test_mil_classifier_rejects_flexible_probabilities(self, flexibility):
+        """A classifier needs a fully known probabilities shape, so conversion must not
+        return a model the Core ML runtime cannot compile for any input shape."""
+        class_labels = ["a", "b", "c", "d"]
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(get_new_symbol(), len(class_labels)))])
+        def classifier_network(x):
+            return mb.softmax(x=x, axis=1)
+
+        if flexibility == "enumerated":
+            shape = ct.EnumeratedShapes(shapes=[(1, 4), (4, 4)], default=(1, 4))
+        else:
+            shape = (ct.RangeDim(lower_bound=1, upper_bound=8), 4)
+
+        with pytest.raises(ValueError, match="fully known shape"):
+            ct.convert(
+                classifier_network,
+                source="milinternal",
+                convert_to="mlprogram",
+                inputs=[ct.TensorType(name="x", shape=shape)],
+                classifier_config=ct.ClassifierConfig(class_labels),
+                minimum_deployment_target=ct.target.iOS16,
+            )
+
 
 class TestMILDefaultValues:
     @mb.program(input_specs=[mb.TensorSpec(shape=[1]), mb.TensorSpec(shape=[1])])


### PR DESCRIPTION
`classify`'s type inference only checks that the number of class labels matches the size of `probabilities` when that shape is fully known. With a flexible input shape the check is skipped, so conversion succeeds and returns a model the Core ML runtime cannot compile:

```
Error: Unable to parse ML Program: in operation classify_1:
Classifier probabilities must have a fully known shape.
```

This fails for every input shape, including the ones where the symbol resolves to a size that matches the labels, so there is no shape at which the returned model works. A fixed non-matching batch already raises at conversion time; this makes the flexible case fail there too instead of at prediction.

Repro on `main` (converts, then every `predict` fails):

```python
@mb.program(input_specs=[mb.TensorSpec(shape=(get_new_symbol(), 4))])
def prog(x):
    return mb.softmax(x=x, axis=1)

ct.convert(
    prog, source="milinternal", convert_to="mlprogram",
    inputs=[ct.TensorType(name="x", shape=ct.EnumeratedShapes([(1, 4), (4, 4)]))],
    classifier_config=ct.ClassifierConfig(["a", "b", "c", "d"]),
    minimum_deployment_target=ct.target.iOS16,
)
```

Added a parametrized test over enumerated and range-dimension shapes; both fail on `main`.

Refs #2764
