### PR TITLE
Decompose Softplus in TF frontend to avoid fp16 overflow on ANE

### DIFF
--- a/coremltools/converters/mil/frontend/tensorflow/ops.py
+++ b/coremltools/converters/mil/frontend/tensorflow/ops.py
@@ -2146,7 +2146,17 @@ def Sigmoid(context, node):
 @register_tf_op
 def Softplus(context, node):
     x = context[node.inputs[0]]
-    x = mb.softplus(x=x, name=node.name)
+    # Numerically stable decomposition: max(x, 0) + log(1 + exp(-|x|)).
+    # The native `mb.softplus` op (log(1 + exp(x))) overflows in fp16 when
+    # routed to the Apple Neural Engine for x gtr ~10.4 (see issue #2747,
+    # and #2687 / #2725 for the analogous PyTorch-frontend fix). Since
+    # -|x| <= 0, exp(-|x|) is always in (0, 1], so this form cannot overflow.
+    abs_x = mb.abs(x=x)
+    neg_abs_x = mb.mul(x=-1.0, y=abs_x)
+    exp_val = mb.exp(x=neg_abs_x)
+    log_val = mb.log(x=mb.add(x=1.0, y=exp_val))
+    max_val = mb.maximum(x=x, y=0.0)
+    x = mb.add(x=max_val, y=log_val, name=node.name)
     context.add(node.name, x)
 
 

--- a/coremltools/converters/mil/frontend/tensorflow/test/test_ops.py
+++ b/coremltools/converters/mil/frontend/tensorflow/test/test_ops.py
@@ -432,6 +432,57 @@ class TestActivation(TensorFlowBaseTest):
             backend=backend,
         )
 
+    def test_softplus_fp16_numerically_stable(self):
+        """The naive softplus formula log(1 + exp(x)) overflows in fp16 for
+        x > ~10.4, which previously caused output collapse to 0 when the TF
+        frontend's native softplus op was routed to the Apple Neural Engine
+        (#2747, #2687). The converter now emits the decomposition
+        max(x, 0) + log(1 + exp(-|x|)) instead, which cannot overflow in any
+        precision since exp(-|x|) is always in (0, 1].
+
+        This is a pure-arithmetic check, independent of hardware or compute
+        unit routing: on CPU the native op does not overflow either (CPU
+        computes internally in fp32 regardless of the model's declared
+        precision), so a converted-model runtime comparison cannot exercise
+        this regression outside of Neural-Engine fp16 execution, which is
+        not available in CI.
+        """
+        x = np.float16(15.0)
+        naive = np.float16(np.log(np.float16(1.0) + np.exp(x)))
+        assert not np.isfinite(naive), f"expected naive fp16 softplus to overflow, got {naive}"
+
+        stable = np.float16(
+            np.maximum(x, np.float16(0)) + np.log(np.float16(1.0) + np.exp(-np.abs(x)))
+        )
+        assert np.isfinite(stable), f"stable decomposition should not overflow, got {stable}"
+        assert abs(float(stable) - 15.0) < 0.01, f"expected ~15.0, got {stable}"
+
+    @pytest.mark.parametrize(
+        "compute_unit, backend, rank",
+        itertools.product(compute_units, backends, [rank for rank in range(1, 6)]),
+    )
+    def test_softplus_large_values(self, compute_unit, backend, rank):
+        """Regression test for #2747: softplus should stay accurate for large
+        positive and negative inputs, where the previous native-op formula
+        would overflow in fp16 on the Neural Engine."""
+        input_shape = np.random.randint(low=1, high=4, size=rank)
+
+        @make_tf_graph([input_shape])
+        def build_model(x):
+            return tf.math.softplus(x)
+
+        model, inputs, outputs = build_model
+
+        input_values = [random_gen(input_shape, -30.0, 30.0)]
+        input_dict = dict(zip(inputs, input_values))
+        self.run_compare_tf(
+            model,
+            input_dict,
+            outputs,
+            compute_unit=compute_unit,
+            backend=backend,
+        )
+
     @pytest.mark.parametrize(
         "compute_unit, backend, rank_and_axes",
         itertools.product(


### PR DESCRIPTION
Fixes #2747.

The native `mb.softplus` op computes `log(1 + exp(x))`, which overflows in fp16 for `x > ~10.4`. On the Apple Neural Engine this collapses the output to 0 for moderately large inputs, since ANE execution runs in fp16 regardless of the model's declared precision.

This uses the numerically stable decomposition `max(x, 0) + log(1 + exp(-|x|))`, the same approach already applied to the PyTorch frontend for the analogous issue (#2687). Since `-|x| <= 0`, `exp(-|x|)` is always in `(0, 1]`, so this form cannot overflow at any precision.

**On test design:** I could not get a converted-model runtime comparison to fail without this fix on the hardware I tested (M2 Pro) — CPU always computes softplus internally in fp32 regardless of declared precision, and on this chip the op did not get routed to the Neural Engine in any of the shapes I tried, so there's no compute-unit combination in CI that would exercise the actual fp16 overflow. Given that, `test_softplus_fp16_numerically_stable` checks the arithmetic directly (proves the naive formula overflows in fp16 and the decomposition doesn't), and `test_softplus_large_values` is a real conversion + runtime comparison across compute units/backends for regression coverage going forward, in case a future device/build does route this to the ANE.

Not claiming to reproduce the ANE-side overflow empirically — flagging this so it doesn't need rediscovering.