### PR TITLE
fuse_matmul_weight_bias: fix sub operand order and drop the const-on-the-left case

### DIFF
--- a/coremltools/converters/mil/mil/passes/defs/optimize_linear.py
+++ b/coremltools/converters/mil/mil/passes/defs/optimize_linear.py
@@ -212,13 +212,16 @@ class fuse_matmul_weight_bias(AbstractGraphPass):
 
         x_is_weight = matmul_op.x.val is not None
         if x_is_weight:
-            weight, linear_x = matmul_op.x, matmul_op.y
-            transpose_weight = matmul_op.transpose_x.val
-            transpose_x = matmul_op.transpose_y.val
-        else:
-            weight, linear_x = matmul_op.y, matmul_op.x
-            transpose_weight = matmul_op.transpose_y.val
-            transpose_x = matmul_op.transpose_x.val
+            # w @ x is rewritten as transpose(linear(transpose(x), w)). linear adds its
+            # bias along its own last axis, which the outer transpose then moves to
+            # axis -2 of the result, so the bias would end up on the wrong axis. There
+            # is no way to express the bias inside the linear op here, and adding it
+            # after the transpose would not fuse anything, so leave this pattern alone.
+            return False
+
+        weight, linear_x = matmul_op.y, matmul_op.x
+        transpose_weight = matmul_op.transpose_y.val
+        transpose_x = matmul_op.transpose_x.val
 
         # We potentially are going to transpose the weight, so if the weight itself is not removable, we skip this path
         if len(weight.nonreplaceable_vars_upstream) > 0:
@@ -249,28 +252,26 @@ class fuse_matmul_weight_bias(AbstractGraphPass):
             return  # cannot transform
 
         if add_op.op_type == "sub":
-            bias = -bias
+            # sub is not commutative, so which operand the matmul output is matters.
+            if add_op.x == matmul_op.outputs[0]:
+                # x @ w - bias == linear(x, w, -bias)
+                bias = -bias
+            else:
+                # bias - x @ w == linear(x, -w, bias)
+                weight = mb.const(val=-weight.val, before_op=matmul_op)
         out_name = add_op.outputs[0].name
 
         with mb.set_before_op(matmul_op):
-            if x_is_weight:
-                # If transpose_x == transpose_weight == False:
-                # w*x = (x^T w^T)^T = linear(x^T, w)^T
-                x_transposed = self._transpose(linear_x) if not transpose_x else linear_x
-                w_no_transpose = weight if not transpose_weight else self._transpose(weight)
-                x = mb.linear(x=x_transposed, weight=w_no_transpose, bias=bias)
-                x = self._transpose(x, name=out_name)
-            else:
-                # If transpose_x == transpose_weight == False
-                # x*w = x*(w^T)^T = linear(x, w^T)
-                x_no_transpose = self._transpose(linear_x) if transpose_x else linear_x
-                w_transposed = weight if transpose_weight else self._transpose(weight)
-                x = mb.linear(
-                    x=x_no_transpose,
-                    weight=w_transposed,
-                    bias=bias,
-                    name=out_name,
-                )
+            # If transpose_x == transpose_weight == False
+            # x*w = x*(w^T)^T = linear(x, w^T)
+            x_no_transpose = self._transpose(linear_x) if transpose_x else linear_x
+            w_transposed = weight if transpose_weight else self._transpose(weight)
+            x = mb.linear(
+                x=x_no_transpose,
+                weight=w_transposed,
+                bias=bias,
+                name=out_name,
+            )
 
         if add_op.enclosing_block.try_replace_uses_of_var_after_op(
             anchor_op=add_op,

--- a/coremltools/converters/mil/mil/passes/tests/test_optimize_linear_passes.py
+++ b/coremltools/converters/mil/mil/passes/tests/test_optimize_linear_passes.py
@@ -218,6 +218,85 @@ class TestFuseMatmulWeightBias:
         if _VALIDATE_MODEL:
             assert_model_is_valid(prog, {"x": (2, 4)})
 
+    @staticmethod
+    def _evaluate(prog, x_val):
+        """Interpret the handful of op types these programs are made of."""
+        env = {}
+        func = prog.functions["main"]
+        for var in func.inputs.values():
+            env[var] = x_val
+
+        def value_of(var):
+            return env[var] if var in env else np.asarray(var.val)
+
+        for op in func.operations:
+            if op.op_type == "const":
+                continue
+            elif op.op_type == "matmul":
+                a, b = value_of(op.x), value_of(op.y)
+                if op.transpose_x.val:
+                    a = np.swapaxes(a, -1, -2)
+                if op.transpose_y.val:
+                    b = np.swapaxes(b, -1, -2)
+                env[op.outputs[0]] = a @ b
+            elif op.op_type == "linear":
+                env[op.outputs[0]] = value_of(op.x) @ value_of(op.weight).T + value_of(op.bias)
+            elif op.op_type == "transpose":
+                env[op.outputs[0]] = np.transpose(value_of(op.x), list(op.perm.val))
+            elif op.op_type == "add":
+                env[op.outputs[0]] = value_of(op.x) + value_of(op.y)
+            elif op.op_type == "sub":
+                env[op.outputs[0]] = value_of(op.x) - value_of(op.y)
+            else:
+                raise AssertionError(f"unhandled op type {op.op_type}")
+        return env[func.outputs[0]]
+
+    @pytest.mark.parametrize(
+        "transpose_x, transpose_y", itertools.product([False, True], [False, True])
+    )
+    def test_fuse_matmul_weight_bias_sub_with_matmul_second(self, transpose_x, transpose_y):
+        """
+        sub is not commutative: ``bias - x @ w`` is ``linear(x, -w, bias)``, not
+        ``linear(x, w, -bias)``.
+        """
+        weights_val = ((np.arange(9, dtype=np.float32).reshape(3, 3) + 1.0) / 7.0)
+        bias_val = np.array([100.0, 200.0, 300.0], dtype=np.float32)
+        x_val = np.arange(9, dtype=np.float32).reshape(3, 3)
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(3, 3))])
+        def prog(x):
+            matmul = mb.matmul(
+                x=x, y=weights_val, transpose_x=transpose_x, transpose_y=transpose_y
+            )
+            return mb.sub(x=bias_val, y=matmul)
+
+        expected = self._evaluate(prog, x_val)
+        PASS_REGISTRY["common::fuse_matmul_weight_bias"](prog)
+        assert get_op_types_in_program(prog).count("linear") == 1
+        np.testing.assert_allclose(self._evaluate(prog, x_val), expected, atol=1e-04, rtol=1e-05)
+
+    @pytest.mark.parametrize(
+        "op_type, bias_first", itertools.product(["add", "sub"], [True, False])
+    )
+    def test_no_fuse_matmul_weight_bias_const_on_the_left(self, op_type, bias_first):
+        """
+        ``w @ x`` becomes ``transpose(linear(transpose(x), w))``, and linear's bias would
+        land on the wrong axis of the result, so this pattern must be left alone.
+        """
+        weights_val = ((np.arange(9, dtype=np.float32).reshape(3, 3) + 1.0) / 7.0)
+        bias_val = np.array([100.0, 200.0, 300.0], dtype=np.float32)
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(3, 3))])
+        def prog(x):
+            matmul = mb.matmul(x=weights_val, y=x)
+            builder_op = getattr(mb, op_type)
+            if bias_first:
+                return builder_op(x=bias_val, y=matmul)
+            return builder_op(x=matmul, y=bias_val)
+
+        PASS_REGISTRY["common::fuse_matmul_weight_bias"](prog)
+        assert get_op_types_in_program(prog) == ["matmul", op_type]
+
 
 class TestFuseTransposeMatmul:
     def test_fuse_transposes(self):


### PR DESCRIPTION
### Problem

`fuse_matmul_weight_bias` rewrites `matmul + add/sub` into `linear`. I swept all 32 combinations of *(which matmul operand is const)* × `transpose_x` × `transpose_y` × `add`/`sub` × *(which add/sub operand the matmul output is)*, evaluating the program before and after the pass. **20 of the 32 fuse into a program that computes something different.** There are two independent causes.

#### 1. `sub` is treated as commutative

The docstring says:

```
%5 = add(x=%3, y=%4) # %4 is const. add(x=%4, y=%3) is equivalent
                     # sub is similar.
```

It is not similar — `sub` is not commutative. The code's entire `sub` handling is:

```python
if add_op.op_type == "sub":
    bias = -bias
```

with no `is_first_input` test anywhere. So `bias - x @ W` silently becomes `x @ W - bias`:

```python
@mb.program(input_specs=[mb.TensorSpec(shape=(2, 3))])
def prog(x):
    mm = mb.matmul(x=x, y=np.eye(3, dtype=np.float32))
    return mb.sub(x=np.array([100., 200., 300.], np.float32), y=mm)
```

With `x = [[1,2,3],[4,5,6]]`:

| | value |
|---|---|
| before | `[[99, 198, 297], [96, 195, 294]]` |
| after | `[[-99, -198, -297], [-96, -195, -294]]` |

Exactly negated. `apply_pass_and_basic_check` raises nothing — the shapes and output names are unchanged.

`fuse_linear_bias`, in the same file, already gets this right: it computes `is_first_input` and negates the **weight** when the fused op is the second operand.

#### 2. Const as the left matmul operand puts the bias inside a transpose

`w @ x` is rewritten as `transpose(linear(transpose(x), w))` with the bias inside the `linear`. But `linear` adds its bias along its own last axis, which the outer transpose then moves to axis −2 of the result, so the bias lands on the wrong axis:

```python
mm  = mb.matmul(x=np.eye(3, dtype=np.float32), y=x)
out = mb.add(x=mm, y=np.array([100., 200., 300.], np.float32))
```

With `x = np.arange(9).reshape(3, 3)`:

| | value |
|---|---|
| before | `[[100,201,302],[103,204,305],[106,207,308]]` |
| after | `[[100,101,102],[203,204,205],[306,307,308]]` |

The existing guard cannot catch this: `d_out` is taken from the weight, but in this branch the output's last dimension comes from the *other* operand, so `bias.shape[0] != d_out` only lets the fusion through when everything is square — exactly the case where the shape check cannot notice.

All 16 `const_is_x=True` combinations are wrong, plus the 4 `sub`-with-bias-first ones from cause 1.

`common::fuse_matmul_weight_bias` is in the default pipeline (`pass_pipeline.py`).

### Fix

- For `sub`, test which operand the matmul output is. `x @ w - bias` stays `linear(x, w, -bias)`; `bias - x @ w` becomes `linear(x, -w, bias)`, mirroring `fuse_linear_bias`.
- Bail out when the const is the left matmul operand. The bias genuinely cannot be expressed inside the `linear` there, and emitting it as a separate `add` after the transpose would turn 2 ops into 4 — not a fusion at all. This removes an "optimization" that was wrong in every one of its 16 configurations.

After the change the same 32-case sweep fuses 16 and **all 16 are numerically identical to the original**.

### Tests

In `TestFuseMatmulWeightBias` (`passes/tests/test_optimize_linear_passes.py`):

- `test_fuse_matmul_weight_bias_sub_with_matmul_second[transpose_x, transpose_y]` — 4 cases; fuses and then compares the evaluated result against the original. Fails on `main`.
- `test_no_fuse_matmul_weight_bias_const_on_the_left[op_type, bias_first]` — 4 cases; the program must be left alone. Fails on `main`.

The tests evaluate the programs with a small interpreter over the five op types involved (`matmul`, `linear`, `transpose`, `add`, `sub`) so the numbers are checked without needing a backend.

The existing `test_fuse_matmul_weight_bias` is untouched and its fusion assertions still pass. I ran `test_optimize_linear_passes.py` in full plus `test_passes.py::TestFuseMatmulWeightBias` before and after; the pre-existing failure set is identical, 56 either way (this environment cannot load CoreML.framework, so `assert_model_is_valid` fails there regardless).
