### PR TITLE
Support in-place PyTorch bitwise and logical ops (__ior__, __iand__, __ixor__)

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -5848,21 +5848,22 @@ def _bitwise_as_logical_if_boolean(context, node, op_name, logical_handler):
         )
 
 
-@register_torch_op(torch_alias=["and"])
+@register_torch_op(torch_alias=["and", "iand"])
 def bitwise_and(context, node):
     _bitwise_as_logical_if_boolean(context, node, "bitwise_and", logical_and)
 
 
-# "or" and "xor" cover the post-sanitize form of "aten::__or__" / "aten::__xor__"
-# which torch.export emits for `tensor | tensor` / `tensor ^ tensor`. These are
-# common when building boolean attention masks (e.g. Gemma combines a causal
-# mask with a padding mask via __or__).
-@register_torch_op(torch_alias=["or"])
+# "or", "ior" and "xor", "ixor" cover the post-sanitize form of
+# "aten::__or__" / "aten::__ior__" / "aten::__xor__" / "aten::__ixor__"
+# which torch.export/torchscript emits for `tensor | tensor`, `tensor |= tensor`,
+# `tensor ^ tensor`, `tensor ^= tensor`. These are common when building boolean
+# attention masks (e.g. Gemma combines a causal mask with a padding mask).
+@register_torch_op(torch_alias=["or", "ior"])
 def bitwise_or(context, node):
     _bitwise_as_logical_if_boolean(context, node, "bitwise_or", logical_or)
 
 
-@register_torch_op(torch_alias=["xor"])
+@register_torch_op(torch_alias=["xor", "ixor"])
 def bitwise_xor(context, node):
     _bitwise_as_logical_if_boolean(context, node, "bitwise_xor", logical_xor)
 

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -14406,6 +14406,52 @@ class TestBitwiseAnd(TorchBaseTest):
             )
 
 
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend",
+        itertools.product(compute_units, backends, frontends),
+    )
+    def test_and_operator(self, compute_unit, backend, frontend):
+        class TestModel(torch.nn.Module):
+            def forward(self, x, y):
+                return x & y
+
+        input_shape = (2, 3)
+        input_data_x = torch.rand(*input_shape) > 0.2
+        input_data_y = torch.rand(*input_shape) < 0.8
+        self.run_compare_torch(
+            [input_data_x, input_data_y],
+            TestModel(),
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+            input_as_shape=False,
+        )
+
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend",
+        itertools.product(compute_units, backends, frontends),
+    )
+    def test_iand_operator(self, compute_unit, backend, frontend):
+        # Exercises tensor.__iand__ (i.e. `x &= y`) which sanitizes to "iand"
+        class TestModel(torch.nn.Module):
+            def forward(self, x, y):
+                x = x.clone()
+                x &= y
+                return x
+
+        input_shape = (2, 3)
+        input_data_x = torch.rand(*input_shape) > 0.2
+        input_data_y = torch.rand(*input_shape) < 0.8
+        self.run_compare_torch(
+            [input_data_x, input_data_y],
+            TestModel(),
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+            input_as_shape=False,
+        )
+
+
 class TestBitwiseOr(TorchBaseTest):
     @pytest.mark.parametrize(
         "compute_unit, backend, frontend",
@@ -14451,6 +14497,31 @@ class TestBitwiseOr(TorchBaseTest):
             input_as_shape=False,
         )
 
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend",
+        itertools.product(compute_units, backends, frontends),
+    )
+    def test_ior_operator(self, compute_unit, backend, frontend):
+        # Exercises tensor.__ior__ (i.e. `x |= y`) which sanitizes to "ior" and
+        # is emitted in in-place boolean attention masks.
+        class TestModel(torch.nn.Module):
+            def forward(self, x, y):
+                x = x.clone()
+                x |= y
+                return x
+
+        input_shape = (2, 3)
+        input_data_x = torch.rand(*input_shape) > 0.2
+        input_data_y = torch.rand(*input_shape) < 0.8
+        self.run_compare_torch(
+            [input_data_x, input_data_y],
+            TestModel(),
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+            input_as_shape=False,
+        )
+
 
 class TestBitwiseXor(TorchBaseTest):
     @pytest.mark.parametrize(
@@ -14461,6 +14532,52 @@ class TestBitwiseXor(TorchBaseTest):
         class TestModel(torch.nn.Module):
             def forward(self, x, y):
                 return torch.bitwise_xor(x, y)
+
+        input_shape = (2, 3)
+        input_data_x = torch.rand(*input_shape) > 0.2
+        input_data_y = torch.rand(*input_shape) < 0.8
+        self.run_compare_torch(
+            [input_data_x, input_data_y],
+            TestModel(),
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+            input_as_shape=False,
+        )
+
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend",
+        itertools.product(compute_units, backends, frontends),
+    )
+    def test_xor_operator(self, compute_unit, backend, frontend):
+        # Exercises tensor.__xor__ (i.e. `x ^ y`) which sanitizes to "xor"
+        class TestModel(torch.nn.Module):
+            def forward(self, x, y):
+                return x ^ y
+
+        input_shape = (2, 3)
+        input_data_x = torch.rand(*input_shape) > 0.2
+        input_data_y = torch.rand(*input_shape) < 0.8
+        self.run_compare_torch(
+            [input_data_x, input_data_y],
+            TestModel(),
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+            input_as_shape=False,
+        )
+
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend",
+        itertools.product(compute_units, backends, frontends),
+    )
+    def test_ixor_operator(self, compute_unit, backend, frontend):
+        # Exercises tensor.__ixor__ (i.e. `x ^= y`) which sanitizes to "ixor"
+        class TestModel(torch.nn.Module):
+            def forward(self, x, y):
+                x = x.clone()
+                x ^= y
+                return x
 
         input_shape = (2, 3)
         input_data_x = torch.rand(*input_shape) > 0.2


### PR DESCRIPTION
### Summary
Adds support for in-place PyTorch logical and bitwise operators (`__ior__`, `__iand__`, `__ixor__`, i.e., `|=`, `&=`, `^=`) in the PyTorch frontend.

### Context / Motivation
Modern transformer and LLM architectures (such as attention mask construction in Gemma and LLaMA) make frequent use of in-place boolean masking (`mask1 |= mask2`). When converted, PyTorch emits `aten::__ior__`, `aten::__iand__`, and `aten::__ixor__` nodes (sanitized to `ior`, `iand`, `ixor`), which previously raised:


NotImplementedError: PyTorch convert function for op 'ior' not implemented.

### Changes
- Registered `iand`, `ior`, and `ixor` aliases for `bitwise_and`, `bitwise_or`, and `bitwise_xor` in `coremltools/converters/mil/frontend/torch/ops.py`.
- Added unit test cases (`test_and_operator`, `test_iand_operator`, `test_ior_operator`, `test_xor_operator`, `test_ixor_operator`) in `coremltools/converters/mil/frontend/torch/test/test_torch_ops.py` covering TorchScript and TorchExport across all backend and compute unit permutations.

### Testing
Ran:
```bash
pytest coremltools/converters/mil/frontend/torch/test/test_torch_ops.py -k "TestBitwise"