### PR TITLE
Support PyTorch angle and trig ops (deg2rad, rad2deg, hypot)

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -7342,6 +7342,30 @@ def atanh(context, node):
     inputs = _get_inputs(context, node, expected=1)
     context.add(mb.atanh(x=inputs[0], name=node.name))
 
+@register_torch_op
+def deg2rad(context, node):
+    inputs = _get_inputs(context, node, expected=1)
+    scale = _math.pi / 180.0
+    context.add(mb.mul(x=inputs[0], y=scale, name=node.name))
+
+
+@register_torch_op
+def rad2deg(context, node):
+    inputs = _get_inputs(context, node, expected=1)
+    scale = 180.0 / _math.pi
+    context.add(mb.mul(x=inputs[0], y=scale, name=node.name))
+
+
+@register_torch_op
+def hypot(context, node):
+    inputs = _get_inputs(context, node, expected=2)
+    x, y = inputs
+    x, y = promote_input_dtypes([x, y])
+    x_sq = mb.mul(x=x, y=x)
+    y_sq = mb.mul(x=y, y=y)
+    sum_sq = mb.add(x=x_sq, y=y_sq)
+    context.add(mb.sqrt(x=sum_sq, name=node.name))
+
 
 @register_torch_op
 def ceil(context, node):

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -7379,6 +7379,7 @@ class TestAtan2(TorchBaseTest):
             input_as_shape=False,
         )
 
+
     @pytest.mark.parametrize(
         "compute_unit, backend, frontend",
         itertools.product(compute_units, backends, frontends),
@@ -7425,6 +7426,57 @@ class TestAtan2(TorchBaseTest):
                 backend=backend,
                 compute_unit=compute_unit,
             )
+
+
+class TestDeg2Rad(TorchBaseTest):
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend, rank",
+        itertools.product(compute_units, backends, frontends, range(1, 5)),
+    )
+    def test_deg2rad(self, compute_unit, backend, frontend, rank):
+        model = ModuleWrapper(function=torch.deg2rad)
+        input_shape = tuple(np.random.randint(low=1, high=10, size=rank))
+        self.run_compare_torch(
+            input_shape,
+            model,
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+        )
+
+
+class TestRad2Deg(TorchBaseTest):
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend, rank",
+        itertools.product(compute_units, backends, frontends, range(1, 5)),
+    )
+    def test_rad2deg(self, compute_unit, backend, frontend, rank):
+        model = ModuleWrapper(function=torch.rad2deg)
+        input_shape = tuple(np.random.randint(low=1, high=10, size=rank))
+        self.run_compare_torch(
+            input_shape,
+            model,
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+        )
+
+
+class TestHypot(TorchBaseTest):
+    @pytest.mark.parametrize(
+        "compute_unit, backend, frontend, rank",
+        itertools.product(compute_units, backends, frontends, range(1, 5)),
+    )
+    def test_hypot(self, compute_unit, backend, frontend, rank):
+        model = ModuleWrapper(function=torch.hypot)
+        input_shape = tuple(np.random.randint(low=1, high=10, size=rank))
+        self.run_compare_torch(
+            [input_shape, input_shape],
+            model,
+            frontend=frontend,
+            backend=backend,
+            compute_unit=compute_unit,
+        )
 
 
 class TestTriu(TorchBaseTest):


### PR DESCRIPTION
### Summary
Adds support for PyTorch angle and trigonometric operators (`deg2rad`, `rad2deg`, and `hypot`) in the PyTorch converter frontend.

### Context / Motivation
`torch.deg2rad`, `torch.rad2deg`, and `torch.hypot` are standard PyTorch operators commonly used in 3D computer vision, robotics, coordinate transformations, and audio processing. Previously, converting models utilizing these operators raised `NotImplementedError`.

### Changes
- Implemented `deg2rad` converter via `mb.mul(x, pi / 180.0)`.
- Implemented `rad2deg` converter via `mb.mul(x, 180.0 / pi)`.
- Implemented `hypot` converter via `mb.sqrt(x^2 + y^2)` with input dtype promotion.
- Added parameterized unit test classes `TestDeg2Rad`, `TestRad2Deg`, and `TestHypot` in `test_torch_ops.py` covering TorchScript and TorchExport across all backend and compute unit permutations.

### Testing
Ran:
```bash
pytest coremltools/converters/mil/frontend/torch/test/test_torch_ops.py -k "TestDeg2Rad or TestRad2Deg or TestHypot"
