### PR TITLE
Add InstanceNorm3d alias-conversion regression coverage

### DIFF
--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -1423,6 +1423,27 @@ class TestInstanceNorm(TorchBaseTest):
             compute_unit=compute_unit,
         )
 
+    @pytest.mark.parametrize("frontend", frontends)
+    @pytest.mark.parametrize("track_running_stats", [False, True])
+    def test_instancenorm_3d(self, frontend, track_running_stats):
+        # Regression test for https://github.com/apple/coremltools/issues/2666:
+        # exporting InstanceNorm3d with track_running_stats=True via torch.export
+        # used to fail with "Unsupported fx node alias, kind alias".
+        # Core ML's runtime only supports rank-3 and rank-4 instance_norm, so
+        # this conversion-only test intentionally targets MIL rather than prediction.
+        input_data = torch.rand(2, 5, 4, 5, 5)
+        model = nn.InstanceNorm3d(5, track_running_stats=track_running_stats)
+        model_spec = export_torch_model_to_frontend(model, input_data, frontend)
+        converter_inputs = None
+        if frontend not in TORCH_EXPORT_BASED_FRONTENDS:
+            converter_inputs = [ct.TensorType(shape=input_data.shape)]
+        ct.convert(
+            model_spec,
+            source="pytorch",
+            convert_to="milinternal",
+            inputs=converter_inputs,
+        )
+
 
 class TestGroupNorm(TorchBaseTest):
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

#2666 reported that converting `InstanceNorm3d(track_running_stats=True)`
through `torch.export` failed with:

```
NotImplementedError: Unsupported fx node alias, kind alias
```

The `alias` operator is already registered on current `main`, so the reported
frontend conversion failure is fixed. This PR adds regression coverage for that
path.

## Changes

- Add conversion-only coverage for `InstanceNorm3d`.
- Exercise both `track_running_stats=False` and `True`.
- Cover TorchScript and `torch.export` frontends.
- Convert to `milinternal`, ensuring the test covers frontend conversion without
  requiring Core ML runtime execution.

## Why conversion-only?

Core ML runtime `instance_norm` supports rank-3 and rank-4 tensors only.
`InstanceNorm3d` uses a rank-5 tensor, so runtime prediction is unsupported
independently of the `alias` conversion issue.

## Verification

```
pytest coremltools/converters/mil/frontend/torch/test/test_torch_ops.py -k TestInstanceNorm -q
40 passed
```

Fixes #2666.
