### PR TITLE
Rename a feature inside nested MIL blocks

### DIFF
--- a/coremltools/models/utils.py
+++ b/coremltools/models/utils.py
@@ -725,24 +725,33 @@ def rename_feature(
             raise ValueError("Input/output names for ML Program must be of the format [a-zA-Z_][a-zA-Z0-9_]*. "
                              "That is, it must start with a letter and only contain numerals, underscore or letters. "
                              "Provided feature name, \"{}\" does not satisfy these requirements.".format(new_name))
+        def rename_in_block(block):
+            for i, out_name in enumerate(block.outputs):
+                if out_name == current_name:
+                    block.outputs[i] = new_name
+            for op in block.operations:
+                for argument in op.inputs.values():
+                    for binding in argument.arguments:
+                        if binding.HasField("name"):
+                            if binding.name == current_name:
+                                binding.name = new_name
+                for name_value_type in op.outputs:
+                    if name_value_type.name == current_name:
+                        name_value_type.name = new_name
+                # Control flow operations such as cond and while_loop hold nested blocks,
+                # and those blocks reference outer vars by name. Leaving them behind makes
+                # the renamed model fail to parse with "Input '<old name>' ... does not
+                # resolve".
+                for nested_block in op.blocks:
+                    rename_in_block(nested_block)
+
         mil = spec.mlProgram
         for function in mil.functions.values():
             for name_value_type in function.inputs:
                 if name_value_type.name == current_name:
                     name_value_type.name = new_name
             for block in function.block_specializations.values():
-                for i, out_name in enumerate(block.outputs):
-                    if out_name == current_name:
-                        block.outputs[i] = new_name
-                for op in block.operations:
-                    for argument in op.inputs.values():
-                        for binding in argument.arguments:
-                            if binding.HasField("name"):
-                                if binding.name == current_name:
-                                    binding.name = new_name
-                    for name_value_type in op.outputs:
-                        if name_value_type.name == current_name:
-                            name_value_type.name = new_name
+                rename_in_block(block)
 
 
 def _sanitize_value(x):

--- a/coremltools/test/neural_network/test_model.py
+++ b/coremltools/test/neural_network/test_model.py
@@ -563,6 +563,48 @@ class MLModelTest(unittest.TestCase):
         self.assertEqual(out[1], 6.0)
 
     @unittest.skipUnless(
+        _is_macos() and _macos_version() >= (12, 0), "Only supported on macOS 12+"
+    )
+    def test_rename_feature_mlprogram_nested_block(self):
+        # A cond op's nested blocks reference the outer input by name, so renaming has to
+        # reach into them. Otherwise the renamed model no longer parses.
+        @mb.program(
+            input_specs=[
+                mb.TensorSpec(shape=(1,), dtype=coremltools.converters.mil.mil.types.bool),
+                mb.TensorSpec(shape=(1,)),
+            ]
+        )
+        def cond_prog(a, b):
+            def true_fn():
+                return mb.add(x=b, y=1.0)
+
+            def false_fn():
+                return mb.mul(x=b, y=2.0)
+
+            return mb.cond(pred=mb.squeeze(x=a), _true_fn=true_fn, _false_fn=false_fn)
+
+        model = coremltools.convert(
+            cond_prog,
+            convert_to="mlprogram",
+            minimum_deployment_target=coremltools.target.iOS16,
+        )
+        output_name = model.get_spec().description.output[0].name
+
+        spec = model.get_spec()
+        rename_feature(spec, "b", "renamed_b")
+        self.assertEqual([i.name for i in spec.description.input], ["a", "renamed_b"])
+
+        renamed_model = coremltools.models.MLModel(spec, weights_dir=model.weights_dir)
+        for pred, expected in ((1.0, 3.0), (0.0, 4.0)):
+            out = renamed_model.predict(
+                {
+                    "a": np.array([pred], dtype=np.float32),
+                    "renamed_b": np.array([2.0], dtype=np.float32),
+                }
+            )[output_name]
+            np.testing.assert_allclose(out, np.array([expected], dtype=np.float32))
+
+    @unittest.skipUnless(
         _is_macos() and _macos_version() >= (12, 0) and _HAS_TORCH, "Only supported on macOS 12+"
     )
     def test_rename_feature_classifier_mlprogram(self):


### PR DESCRIPTION
`rename_feature`'s ML Program branch walks each function's `block_specializations` but not the nested blocks that control flow operations hold. `cond` and `while_loop` blocks reference outer vars by name, so renaming an input or output that they use leaves those references pointing at the old name. The renamed model then fails to load:

```
Unable to parse ML Program: at unknown location:
Input 'b' for parameter 'x' does not resolve.
```

Repro on `main`:

```python
@mb.program(input_specs=[mb.TensorSpec(shape=(1,), dtype=types.bool),
                         mb.TensorSpec(shape=(1,))])
def prog(a, b):
    def true_fn():
        return mb.add(x=b, y=1.0)
    def false_fn():
        return mb.mul(x=b, y=2.0)
    return mb.cond(pred=mb.squeeze(x=a), _true_fn=true_fn, _false_fn=false_fn)

model = ct.convert(prog, convert_to="mlprogram",
                   minimum_deployment_target=ct.target.iOS16)
spec = model.get_spec()
ct.utils.rename_feature(spec, "b", "renamed_b")
ct.models.MLModel(spec, weights_dir=model.weights_dir).predict(...)  # raises
```

The block walk is now a recursive helper so nested blocks get the same treatment. Added a test that renames an input used by both `cond` branches and checks the predictions on each branch; it fails on `main` with the error above.
