### PR TITLE
Do not count ceil_mode overhang in the avg_pool divisor

### DIFF
--- a/coremltools/converters/mil/frontend/torch/ops.py
+++ b/coremltools/converters/mil/frontend/torch/ops.py
@@ -6290,6 +6290,15 @@ def _avg_pool(context, node, inputs):
                 raise ValueError('pool3D with ceil mode=True and include_pad=True not supported')
         pad = new_pad
 
+    exclude_padding_from_average = not include_pad
+    if ceil_mode and include_pad and (pad is None or not np.any(pad)):
+        # count_include_pad only governs the explicit padding, and there is none here.
+        # It does not cover the zeros ceil_mode appends past the input edge: torch divides
+        # such a window by the elements actually inside the input, while MIL would divide
+        # by the full kernel. Excluding padding is the same thing when there is no explicit
+        # padding to exclude, and it gives the trailing windows torch's divisor.
+        exclude_padding_from_average = True
+
     pool = mb.avg_pool(
         x=x,
         kernel_sizes=kernel_sizes,
@@ -6297,7 +6306,7 @@ def _avg_pool(context, node, inputs):
         pad_type=pad_type,
         pad=pad,
         name=node.name,
-        exclude_padding_from_average=not include_pad,
+        exclude_padding_from_average=exclude_padding_from_average,
         ceil_mode=ceil_mode if spatial_rank <= 2 else False,
     )
     context.add(pool)

--- a/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
+++ b/coremltools/converters/mil/frontend/torch/test/test_torch_ops.py
@@ -3385,6 +3385,9 @@ class TestAvgPool(TorchBaseTest):
                     ((1, 3, 10), 1, 2, 1, True, True),
                     ((1, 3, 10), 3, 2, 0, True, False),
                     ((1, 3, 10), 1, 1, 1, True, True),
+                    # ceil_mode with no explicit padding: the trailing window hangs past
+                    # the input, and torch divides it by the elements actually inside.
+                    ((1, 3, 7), 2, 3, 0, True, True),
                 ],
             )
         ],
@@ -3450,6 +3453,9 @@ class TestAvgPool(TorchBaseTest):
                     ((1, 3, 10, 10), 1, 2, 1, True, True),
                     ((1, 3, 10, 10), 3, 2, 0, True, False),
                     ((1, 3, 10, 10), 1, 1, 1, True, True),
+                    # ceil_mode with no explicit padding: the trailing window hangs past
+                    # the input, and torch divides it by the elements actually inside.
+                    ((1, 3, 7, 7), 2, 3, 0, True, True),
                 ],
             )
         ],


### PR DESCRIPTION
### The bug

`count_include_pad` in torch governs the **explicit** padding. It does not cover the zeros that `ceil_mode` appends past the input edge — torch divides such a window by the elements actually inside the input, while MIL divides by the full kernel.

So with `count_include_pad` left at its default of `True` and no explicit padding, every window that hangs off the edge comes out too small:

```python
torch.nn.AvgPool2d(2, stride=3, ceil_mode=True)     # input torch.arange(49).reshape(1,1,7,7)
```

```
TORCH:                      COREML:
[[ 4.   7.   9.5]           [[ 4.    7.    4.75]
 [25.  28.  30.5]            [25.   28.   15.25]
 [42.5 45.5 48. ]]           [21.25 22.75 12.  ]]
```

The interior windows agree exactly. Only the ones hanging off the edge are wrong, and by exactly the ratio of the kernel size to the elements really covered — 2x along an edge, 4x in the corner where only one element is real. No error is raised and the output shape is correct, so this is silent.

`AvgPool1d` is affected the same way: `[0.5, 3.5, 6.0]` becomes `[0.5, 3.5, 3.0]`.

### The fix

When there is no explicit padding, `count_include_pad` has nothing to include. Excluding padding is therefore equivalent for the interior windows and gives the trailing ones torch's divisor.

I deliberately left the mixed case alone — explicit padding together with `ceil_mode` and `count_include_pad=True`. MIL has a single `exclude_padding_from_average` flag, and torch wants the two kinds of padding counted differently there, so it isn't expressible without more work. Happy to take that on separately if you want it.

### Why it wasn't caught

Every existing parametrization with `ceil_mode=True` and `padding=0` uses either `kernel_size=1` or `count_include_pad=False`, so none of them can produce an overhang window. I added one case to each of the existing `test_avg_pool1d` and `test_avg_pool2d` lists rather than writing new test functions.

`TestAvgPool` goes from 1 failed to 0 with the change, and `TestAvgPool` + `TestAdaptiveAvgPool` are clean. Note the harness surfaces the failure on the TorchExport 2d case at the default deployment target; my standalone repro above shows the same divergence on TorchScript at `iOS17` for both 1d and 2d.

`ruff check` reports the same 15 pre-existing errors in `ops.py` before and after, none from this change.
