### PR TITLE
Read the packed-sequence schema of gru / rnn_tanh / rnn_relu correctly

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -3404,13 +3404,9 @@ def gru(context, node):
     inputs = _get_inputs(context, node, expected=9)
 
     _input = inputs[0]
-    h0 = inputs[1]
-    weights_list = inputs[2]
-    has_bias = inputs[3].val
-    num_layers = inputs[4].val
-    dropout = inputs[5]
-    bidirectional = inputs[7].val
-    batch_first = inputs[8].val
+    h0, weights_list, has_bias, num_layers, dropout, bidirectional, batch_first = _parse_rnn_args(
+        inputs
+    )
 
     # For each layer of GRU, the layout of the weights list is [Wi, Wh, bi, bh] with has_bias == True,
     # and is [Wi, Wh] with bias == False.
@@ -3548,6 +3544,40 @@ def gru(context, node):
     context.add(h, state_output_name)
 
 
+def _parse_rnn_args(inputs: List[Var]) -> Tuple:
+    """
+    Read the arguments shared by the single-hidden-state recurrent ops (gru,
+    rnn_tanh, rnn_relu), from either of the two torch schemas.
+
+    The packed-sequence schema inserts ``batch_sizes`` ahead of ``hx``, e.g. for gru::
+
+        aten::gru.input(Tensor input, Tensor hx, Tensor[] params, bool has_biases,
+                        int num_layers, float dropout, bool train, bool bidirectional,
+                        bool batch_first)
+        aten::gru.data(Tensor data, Tensor batch_sizes, Tensor hx, Tensor[] params,
+                       bool has_biases, int num_layers, float dropout, bool train,
+                       bool bidirectional)
+
+    Both bind 9 inputs, so the arity cannot tell them apart. The weight list is a
+    ``Tensor[]``, which binds to a python list, while every argument that could take
+    its place is a single Var -- so where that list lands identifies the schema.
+    """
+    has_batch_sizes = not isinstance(inputs[2], Iterable)
+    offset = 1 if has_batch_sizes else 0
+
+    h0 = inputs[1 + offset]
+    weights_list = inputs[2 + offset]
+    has_bias = inputs[3 + offset].val
+    num_layers = inputs[4 + offset].val
+    dropout = inputs[5 + offset]
+    bidirectional = inputs[7 + offset].val
+    # a packed sequence carries no batch_first argument: the output of
+    # _pack_padded_sequence is always laid out batch first
+    batch_first = True if has_batch_sizes else inputs[8].val
+
+    return h0, weights_list, has_bias, num_layers, dropout, bidirectional, batch_first
+
+
 def _add_simple_rnn(context, node, activation):
     inputs = _get_inputs(context, node, expected=9)
 
@@ -3561,13 +3591,9 @@ def _add_simple_rnn(context, node, activation):
     (2) h0: (num_layers, B, H)
     '''
     _input = inputs[0]
-    h0 = inputs[1]
-    weights_list = inputs[2]
-    has_bias = inputs[3].val
-    num_layers = inputs[4].val
-    dropout = inputs[5]
-    bidirectional = inputs[7].val
-    batch_first = inputs[8].val
+    h0, weights_list, has_bias, num_layers, dropout, bidirectional, batch_first = _parse_rnn_args(
+        inputs
+    )
 
     # We only support uni-directional simple RNN now
     if bidirectional:

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -4002,6 +4002,59 @@ class TestLSTMWithPackedSequence(TorchBaseTest):
         )
 
 
+class TestRNNWithPackedSequence(TorchBaseTest):
+    @pytest.mark.parametrize(
+        "compute_unit, backend, nonlinearity, RNN_batch_first",
+        itertools.product(compute_units, backends, ["tanh", "relu"], [True, False]),
+    )
+    def test_rnn(self, compute_unit, backend, nonlinearity, RNN_batch_first):
+        """
+        A PackedSequence makes torch pick aten::rnn_tanh.data / aten::rnn_relu.data,
+        which insert batch_sizes ahead of hx. Both schemas bind 9 inputs, so the
+        arity does not distinguish them and every later argument has to be read at
+        the shifted offset.
+        """
+        from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence
+
+        input_size = 4
+        hidden_size = 6
+
+        class Encoder(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.rnn = torch.nn.RNN(
+                    input_size=input_size,
+                    hidden_size=hidden_size,
+                    num_layers=1,
+                    nonlinearity=nonlinearity,
+                    batch_first=RNN_batch_first,
+                    bidirectional=False,
+                )
+
+            def forward(self, batch_in, seq_lengths):
+                packed_input = pack_padded_sequence(batch_in, seq_lengths, batch_first=True)
+                output_packed, _ = self.rnn(packed_input)
+                output, _ = pad_packed_sequence(output_packed, batch_first=True)
+                return output
+
+        model = Encoder()
+        model.eval()
+
+        _input = torch.randn(3, 10, input_size)
+        seq_lengths = torch.tensor([10, 5, 1], dtype=torch.int32)
+
+        inputs = (_input, seq_lengths)
+        expected_results = model(*inputs)
+        self.run_compare_torch(
+            inputs,
+            model,
+            expected_results,
+            input_as_shape=False,
+            backend=backend,
+            compute_unit=compute_unit,
+        )
+
+
 # Workaround for GitHub Issue #824
 # i.e. the return h_n/c_n for a converted BLSTM are mangled.
 # Therefore, just look at output 'y' (for now) which is correct.


### PR DESCRIPTION
## Problem

Feeding a `PackedSequence` to `nn.RNN` or `nn.GRU` aborts conversion:

```python
import torch, torch.nn as nn, coremltools as ct
from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence

class Encoder(nn.Module):
    def __init__(self):
        super().__init__()
        self.rnn = nn.RNN(4, 6, batch_first=True)

    def forward(self, x, lens):
        packed, _ = self.rnn(pack_padded_sequence(x, lens, batch_first=True))
        out, _ = pad_packed_sequence(packed, batch_first=True)
        return out

x, lens = torch.randn(3, 10, 4), torch.tensor([10, 5, 1], dtype=torch.int32)
ct.convert(torch.jit.trace(Encoder().eval(), (x, lens)), convert_to="mlprogram", inputs=[...])
```

```
ERROR - converting 'rnn_tanh' op
AttributeError: 'list' object has no attribute 'val'
```

torch has two schemas for each of these ops, and the packed one inserts `batch_sizes` **ahead of** `hx`:

```
aten::rnn_tanh.input(Tensor input, Tensor hx, Tensor[] params, bool has_biases,
                     int num_layers, float dropout, bool train, bool bidirectional,
                     bool batch_first)
aten::rnn_tanh.data(Tensor data, Tensor batch_sizes, Tensor hx, Tensor[] params,
                    bool has_biases, int num_layers, float dropout, bool train,
                    bool bidirectional)
```

**Both bind exactly 9 inputs**, so the `expected=9` check passes and nothing catches the shift — every argument from index 1 on is read one slot early. `has_bias = inputs[3].val` lands on the `Tensor[] params` list, which is where the `AttributeError` comes from. `gru` and `rnn_relu` have the identical pair of schemas and the identical bug.

`lstm` already handles this (`has_batch_sizes = not isinstance(inputs[1], Iterable)`); the single-hidden-state ops just never got the same treatment.

## Fix

A shared `_parse_rnn_args` helper used by `gru`, `rnn_tanh` and `rnn_relu`.

Distinguishing the schemas needs care, because `lstm`'s test does not transfer: `lstm`'s `hx` is a `Tensor[]`, so a list at index 1 means the unpacked schema — but for these ops `hx` is a single `Tensor`, so index 1 is a Var either way. What *is* unambiguous is the `Tensor[] params` weight list, the only list-valued argument: it sits at index 2 for `.input` and index 3 for `.data`. So `isinstance(inputs[2], Iterable)` identifies the schema, and everything after is read at the matching offset.

`.data` carries no `batch_first` argument, because the output of `_pack_padded_sequence` is always laid out batch first — same as `lstm` already assumes.

## Test

`TestRNNWithPackedSequence::test_rnn` runs a packed `nn.RNN` through `pack_padded_sequence` / `pad_packed_sequence` for both nonlinearities (`tanh` -> `aten::rnn_tanh.data`, `relu` -> `aten::rnn_relu.data`) and both `batch_first` settings, comparing against torch. It mirrors the existing `TestLSTMWithPackedSequence`, which is what made the `lstm` handling visible in the first place.

All 8 parametrizations fail with the `AttributeError` without the fix and pass with it (max abs difference vs torch ~1.2e-07).

## A note on GRU

`gru` gets the same corrected parsing, but a packed GRU still does not convert end to end — it now fails further downstream with

```
NotImplementedError: Only static shape of PackedSequence object is supported.
```

That is a separate, pre-existing limitation: `_add_gru_layer` builds its hidden-state list with `mb.fill` over a shape computed at run time, so the GRU output carries a symbolic batch dimension that `_pad_packed_sequence` rejects. `lstm` avoids it because `_add_mil_lstm` keeps a static shape. I left that alone rather than widen this change — the argument-offset fix stands on its own, and it turns a misleading `AttributeError` deep inside argument parsing into an accurate message about what is actually unsupported. Happy to look at the GRU lowering separately if it is wanted.

## Verification

```
pytest coremltools/converters/mil/frontend/torch/test/test_torch_ops.py -k "TestRNN or TestGRU or TestLSTM"
```
on macOS / Apple silicon, torch 2.12, mlprogram + neuralnetwork.
