### PR TITLE
Reject a non-PassPipeline pass_pipeline argument

### DIFF
--- a/coremltools/converters/_converters_entry.py
+++ b/coremltools/converters/_converters_entry.py
@@ -608,6 +608,14 @@ def convert(
 
     if pass_pipeline is None:
         pass_pipeline = PassPipeline()
+    elif not isinstance(pass_pipeline, PassPipeline):
+        # Otherwise the wrong type is only noticed much later, as an AttributeError
+        # from inside the pass machinery, which does not name the argument.
+        raise TypeError(
+            "Unrecognized value of argument 'pass_pipeline': {}. "
+            "It needs to be an instance of 'coremltools.PassPipeline'. "
+            "For example, coremltools.PassPipeline.EMPTY".format(pass_pipeline)
+        )
     if not need_fp16_cast_pass:
         pass_pipeline.remove_passes({"common::add_fp16_cast", "common::add_int16_cast"})
     if isinstance(compute_precision, FP16ComputePrecision):

--- a/coremltools/test/api/test_api_examples.py
+++ b/coremltools/test/api/test_api_examples.py
@@ -353,6 +353,20 @@ class TestGraphPassManagement:
 
         return TestModel().eval()
 
+    @pytest.mark.parametrize("bad_pipeline", ["default", 3, ["common::const_elimination"]])
+    def test_pass_pipeline_rejects_a_non_pipeline(self, bad_pipeline):
+        """A wrong type used to surface later as an AttributeError from the pass machinery."""
+        model = self._get_test_model()
+        example_input = torch.rand(1, 1, 28, 28)
+        traced_model = torch.jit.trace(model, example_input)
+        with pytest.raises(TypeError, match="Unrecognized value of argument 'pass_pipeline'"):
+            ct.convert(
+                traced_model,
+                inputs=[ct.TensorType(shape=example_input.shape)],
+                convert_to="mlprogram",
+                pass_pipeline=bad_pipeline,
+            )
+
     def test_default_pipeline(self):
         model = self._get_test_model()
         example_input = torch.rand(1, 1, 28, 28)


### PR DESCRIPTION
### The bug

`pass_pipeline` is never type-checked, so a wrong type reaches the pass machinery and fails there:

```python
ct.convert(model, inputs=..., convert_to="mlprogram", pass_pipeline="default")
```

```
AttributeError: 'str' object has no attribute 'get_all_options'
```

Passing the name as a string is an easy mistake, since the pipelines are named things like `"default"` and `"cleanup"` and other coremltools arguments do take strings. The error mentions neither `pass_pipeline` nor `PassPipeline`, so there is nothing to point the caller at the argument they got wrong.

### The fix

Reject it up front:

```
TypeError: Unrecognized value of argument 'pass_pipeline': default. It needs to be an
instance of 'coremltools.PassPipeline'. For example, coremltools.PassPipeline.EMPTY
```

This is the shape the sibling arguments already use. `_check_deployment_target` raises a `TypeError` naming the argument, the expected type and an example, and `compute_precision` does the same. `pass_pipeline` was the one that did not.

### Verification

The new test is parametrized over a string, an int and a list. All three fail on `main` and pass with the change:

```
without the fix:  FFF
with the fix:     ...
```

`pass_pipeline=ct.PassPipeline.EMPTY` and the default `pass_pipeline=None` both still convert, and `TestGraphPassManagement` has no failures.
