### PR TITLE
Fix pipeline traversal when mapping a model to structure paths

### DIFF
--- a/coremltools/models/ml_program/experimental/model_structure_path.py
+++ b/coremltools/models/ml_program/experimental/model_structure_path.py
@@ -301,7 +301,6 @@ def map_model_structure_to_path(
             components=components,
         )
     elif model_structure.pipeline:
-        components.append(ModelStructurePath.Pipeline())
         result = []
         for submodel_name, submodel in model_structure.pipeline.sub_models:
             result.extend(
@@ -315,7 +314,7 @@ def map_model_structure_to_path(
                 )
             )
 
-            return result
+        return result
     else:
         raise ValueError("Invalid model structure: no recognized components found")
 
@@ -379,12 +378,16 @@ def map_model_spec_to_path(
             components=components,
         )
     elif spec_type == "pipeline":
-        components.append(ModelStructurePath.Pipeline())
+        # The spec may leave the sub-model names unset, in which case the framework names them
+        # by position. Match that here so these paths line up with the ones built from the
+        # loaded model structure.
+        names = list(model_spec.pipeline.names)
         result = []
-        for submodel_name, submodel in zip(model_spec.names.model_spec.models):
+        for index, submodel in enumerate(model_spec.pipeline.models):
+            submodel_name = names[index] if index < len(names) else f"model{index}"
             result.extend(
                 map_model_spec_to_path(
-                    model_structure=submodel,
+                    model_spec=submodel,
                     components=components
                     + [
                         ModelStructurePath.Pipeline(),
@@ -393,6 +396,6 @@ def map_model_spec_to_path(
                 )
             )
 
-            return result
+        return result
     else:
         raise ValueError("Invalid model structure: no recognized components found")

--- a/coremltools/test/ml_program/experimental/test_perf_utils.py
+++ b/coremltools/test/ml_program/experimental/test_perf_utils.py
@@ -140,6 +140,53 @@ class TestMLModelBenchmarker:
 
     @staticmethod
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("set_submodel_names", [True, False])
+    async def test_benchmark_operation_execution_pipeline(set_submodel_names: bool):
+        # The sub-model names are optional in the spec, and the framework falls back to
+        # naming them by position, so both spellings have to reach the same paths.
+        @mb.program(input_specs=[mb.TensorSpec(shape=(3,))])
+        def first(x):
+            return mb.relu(x=x, name="relu_op")
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(3,))])
+        def second(x):
+            return mb.mul(x=x, y=2.0, name="mul_op")
+
+        first_model = ct.convert(
+            first, convert_to="mlprogram", compute_precision=ct.precision.FLOAT32
+        )
+        second_model = ct.convert(
+            second, convert_to="mlprogram", compute_precision=ct.precision.FLOAT32
+        )
+
+        second_spec = second_model.get_spec()
+        ct.utils.rename_feature(
+            second_spec,
+            second_spec.description.input[0].name,
+            first_model.get_spec().description.output[0].name,
+        )
+        second_model = ct.models.MLModel(second_spec, weights_dir=second_model.weights_dir)
+
+        pipeline = ct.utils.make_pipeline(first_model, second_model)
+        if set_submodel_names:
+            pipeline_spec = pipeline.get_spec()
+            del pipeline_spec.pipeline.names[:]
+            pipeline_spec.pipeline.names.extend(["first_stage", "second_stage"])
+            pipeline = ct.models.MLModel(pipeline_spec, weights_dir=pipeline.weights_dir)
+
+        benchmarker = MLModelBenchmarker(model=pipeline)
+        execution_infos = await benchmarker.benchmark_operation_execution(
+            iterations=1,
+            warmup=False,
+        )
+
+        # Operations from both sub-models have to be reported.
+        op_types = {execution_info.spec.type for execution_info in execution_infos}
+        assert "relu" in op_types
+        assert "mul" in op_types
+
+    @staticmethod
+    @pytest.mark.asyncio
     async def test_benchmark_predict_with_int32_inputs():
         prog = TestMLModelBenchmarker.get_test_model_with_int32_inputs()
         mlmodel = ct.convert(prog, convert_to="mlprogram", compute_precision=ct.precision.FLOAT32)


### PR DESCRIPTION
`MLModelBenchmarker.benchmark_operation_execution()` raises `AttributeError: names` for any pipeline model, because `map_model_spec_to_path`'s pipeline branch:

- reads `model_spec.names.model_spec.models` instead of `model_spec.pipeline.names` / `.models`
- calls `zip()` with one iterable, then unpacks two values
- passes `model_structure=` to itself, which only takes `model_spec=`
- returns inside the loop, so only the first sub-model would be visited

`map_model_structure_to_path` has the last problem too, and also appends to its shared default `components` argument.

Fixing only those still reports nothing, because the paths from the two functions have to be equal to be joined. The spec leaves `pipeline.names` unset (`ct.utils.make_pipeline` does not populate it) while the framework names sub-models by position, so the spec side now uses the same `model<i>` fallback. Verified both spellings against a compute plan retrieved from a real pipeline: with names unset and with names set, all 11 operations across both sub-models are now reported; on `main` both raise.

Added a parametrized test covering both.
