### PR TITLE
Bound gather_nd / scatter_nd indices by the dims they actually address

### DIFF
--- a/coremltools/converters/mil/mil/ops/defs/iOS17/scatter_gather.py
+++ b/coremltools/converters/mil/mil/ops/defs/iOS17/scatter_gather.py
@@ -23,6 +23,7 @@ from coremltools.converters.mil.mil.ops.defs.iOS16.scatter_gather import (
     gather_nd as _gather_nd_iOS16,
 )
 from coremltools.converters.mil.mil.ops.defs.iOS17 import _IOS17_TARGET
+from coremltools.converters.mil.mil.types.symbolic import any_symbolic
 
 
 @register_op(opset_version=_IOS17_TARGET)
@@ -231,8 +232,10 @@ class scatter_nd(_scatter_nd_iOS15):
         result = super().type_inference()
         if self.validate_indices.val:
             indices = self.indices.val
-            upper_bound = self.data.shape
-            if indices is not None:
+            # The last axis of indices addresses the leading indices.shape[-1] dims of
+            # data, which may be fewer than data's rank.
+            upper_bound = self.data.shape[: self.indices.shape[-1]]
+            if indices is not None and not any_symbolic(upper_bound):
                 if np.count_nonzero(np.logical_or(indices < 0, indices >= upper_bound)):
                     raise IndexError(
                         f"Indices is out of bounds for `{self.op_type}` node {self.name}. "
@@ -466,8 +469,11 @@ class gather_nd(_gather_nd_iOS16):
         result = super().type_inference()
         if self.validate_indices.val:
             indices = self.indices.val
-            upper_bound = self.x.shape
-            if indices is not None:
+            # The last axis of indices addresses indices.shape[-1] dims of x, starting
+            # after the batch dims. That is fewer than x's rank in general.
+            batch_dims = self.batch_dims.val
+            upper_bound = self.x.shape[batch_dims : batch_dims + self.indices.shape[-1]]
+            if indices is not None and not any_symbolic(upper_bound):
                 if np.count_nonzero(np.logical_or(indices < 0, indices >= upper_bound)):
                     raise IndexError(
                         f"Indices is out of bounds for `{self.op_type}` node {self.name}. "

--- a/coremltools/converters/mil/mil/ops/tests/iOS17/test_scatter_gather.py
+++ b/coremltools/converters/mil/mil/ops/tests/iOS17/test_scatter_gather.py
@@ -297,6 +297,36 @@ class TestScatterNd:
             expected_error_msg = expected_error_msg
         assert any(err in str(excinfo.value) for err in expected_error_msg)
 
+    @pytest.mark.parametrize("backend", backends)
+    def test_ios17_indices_shorter_than_rank(self, backend):
+        """
+        indices' last axis addresses the leading indices.shape[-1] dims of data, which is
+        fewer than data's rank in general.
+        """
+        data = np.zeros((2, 3, 4), dtype=np.float32)
+        updates = np.ones((2, 4), dtype=np.float32)
+
+        def build(indices_val):
+            def prog(x):
+                return mb.scatter_nd(
+                    data=data,
+                    indices=np.array(indices_val, dtype=np.int32),
+                    updates=updates,
+                    validate_indices=True,
+                )
+
+            return mb.program(
+                input_specs=[mb.TensorSpec(shape=(1,), dtype=types.fp32)],
+                opset_version=backend.opset_version,
+            )(prog)
+
+        # 0, 1 are in bounds for dim 0 (2 long) and 1, 2 for dim 1 (3 long)
+        program = build([[0, 1], [1, 2]])
+        assert len(program.functions["main"].find_ops(op_type="scatter_nd")) == 1
+
+        with pytest.raises(IndexError, match="Indices is out of bounds for `scatter_nd` node"):
+            build([[0, 1], [1, 3]])
+
 
 class TestGather(_TestGatherIOS16):
     @pytest.mark.parametrize(
@@ -466,3 +496,51 @@ class TestGatherNd(_TestGatherNdIOS16):
                 input_specs=[mb.TensorSpec(shape=(1,), dtype=types.fp32)],
                 opset_version=backend.opset_version,
             )(prog)
+
+    @pytest.mark.parametrize("backend", backends)
+    def test_builder_valid_indices_index_depth_below_rank(self, backend):
+        """
+        indices' last axis addresses indices.shape[-1] dims of x starting at batch_dims,
+        which is fewer than x's rank in general.
+        """
+        params = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float32)
+
+        def prog(x):
+            # batch dim is 2 long and the indexed dim is 3 long, so 2 is in bounds
+            return mb.gather_nd(
+                x=params,
+                indices=np.array([[1], [2]], dtype=np.int32),
+                batch_dims=1,
+                validate_indices=True,
+            )
+
+        program = mb.program(
+            input_specs=[mb.TensorSpec(shape=(1,), dtype=types.fp32)],
+            opset_version=backend.opset_version,
+        )(prog)
+        assert len(program.functions["main"].find_ops(op_type="gather_nd")) == 1
+
+    @pytest.mark.parametrize("backend", backends)
+    def test_builder_indices_shorter_than_rank(self, backend):
+        """An index depth below the rank must not be compared against the whole shape."""
+        params = np.arange(24, dtype=np.float32).reshape(2, 3, 4)
+
+        def build(indices_val):
+            def prog(x):
+                return mb.gather_nd(
+                    x=params,
+                    indices=np.array(indices_val, dtype=np.int32),
+                    validate_indices=True,
+                )
+
+            return mb.program(
+                input_specs=[mb.TensorSpec(shape=(1,), dtype=types.fp32)],
+                opset_version=backend.opset_version,
+            )(prog)
+
+        # 0, 1 are in bounds for dim 0 (2 long) and 1, 2 for dim 1 (3 long)
+        program = build([[0, 1], [1, 2]])
+        assert len(program.functions["main"].find_ops(op_type="gather_nd")) == 1
+
+        with pytest.raises(IndexError, match="Indices is out of bounds for `gather_nd` node"):
+            build([[0, 3]])


### PR DESCRIPTION
iOS17 `gather_nd` and `scatter_nd` validate `indices` against the full input shape:

```python
upper_bound = self.x.shape
if np.count_nonzero(np.logical_or(indices < 0, indices >= upper_bound)):
```

`indices` has shape `(*K)` and its last axis addresses only `indices.shape[-1]` dims, starting after `batch_dims` for `gather_nd`. Comparing a `(..., K)` array against a length `rank(x)` tuple only lines up when `K == rank(x)`.

Two in-bounds programs that fail to convert today:

```python
# x is rank 3, index depth is 2
mb.gather_nd(x=np.arange(24, dtype=np.float32).reshape(2, 3, 4),
             indices=np.array([[0, 1], [1, 2]], dtype=np.int32),
             validate_indices=True)
# ValueError: operands could not be broadcast together with shapes (2,2) (3,)

# batch_dims=1, so index 2 addresses x.shape[1], which is 3 long
mb.gather_nd(x=np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float32),
             indices=np.array([[1], [2]], dtype=np.int32),
             batch_dims=1, validate_indices=True)
# IndexError: Indices is out of bounds ... Expected indices between [0, (2, 3))
```

The second is the `K == 1` case, where the comparison broadcasts and then checks every index against every dim.

Fix: slice the shape down to the dims the indices address — `data.shape[:K]` for `scatter_nd`, `x.shape[batch_dims : batch_dims + K]` for `gather_nd`. Symbolic dims are skipped, since they cannot be compared. Out-of-bounds indices are still rejected, now against the right bound.

Three new tests in `TestScatterNd` and `TestGatherNd`, all failing on `main`. The existing `validate_indices` tests are unchanged and still pass.
