### PR TITLE
loop_invariant_elimination: require the body to return the loop var itself

### DIFF
--- a/coremltools/converters/mil/mil/passes/defs/cleanup/loop_invariant_elimination.py
+++ b/coremltools/converters/mil/mil/passes/defs/cleanup/loop_invariant_elimination.py
@@ -63,20 +63,43 @@ class loop_invariant_elimination(AbstractGraphPass):
         block = while_op.blocks[1]  # body block
         loop_invariant_ids = []  # list of index in op.loop_vars, block.inputs
         for i, vx_in in enumerate(block.inputs):
-            vx_out = block.outputs[i]  # first output is cond var.
+            vx_out = block.outputs[i]  # body outputs are the next iteration's loop vars
             return_input_as_output = vx_in == vx_out
-            # this block output is a var from outside of the block
-
-            enclosing_block = while_op.enclosing_block
-            output_from_outside_of_block = enclosing_block.is_var_visible_in_block(
-                vx_out, upto_op=while_op
-            )
-            if return_input_as_output or output_from_outside_of_block:
+            # This block output is the very var the loop var was seeded with, so feeding
+            # it back leaves the loop var unchanged. Any *other* var from the enclosing
+            # scope is a value the loop var changes to from the second iteration on, and
+            # is therefore not invariant.
+            return_loop_var_as_output = vx_out == while_op.loop_vars[i]
+            if return_input_as_output or return_loop_var_as_output:
                 loop_invariant_ids.append(i)
 
         # TODO: All outputs that depend on only invariants are invariant. We
         # need to move computation out of while loop.
         return loop_invariant_ids
+
+    @staticmethod
+    def _materialize_body_outputs_from_outer_scope(while_op):
+        """
+        Re-emit inside the body block any body output that is a var from the enclosing
+        scope and is not the loop var it feeds back into.
+
+        Such an output is not loop invariant, so it has to stay a loop var, but it also
+        cannot stay as it is: a block output has to be produced inside its own block.
+        An ``identity`` gives the same value a definition inside the body.
+        """
+        body_block = while_op.blocks[1]
+        outputs = list(body_block.outputs)
+        materialized = False
+        for i, vx_out in enumerate(outputs):
+            if vx_out == body_block.inputs[i] or vx_out == while_op.loop_vars[i]:
+                continue
+            if not while_op.enclosing_block.is_var_visible_in_block(vx_out, upto_op=while_op):
+                continue
+            with body_block:
+                outputs[i] = mb.identity(x=vx_out, name=vx_out.name + "_loop_var")
+            materialized = True
+        if materialized:
+            body_block.set_outputs(outputs)
 
     @block_context_manager
     def _loop_invariant_elimination_block(self, block):
@@ -96,6 +119,7 @@ class loop_invariant_elimination(AbstractGraphPass):
             if op.op_type != "while_loop":
                 continue
 
+            self._materialize_body_outputs_from_outer_scope(op)
             loop_invariant_ids = self._detect_loop_invariants(op)
             for i in loop_invariant_ids:
                 output_rename.append((op.loop_vars[i], op.outputs[i], op))

--- a/coremltools/converters/mil/mil/passes/tests/test_cleanup_passes.py
+++ b/coremltools/converters/mil/mil/passes/tests/test_cleanup_passes.py
@@ -1282,6 +1282,78 @@ class TestLoopInvariantElimination:
         if _VALIDATE_MODEL:
             assert_model_is_valid(prog, {"a": (1, 2), "b": (1, 2)})
 
+    @staticmethod
+    def _while_loop_body_returns_other_outer_var(a, b, c):
+        """
+        Body output 1 is ``c``, a var from the enclosing scope that is not ``loop_vars[1]``
+        (which is ``b``). The loop var is therefore ``b`` on the first iteration and ``c``
+        from the second on, so it is not invariant.
+        """
+
+        def body(ax, bx):
+            return mb.add(x=ax, y=np.float32([[1.0, 1.0]])), c
+
+        def cond(ax, bx):
+            return mb.less(x=mb.reduce_mean(x=ax, axes=[0, 1]), y=np.float32(3.0))
+
+        return mb.while_loop(_cond=cond, _body=body, loop_vars=(a, b))
+
+    def test_loop_invariant_elimination_other_outer_var(self):
+        """
+        Not an invariant pattern: the block outputs a var from outside of the block, but
+        not the one the loop var was seeded with.
+        """
+
+        @mb.program(
+            input_specs=[
+                mb.TensorSpec(shape=(1, 2)),
+                mb.TensorSpec(shape=(1, 2)),
+                mb.TensorSpec(shape=(1, 2)),
+            ]
+        )
+        def prog(a, b, c):
+            return self._while_loop_body_returns_other_outer_var(a, b, c)
+
+        PASS_REGISTRY["common::loop_invariant_elimination"](prog)
+
+        while_op = prog.find_ops(op_type="while_loop", exactly_one=True)[0]
+        assert len(while_op.loop_vars) == 2
+        assert len(while_op.outputs) == 2
+        # The outer var now has a definition inside the body block.
+        body_output = while_op.blocks[1].outputs[1]
+        assert body_output.op.op_type == "identity"
+        assert body_output.op.x is prog.functions["main"].inputs["c"]
+
+    @pytest.mark.parametrize(
+        "compute_unit, backend",
+        itertools.product(compute_units, backends),
+    )
+    def test_loop_invariant_elimination_other_outer_var_prediction(self, compute_unit, backend):
+        """End to end counterpart: the second output is ``c``, not ``b``."""
+        if backend.backend == "neuralnetwork":
+            pytest.skip("neuralnetwork backend does not support while_loop")
+
+        def build(a, b, c):
+            return self._while_loop_body_returns_other_outer_var(a, b, c)
+
+        a = np.zeros((1, 2), dtype=np.float32)
+        b = np.full((1, 2), 10.0, dtype=np.float32)
+        c = np.full((1, 2), 20.0, dtype=np.float32)
+
+        run_compare_builder(
+            build,
+            {
+                "a": mb.placeholder(shape=(1, 2)),
+                "b": mb.placeholder(shape=(1, 2)),
+                "c": mb.placeholder(shape=(1, 2)),
+            },
+            {"a": a, "b": b, "c": c},
+            expected_output_types=[(1, 2, types.fp32), (1, 2, types.fp32)],
+            expected_outputs=[np.full((1, 2), 3.0, dtype=np.float32), c],
+            compute_unit=compute_unit,
+            backend=backend,
+        )
+
 
 class TestNoopElimination:
     @pytest.mark.parametrize("is_block_output", ((True, False)))


### PR DESCRIPTION
`loop_invariant_elimination` treated "the body returns any var visible outside the block" as proof a loop var is invariant. A `while_loop` with `loop_vars=(a, b)` whose body returns `c` therefore returned `b`.

Fixing the detection alone leaves a body output with no definition inside the block, which segfaults CoreML at model load, so the pass now re-emits it through an `identity`.

Verified end to end with a real prediction: `[[10,10]]` -> `[[20,20]]`. The test fails on `main`.
