### PR TITLE
Use the first dim of size 3 when torch.cross has no dim

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -632,6 +632,20 @@ def cross(context, node):
     y = inputs[1]
     dim = inputs[2]
 
+    if dim is None or dim.val is None:
+        # dim is optional in aten::cross. Omitted, torch takes the first dim of size 3,
+        # which is not dim 0 in general.
+        dim = None
+        for axis, size in enumerate(x.shape):
+            if not is_symbolic(size) and size == 3:
+                dim = axis
+                break
+        if dim is None:
+            raise ValueError(
+                f"torch.cross expects a dimension of size 3, but got shape {x.shape} "
+                f"for node {node.name}"
+            )
+
     x1 = mb.gather(x=x, indices=[1, 2, 0], axis=dim, name="x1")
     x2 = mb.gather(x=x, indices=[2, 0, 1], axis=dim, name="x2")
     y1 = mb.gather(x=y, indices=[1, 2, 0], axis=dim, name="y1")

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -650,6 +650,33 @@ class TestCross(TorchBaseTest):
             compute_unit=compute_unit,
         )
 
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend, shape",
+        itertools.product(
+            compute_units, backends, frontends, [(2, 3), (3, 4), (3, 3), (2, 3, 4)]
+        ),
+    )
+    def test_cross_default_dim(self, compute_unit, backend, frontend, shape):
+        """dim is optional; omitted, torch takes the first dim of size 3."""
+
+        class CrossModel(nn.Module):
+            def forward(self, x, y):
+                return torch.cross(x, y)
+
+        x = generate_input_data(shape)
+        y = generate_input_data(shape)
+        model = CrossModel().eval()
+        torch_out = model(x, y)
+        self.run_compare_torch(
+            (x, y),
+            model,
+            expected_results=torch_out,
+            input_as_shape=False,
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+        )
+
 
 class TestNormalize(TorchBaseTest):
     @pytest.mark.parametrize(


### PR DESCRIPTION
`dim` is optional in `aten::cross`. Omitted, torch uses **the first dimension of size 3**, which is not dim 0 in general. The converter passed the argument straight to `mb.gather`, where the missing `dim` fell back to axis 0.

```python
class M(nn.Module):
    def forward(self, x, y):
        return torch.cross(x, y)          # no dim

a = b = torch.rand(2, 3)
```

torch returns shape `(2, 3)`; Core ML returns `(3, 3)` — wrong shape and wrong values, with nothing raised. Passing `dim=1` explicitly has always been correct, which is why the existing `test_cross` (which always passes `dim`) never caught it.

The fix resolves the default the way torch does, and raises when no dim has size 3 rather than gathering along a dim that cannot hold a cross product.

### Testing

`TestCross::test_cross_default_dim` over shapes `(2, 3)`, `(3, 4)`, `(3, 3)`, `(2, 3, 4)`. The `(2, 3)` and `(2, 3, 4)` cases fail on `main`; `(3, 4)` and `(3, 3)` pass either way and are there as controls, since for those the first dim of size 3 *is* dim 0. Existing `test_cross` is unchanged and still passes.

This machine has a broken scikit-learn install that makes every `TorchFrontend.TORCHEXPORT` case error out, including pre-existing ones, so I could only exercise the TorchScript frontend locally.
