### PR TITLE
Add torch.prod to the PyTorch converter

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -2134,6 +2134,8 @@ def sub(context, node):
         "mean.dim",
         "sum",
         "sum.dim_intlist",
+        "prod",
+        "prod.dim_int",
         "logsumexp",
         "all",
         "all.dim",
@@ -2153,7 +2155,7 @@ def mean(context, node):
             dim = inputs[1] if nargs > 1 else None
             keepdim = inputs[2] if nargs > 2 else False
         else:
-            if node.kind in ("mean", "sum", "all", "any"):
+            if node.kind in ("mean", "sum", "prod", "all", "any"):
                 x = inputs[0]
                 dim = None
                 keepdim = None
@@ -2216,6 +2218,8 @@ def mean(context, node):
             reduction_op_type = "reduce_mean"
         elif node_kind == "sum":
             reduction_op_type = "reduce_sum"
+        elif node_kind == "prod":
+            reduction_op_type = "reduce_prod"
         else:
             assert node_kind == "logsumexp"
             reduction_op_type = "reduce_log_sum_exp"

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -12616,6 +12616,48 @@ class TestSum(TorchBaseTest):
         )
 
     @pytest.mark.parametrize(
+        "compute_unit, backend, frontend, input_dtype",
+        itertools.product(
+            compute_units, backends, frontends, [torch.int32, torch.float32]
+        ),
+    )
+    def test_prod(self, compute_unit, backend, frontend, input_dtype):
+        model = ModuleWrapper(function=torch.prod)
+
+        input_data = torch.arange(1, 7).reshape(2, 3).to(input_dtype)
+        expected_results = model(input_data)
+
+        TorchBaseTest.run_compare_torch(
+            input_data,
+            model,
+            expected_results=expected_results,
+            input_as_shape=False,
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+        )
+
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend, dim, keepdim",
+        itertools.product(compute_units, backends, frontends, (0, -1), (True, False)),
+    )
+    def test_prod_dim(self, compute_unit, backend, frontend, dim, keepdim):
+        class Model(nn.Module):
+            def forward(self, x):
+                return torch.prod(x, dim=dim, keepdim=keepdim)
+
+        model = Model()
+        shape = (2, 3, 4)
+
+        self.run_compare_torch(
+            shape,
+            model,
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+        )
+
+    @pytest.mark.parametrize(
         "compute_unit, backend, frontend, shape, dim",
         itertools.product(
             compute_units,


### PR DESCRIPTION
## Summary

`torch.prod` (product reduction) has no PyTorch→MIL converter, so any model that
uses it fails during conversion with:

```
NotImplementedError: PyTorch convert function for op 'prod' not implemented.
```

`torch.prod` has the same signatures as `torch.sum` — a full-reduction form and a
`.dim_int` form taking `dim`, `keepdim`, and an optional `dtype`. So this routes
it through the existing shared reduction handler (`mean`) to MIL's `reduce_prod`,
exactly the way `sum` maps to `reduce_sum`.

## Change

Three lines in `converters/mil/frontend/torch/ops.py`, mirroring `sum`:

- register `prod` / `prod.dim_int` on the shared reduction op,
- include `prod` in the no-`dim` argument-parsing branch,
- map `node_kind == "prod"` to `reduce_prod`.

## Tests

Adds `test_prod` (full reduction, `int32`/`float32`) and `test_prod_dim`
(`dim ∈ {0, -1}` × `keepdim ∈ {True, False}`) to `TestSum`, following the existing
`test_sum` / `test_mean` pattern.

Verified locally on Apple silicon (torch 2.8, coremltools built from this branch):
all new cases pass across `mlprogram` and `neuralnetwork`, fp16 and fp32, and the
converted outputs match PyTorch exactly (full reduction, per-`dim`, `keepdim`,
negative `dim`, 3-D, and integer inputs). The existing `sum` / `mean` /
`logsumexp` tests, which share the same handler, still pass.
