### PR TITLE
const_deduplication: compare constexpr inputs by value, not by str(ndarray)

### DIFF
--- a/coremltools/converters/mil/mil/passes/defs/cleanup/const_deduplication.py
+++ b/coremltools/converters/mil/mil/passes/defs/cleanup/const_deduplication.py
@@ -174,7 +174,7 @@ class const_deduplication(AbstractGraphPass):
                     if v.val is None or const_deduplication.should_be_deduplicated(v.val):
                         hash_key.append(v)
                     else:
-                        hash_key.append(str(v.val))
+                        hash_key.append(const_deduplication.value_key(v.val))
                 hash_key = tuple(hash_key)
                 if hash_key not in hashkey_2_duplicates:
                     hashkey_2_duplicates[hash_key] = [op.outputs[0]]
@@ -182,6 +182,21 @@ class const_deduplication(AbstractGraphPass):
                     hashkey_2_duplicates[hash_key].append(op.outputs[0])
 
         return {v[0]: v[1:] for v in hashkey_2_duplicates.values()}
+
+    @staticmethod
+    def value_key(val: Union[str, bool, np.ndarray]) -> Tuple:
+        """
+        An exact, hashable stand-in for a small value.
+
+        ``str(np.ndarray)`` cannot be used for this. It rounds to ``precision``
+        fractional digits and summarizes arrays longer than ``threshold``, and both of
+        those are read from the process wide ``np.printoptions``, so two arrays that
+        differ can share a rendering.
+        """
+        if isinstance(val, (str, bool)):
+            return (type(val).__name__, val)
+        val = np.asarray(val)
+        return (val.dtype.str, val.shape, val.tobytes())
 
     @staticmethod
     def should_be_deduplicated(val: Union[str, bool, np.ndarray]) -> bool:

--- a/coremltools/converters/mil/mil/passes/tests/test_cleanup_passes.py
+++ b/coremltools/converters/mil/mil/passes/tests/test_cleanup_passes.py
@@ -358,6 +358,69 @@ class TestConstDeduplication:
         # bias will be deduplicated only when q and k have same weight key
         assert_op_count_match(prog, expect=2 if q_bias_key == k_bias_key else 3, op=constexpr_op)
 
+    @staticmethod
+    def _prog_with_two_dequantized_weights(scale_q, scale_k):
+        """Two constexpr_affine_dequantize that differ only in their scale."""
+        ENCODING_DIM = 4
+        EMBEDDING_DIM = len(scale_q)
+        quantized_data = np.arange(
+            -(EMBEDDING_DIM * ENCODING_DIM) // 2,
+            EMBEDDING_DIM * ENCODING_DIM - (EMBEDDING_DIM * ENCODING_DIM) // 2,
+            dtype=np.int8,
+        ).reshape(EMBEDDING_DIM, ENCODING_DIM)
+        zero_point = np.zeros((EMBEDDING_DIM,), dtype=np.int8)
+
+        @mb.program(
+            input_specs=[mb.TensorSpec(shape=(2, ENCODING_DIM))],
+            opset_version=ct.target.iOS16,
+        )
+        def prog(x):
+            weight_q = mb.constexpr_affine_dequantize(
+                quantized_data=quantized_data, zero_point=zero_point, scale=scale_q, axis=0
+            )
+            weight_k = mb.constexpr_affine_dequantize(
+                quantized_data=quantized_data, zero_point=zero_point, scale=scale_k, axis=0
+            )
+            return mb.add(x=mb.linear(x=x, weight=weight_q), y=mb.linear(x=x, weight=weight_k))
+
+        return prog
+
+    def test_constexpr_deduplication_distinct_small_values(self):
+        """
+        constexpr inputs below the threshold are compared by value, not by the way numpy
+        happens to render them. These two scales are adjacent fp32 values, and both
+        render as "0.0001".
+        """
+        scale_q = np.full((32,), np.float32(9.999999747378752e-05))
+        scale_k = np.full((32,), np.nextafter(scale_q[0], np.float32(1)))
+        assert not np.array_equal(scale_q, scale_k)
+        assert str(scale_q) == str(scale_k)
+
+        prog = self._prog_with_two_dequantized_weights(scale_q, scale_k)
+        graph_pass = PASS_REGISTRY["common::const_deduplication"]
+        # keep the 32 element scales below the threshold, so they take the by value path
+        graph_pass.const_threshold = 100
+        apply_pass_and_basic_check(prog, graph_pass)
+        assert_op_count_match(prog, expect=2, op="constexpr_affine_dequantize")
+
+    def test_constexpr_deduplication_ignores_numpy_printoptions(self):
+        """
+        np.printoptions is process wide state that any code in the process can change, so
+        it must not decide whether two constexpr ops are the same.
+        """
+        scale_q = np.arange(32, dtype=np.float32) / 100 + 0.5
+        scale_k = scale_q.copy()
+        scale_k[5:25] = 9.75
+
+        graph_pass = PASS_REGISTRY["common::const_deduplication"]
+        # keep the 32 element scales below the threshold, so they take the by value path
+        graph_pass.const_threshold = 100
+        with np.printoptions(threshold=10):
+            assert str(scale_q) == str(scale_k)
+            prog = self._prog_with_two_dequantized_weights(scale_q, scale_k)
+            apply_pass_and_basic_check(prog, graph_pass)
+        assert_op_count_match(prog, expect=2, op="constexpr_affine_dequantize")
+
     def test_const_deduplication_as_outputs(self):
         """
         If the duplicated constants are block outputs, we should not remove them.


### PR DESCRIPTION
`const_deduplication` used `str(np.ndarray)` as an equality key and then merged with `force_replace=True`, without re-checking the values. numpy truncates long arrays, so two different per-channel quantization scales both render as `[0.0001 ...]` and get merged. The rendering also depends on process-global `np.printoptions`.

Constexpr inputs are now compared by value.

The new test fails on `main`. I left the neighbouring `np.allclose(rtol=0, atol=DTYPE2ATOL[dtype])` comparison in `find_constants` alone — it also merges non-equal constants, but the tolerance looks deliberate and that is a separate call.
