### PR TITLE
Support torch.gather indices smaller than the input

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -7464,7 +7464,24 @@ def append(context, node):
 @register_torch_op
 def gather(context, node):
     inputs = _get_inputs(context, node)
-    res = mb.gather_along_axis(x=inputs[0], indices=inputs[2], axis=inputs[1], name=node.name)
+    x, dim, indices = inputs[0], inputs[1], inputs[2]
+
+    # torch.gather only requires indices.size(d) <= x.size(d) for every d other than dim, and
+    # reads just x[..., i_d, ...] for i_d < indices.size(d) there. mb.gather_along_axis asserts
+    # the two sizes are equal, so trim x down to the index size wherever it is longer.
+    axis = dim.val if dim.val >= 0 else dim.val + x.rank
+    size = [-1] * x.rank
+    trim_needed = False
+    for d in range(x.rank):
+        if d == axis or is_symbolic(x.shape[d]) or is_symbolic(indices.shape[d]):
+            continue
+        if indices.shape[d] < x.shape[d]:
+            size[d] = indices.shape[d]
+            trim_needed = True
+    if trim_needed:
+        x = mb.slice_by_size(x=x, begin=[0] * x.rank, size=size)
+
+    res = mb.gather_along_axis(x=x, indices=indices, axis=dim, name=node.name)
     context.add(res)
 
 

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -6648,6 +6648,23 @@ class TestGather(TorchBaseTest):
         )
 
     @pytest.mark.parametrize(
+        "compute_unit, backend, frontend, axis",
+        itertools.product(compute_units, backends, frontends, (0, 1, 2)),
+    )
+    def test_gather_indices_smaller_than_input(self, compute_unit, backend, frontend, axis):
+        """torch.gather allows indices to be smaller than the input off the gathered axis."""
+        params_shape = (3, 4, 5)
+        indices_shape = tuple(d if i == axis else d - 1 for i, d in enumerate(params_shape))
+        indices = np.random.randint(0, params_shape[axis], size=indices_shape)
+        model = ModuleWrapper(
+            function=torch.gather,
+            kwargs={"dim": axis, "index": torch.from_numpy(indices)},
+        )
+        self.run_compare_torch(
+            [params_shape], model, compute_unit=compute_unit, backend=backend, frontend=frontend
+        )
+
+    @pytest.mark.parametrize(
         "compute_unit, backend, frontend, input_enumerated_shape",
         itertools.product(compute_units, backends, frontends, (True, False)),
     )


### PR DESCRIPTION
### The bug

`torch.gather` only requires `indices.size(d) <= x.size(d)` for every dimension `d` other than `dim`, and reads just the leading `indices.size(d)` entries of `x` there. `mb.gather_along_axis` asserts the two sizes are equal, so converting a perfectly valid model dies outright.

```python
class M(torch.nn.Module):
    def forward(self, x):
        idx = torch.tensor([[0, 1], [1, 0]])   # 2x2 indices into a 3x3 input, dim=1
        return torch.gather(x, 1, idx)
```

Before:

```
torch  : [[0.0, 1.0], [4.0, 3.0]]
ERROR - converting 'gather' op (located at: '12'):
AssertionError: The input data and indices should have the same size at axis 0, but got 3 vs 2
```

After:

```
torch  : [[0.0, 1.0], [4.0, 3.0]]
coreml : [[0.0, 1.0], [4.0, 3.0]]
MAXDIFF: 0.0
```

### The fix

Trim `x` down to the index size wherever it is longer, off the gathered axis, before handing it to `gather_along_axis`. Symbolic dimensions are skipped, so dynamic shapes behave as before.

### Why it wasn't caught

`test_gather_along_axis` builds `indices_shape` as a copy of `params_shape` and then varies only `indices_shape[axis]` — the one dimension where the sizes genuinely do have to match. Every other dimension is always equal, so the unequal case never ran. The new test shrinks a non-gathered dimension instead.

`TestGather` is 41 passed / 4 skipped / 0 failed locally on the TorchScript frontend. The TorchExport cases fail on my machine both with and without this change (a `FileNotFoundError` from a missing external tool), so I couldn't exercise those.
