### PR TITLE
Copy the input in thresholded_relu's value_inference

### DIFF
--- a/coremltools/converters/mil/mil/ops/defs/iOS15/activation.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS15/activation.py
@@ -616,6 +616,6 @@ class thresholded_relu(activation_with_alpha):
 
     @precondition(allow=VALUE)
     def value_inference(self):
-        y = self.x.val
+        y = np.copy(self.x.val)
         y[y < self.alpha.val] = 0
         return y

--- a/coremltools/converters/mil/mil/ops/tests/iOS14/test_activation.py
+++ b/coremltools/converters/mil/mil/ops/tests/iOS14/test_activation.py
@@ -987,6 +987,39 @@ class TestThresholdedReLU:
         y[y < 2.0] = 0
         np.testing.assert_allclose(y, v.val, atol=1e-04, rtol=1e-05)
 
+    @ssa_fn
+    def test_builder_eval_does_not_mutate_input(self):
+        """value_inference must not write through to the input's own array."""
+        x_val = np.array([[-1.0, 0.5], [2.0, -3.0]], dtype=np.float32)
+        original = np.copy(x_val)
+        v = mb.thresholded_relu(x=x_val, alpha=1.0)
+        np.testing.assert_allclose(
+            v.val, np.array([[0.0, 0.0], [2.0, 0.0]], dtype=np.float32), atol=1e-04, rtol=1e-05
+        )
+        np.testing.assert_allclose(x_val, original, atol=1e-04, rtol=1e-05)
+
+    def test_builder_eval_does_not_corrupt_shared_const(self):
+        """
+        A const consumed both by thresholded_relu and by another op must keep its
+        value for that other op.
+        """
+        w_val = np.array([[-1.0, 0.5], [2.0, -3.0]], dtype=np.float32)
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 2))])
+        def prog(x):
+            w = mb.const(val=w_val, name="weight")
+            y = mb.matmul(x=x, y=w)
+            z = mb.thresholded_relu(x=w, alpha=1.0)
+            return mb.add(x=y, y=z)
+
+        matmul_op = prog.functions["main"].find_ops(op_type="matmul")[0]
+        np.testing.assert_allclose(
+            matmul_op.y.val,
+            np.array([[-1.0, 0.5], [2.0, -3.0]], dtype=np.float32),
+            atol=1e-04,
+            rtol=1e-05,
+        )
+
     @pytest.mark.parametrize(
         "compute_unit, backend, dim, alpha",
         itertools.product(compute_units, backends, [2, 4, 8], [2.0, 3.0]),


### PR DESCRIPTION
### Problem

`thresholded_relu.value_inference` aliases its input's array and then writes through it:

```python
@precondition(allow=VALUE)
def value_inference(self):
    y = self.x.val          # alias, not a copy
    y[y < self.alpha.val] = 0
    return y
```

Every sibling op in the same file copies first — `elu` (line 107), `leaky_relu` (line 210), `softplus_parametric` (lines 497-498) all start with `np.copy(...)`. `thresholded_relu` does not, so constant-folding it **overwrites the value of its input const**.

When that const is also used elsewhere — as a weight, say — the weight is silently replaced with the thresholded values:

```python
w_val = np.array([[-1.0, 0.5], [2.0, -3.0]], dtype=np.float32)

@mb.program(input_specs=[mb.TensorSpec(shape=(2, 2))])
def prog(x):
    w = mb.const(val=w_val, name="weight")
    y = mb.matmul(x=x, y=w)
    z = mb.thresholded_relu(x=w, alpha=1.0)
    return mb.add(x=y, y=z)
```

| | value |
|---|---|
| `matmul`'s weight operand | `[[0.0, 0.0], [2.0, 0.0]]` |
| correct | `[[-1.0, 0.5], [2.0, -3.0]]` |

The corrupted array is what gets serialized into the weight blob. The caller's own numpy array is clobbered as well, since the const does not copy it on the way in.

### Fix

`y = np.copy(self.x.val)`, matching the other activation ops in the file.

### Tests

In `TestThresholdedReLU` (`ops/tests/iOS14/test_activation.py`):

- `test_builder_eval_does_not_mutate_input` — the input array must be unchanged after folding, and the folded value must still be correct.
- `test_builder_eval_does_not_corrupt_shared_const` — the shared-weight program above; `matmul`'s operand must keep its original value.

Both fail on `main` and pass with the fix.

The existing `test_builder_eval` is untouched and still passes. It happens to compute its expected value as `y = x_val; y[y < 2.0] = 0` on the same array `value_inference` was mutating, which is why it never caught this.

I ran all of `ops/tests/iOS14/test_activation.py` before and after; the pre-existing failure set is identical, 188 either way (this environment cannot load CoreML.framework, so the `run_compare_builder` tests fail there regardless).
