### PR TITLE
Fall back instead of baking a symbolic dim into softplus and nll_loss

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -1812,8 +1812,9 @@ def softplus(context, node):
         # this is the special case that Core ML softplus handles
         res = mb.softplus(x=x, name=node.name)
     else:
-        if x.rank == 4:
-            # can use Core ML softplus_parametric
+        if x.rank == 4 and not is_symbolic(x.shape[1]):
+            # can use Core ML softplus_parametric, whose alpha and beta are per channel
+            # and so need the channel count at conversion time
             C = x.shape[1]
             alpha_br = np.repeat(1.0 / beta, C).astype("float32")
             beta_br = np.repeat(beta, C).astype("float32")
@@ -5990,7 +5991,6 @@ def nll_loss(context, node):
     reduction = reduction_mapping[reduction.val]
 
     # compute the weights loss
-    batch_size = x.shape[0]
     class_num = x.shape[1]
 
     # only support weight and ignore_index both None
@@ -6014,8 +6014,9 @@ def nll_loss(context, node):
     elif reduction == "sum":
         out = mb.reduce_sum(x=loss, axes=[0], keep_dims=False, name=node.name)
     elif reduction == "mean":
-        out = mb.real_div(x=loss, y=np.float32(batch_size))
-        out = mb.reduce_sum(x=out, axes=[0], keep_dims=False, name=node.name)
+        # dividing by the batch size and then summing needs the batch size as a
+        # constant, which it is not under a flexible input shape
+        out = mb.reduce_mean(x=loss, axes=[0], keep_dims=False, name=node.name)
     else:
         raise NotImplementedError("Unsupported reduction type for NLLLoss.")
 

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -467,6 +467,35 @@ class TestNLLLoss(TorchBaseTest):
         assert "gather" not in ops and "gather_nd" not in ops
         assert "one_hot" in ops
 
+    @pytest.mark.parametrize(
+        "compute_unit, backend, reduction",
+        itertools.product(compute_units, backends, ["none", "sum", "mean"]),
+    )
+    def test_nllloss_dynamic_batch(self, compute_unit, backend, reduction):
+        """The mean reduction must not need the batch size as a constant."""
+
+        class NLLLossModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.loss = nn.NLLLoss(reduction=reduction)
+
+            def forward(self, x):
+                target = torch.zeros(x.shape[0], dtype=torch.long)
+                return self.loss(x, target)
+
+        model = NLLLossModel()
+        batch_coreml = RangeDim(
+            default=3, lower_bound=2, upper_bound=10 if backend[0] == "mlprogram" else -1
+        )
+
+        self.run_compare_torch(
+            (3, 5),
+            model,
+            backend=backend,
+            compute_unit=compute_unit,
+            converter_input_type=[TensorType(shape=(batch_coreml, 5), dtype=np.float32)],
+        )
+
 
 class TestArgSort(TorchBaseTest):
     @pytest.mark.parametrize(
@@ -6807,6 +6836,37 @@ class TestActivation(TorchBaseTest):
             compute_unit=compute_unit,
             minimum_deployment_target=minimum_deployment_target,
             target_op=target_op,
+        )
+
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend",
+        itertools.product(compute_units, backends, frontends),
+    )
+    def test_softplus_beta_dynamic_channel(self, compute_unit, backend, frontend):
+        """
+        softplus_parametric needs the channel count at conversion time, so a rank 4
+        input with a dynamic channel dim has to fall back to the decomposition.
+        """
+        model = nn.Softplus(beta=2).eval()
+
+        lower_bound = 2
+        upper_bound_coreml = 10 if backend[0] == "mlprogram" else -1
+        upper_bound_torch = None if upper_bound_coreml == -1 else upper_bound_coreml
+        channel_coreml = RangeDim(
+            default=3, lower_bound=lower_bound, upper_bound=upper_bound_coreml
+        )
+        channel_torch = torch.export.Dim(name="channel", min=lower_bound, max=upper_bound_torch)
+
+        self.run_compare_torch(
+            (2, 3, 4, 5),
+            model,
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+            converter_input_type=[
+                TensorType(shape=(2, channel_coreml, 4, 5), dtype=np.float32)
+            ],
+            torch_export_dynamic_shapes={"input": {1: channel_torch}},
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Same class as #2808: both converters read a shape dim and use it where only a constant works, so a flexible input shape aborts the conversion.

**`softplus`** with `beta != 1` on a rank 4 input builds per-channel `alpha`/`beta` for `softplus_parametric` out of `x.shape[1]`:

```python
model = torch.jit.trace(nn.Softplus(beta=2).eval(), torch.rand(2, 3, 4, 5))
ct.convert(model, inputs=[ct.TensorType(shape=(2, ct.RangeDim(2, 10), 4, 5))])
# TypeError: Cannot convert symbols to int
```

Falls back to the general decomposition `softplus(beta * x) / beta` when the channel dim is dynamic — the same path every other rank already takes, and numerically identical.

**`nll_loss`** with `reduction="mean"` divided by `np.float32(x.shape[0])` before summing, which raises `TypeError: Cannot convert expression to float` on a dynamic batch. `reduce_mean` over the batch axis is the same value and needs no constant, so the batch size is no longer read at all. `"none"` and `"sum"` never used it and are unchanged.

### Testing

`test_softplus_beta_dynamic_channel` and `test_nllloss_dynamic_batch` (all three reductions). 4 of the 8 cases fail on `main` — the `"none"` and `"sum"` reductions pass either way and are there as controls. Existing `test_softplus` and `test_nllloss` are unchanged and still pass. Checked `nll_loss` numerically at a batch size different from the traced one.

This machine has a broken scikit-learn install that makes every `TorchFrontend.TORCHEXPORT` case error out, including pre-existing ones, so I could only exercise the TorchScript frontend locally.
